### PR TITLE
Fix several typos in the getElementAttribute prose

### DIFF
--- a/10_element_state.html
+++ b/10_element_state.html
@@ -115,7 +115,7 @@
               <p>The end result of this algorithm are values that can be passed to other commands within this specification. Notably, this means that URLs that are returned can be passed to <a href="#widl-WebDriver-get-void-DOMString-url">get</a> and the expected URL will be navigated to.</p>
               </div>
 
-              <p>To determine the <var>value</var> of the <a>response</a>, the following steps must be taken where <var>name</var> is the <code>name</code> property on the <code>parameters</code> dictionary in <a>Command</a>, and <var>element</var> is the <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> modeled by the <code>ELEMENT</code> parameter.:
+              <p>To determine the <var>value</var> of the <a>response</a>, the following steps must be taken where <var>name</var> is the <code>name</code> property on the <code>parameters</code> dictionary in <a>Command</a>, and <var>element</var> is the <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> modeled by the <code>ELEMENT</code> parameter:
 
               <ol>
                 <li>Initially set <var>result</var> to null.
@@ -136,13 +136,13 @@
 
                 <li>Obtain the property indexed by "<var>name</var>" from the element and store this as <var>result</var>. If <var>name</var> case insensitively matches "class" set <var>result</var> to be <var>element</var>'s <code>className</code> property. Similarly, if <var>name</var> case insensitively matches "readonly", set <var>result</var> to be the <var>element</var>'s <code>readOnly</code> property.</li>
 
-                <li>If <var>result</var> is null or undefined, or if it is an object, set the value of <var>result</var> to be the <code>value</code> of the AttributeNode obtained by calling <code>getAttributeNode</code> on <var>element</var> iff that AttributeNode is <code>specified</code>. That is, <var>result</var> is the equivalent of executing the following Ecmascript: <code>var attr = element.getAttribute(name); var result = (attr &amp;&amp; attr.specified) ? attr.value : null;</code></li>
+                <li>If <var>result</var> is null or undefined, or if it is an object, set the value of <var>result</var> to be the <code>value</code> of the Attr node obtained by calling <code>getAttributeNode</code> on <var>element</var> iff that Attr is <code>specified</code>. That is, <var>result</var> is the equivalent of executing the following Ecmascript: <code>var attr = element.getAttributeNode(name); var result = (attr &amp;&amp; attr.specified) ? attr.value : null;</code></li>
 
                 <li name="attribute-result-coercion">Coerce the return value to a DOMString:
                   <ol>
                     <li>If <var>result</var> is a boolean value, use the value "true" if <var>result</var> is true, or null otherwise.</li>
                     <li>if <var>result</var> is null or undefined, set <var>result</var> to be null.</li>
-                    <li>In all other cases, ceorce <var>result</var> to a DOMString.</li>
+                    <li>In all other cases, coerce <var>result</var> to a DOMString.</li>
                   </ol>
                 </li>
               </ol>


### PR DESCRIPTION
Also I don't understand the reason why `getAttributeNode` is invoked instead of `getAttribute`. `specified` [always returns true](http://www.w3.org/TR/dom/#dom-attr-specified)