### PR TITLE
Rewrite getCookies to be more specific and allow getting a cookie by nam...

### DIFF
--- a/01_introduction.html
+++ b/01_introduction.html
@@ -114,7 +114,7 @@
     from [[!ECMA-262]] with the exception that non-valid integer
     or float return values are returned as 0 or 0.0.
 
-    <h4>Top Browsing content no longer open</h4>
-    <p>A top browsing context is <dfn>no longer open</dfn> if it has been <a href="https://html.spec.whatwg.org/#a-browsing-context-is-discarded">discarded</a>
+    <h4>Top Level Browsing Context no longer open</h4>
+    <p>A top level browsing context is <dfn>no longer open</dfn> if it has been <a href="https://html.spec.whatwg.org/#a-browsing-context-is-discarded">discarded</a>
   </section>
 </section>

--- a/01_introduction.html
+++ b/01_introduction.html
@@ -64,7 +64,7 @@
    <h3>Terminology</h3>
 
    <p>In equations, all numbers are integers,
-    subtraction is represented by “−”, and bitwise OR by “|”. 
+    subtraction is represented by “−”, and bitwise OR by “|”.
     The characters “(” and “)” are used to provide logical grouping in these contexts.
   </section>
 
@@ -113,5 +113,8 @@
     and <code><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.3>parseFloat</a></code>
     from [[!ECMA-262]] with the exception that non-valid integer
     or float return values are returned as 0 or 0.0.
+
+    <h4>Top Browsing content no longer open</h4>
+    <p>A top browsing context is <dfn>no longer open</dfn> if it has been <a href="https://html.spec.whatwg.org/#a-browsing-context-is-discarded">discarded</a>
   </section>
 </section>

--- a/02_commands.html
+++ b/02_commands.html
@@ -295,7 +295,7 @@
         <td><a>Execute Async Script</a></td>
       </tr>
       <tr>
-        <td>GET</td>
+        <td>POST</td>
         <td>/session/{sessionId}/cookie</td>
         <td><a>Get Cookie</a></td>
       </tr>

--- a/05_navigation.html
+++ b/05_navigation.html
@@ -53,7 +53,7 @@
 
     <p>The <a>remote end steps</a> for the <a>get</a> command are:</p>
     <ol>
-      <li><p>If the <a>current browsing context</a> is no longer open, return an error with code <a>no such window</a>.</p></li>
+      <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
       <li><p>Let <var>url</var> be the result of <a>getting a property</a> named "url" from the <var>parameters</var> argument.</p></li>
       <li><p>If <var>url</var> is undefined, return an <a>error</a> with code <a>invalid argument</a></p></li>
       <li><p><a href="">Navigate</a> the <a>current browsing context</a>'s to <var>url</var>. If this navigation results in a HTTP 401 response, the <a>remote end</a> must proceed with the steps below, irrespective of how the authentication challenge is handled.</p></li>

--- a/12_cookies.html
+++ b/12_cookies.html
@@ -11,7 +11,7 @@
     <p>When returning Cookie objects, the server SHOULD include all optional fields it is capable of providing the information for.</p>
     <section>
       <!-- getCookie() -->
-      <h3>getCookie()</h3>
+      <h3>getCookie</h3>
         <p>
           <table class="simple jsoncommand">
             <tr>
@@ -27,44 +27,24 @@
           </table>
           <p>The <a>remote end steps</a> for the <a>getCookie</a> command are:</p>
           <ol>
-            <li><p>If the <a>current browsing context</a> is no longer open, return an error with code <a>no such window</a>.</p></li>
+            <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
             <li><p>Let <var>name</var> be the result of <a>getting a property</a> named "name" from the <var>parameters</var> argument.</p></li>
-            <li><p>Let <var>result</var> be an empty sequence</p></li>
-            <li><p>Let <var>cookies</var> be all cookies of the resource represented by the idenfied by <a href="https://dom.spec.whatwg.org/#concept-document-url"> the document's address</a></p></li>
-            <li><p>Let <var>cookies</var> be the list of <a href='http://heycam.github.io/webidl/#dfn-values-to-iterate-over'>values to iterate over</a></p></li>
+            <li><p>Let <var>result</var> be an empty JSON List</p></li>
+            <li><p>Let <var>cookies</var> be all cookies [[!RFC6265]] of the resource represented by the idenfied by <a href="https://dom.spec.whatwg.org/#concept-document-url"> the document's address</a></p></li>
+            <li><p>Let <var>cookies</var> be the list of values to iterate over</p></li>
             <li><p>Let <var>len</var> be the length of <var>cookies</var>.</p></li>
-            <li><p>Initialize <var>k</var> to 0</p></li>
+            <li><p>Let <var>k</var> be 0</p></li>
             <li><p>While <var>k</var> < <var>len</var>: </p>
               <ol>
                 <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
                 <li><p>If <var>name</var> is undefined:</p>
                   <ol>
-                    <li><p>Append an object with the following keys and values:</p>
-                      <ul>
-                        <li><p><var>name</var> = <var>cookie.name</var></p></li>
-                        <li><p><var>value</var> = <var>cookie.value</var></p></li>
-                        <li><p><var>path</var> = <var>cookie.path</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
-                        <li><p><var>domain</var> = <var>cookie.domain</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
-                        <li><p><var>secure</var> = <var>cookie.isSecure</var> if <var>cookie.isSecure</var> is defined else it MUST be false.</p></li>
-                        <li><p><var>expiry</var> = <var>cookie.expires</var> where <var>cookie.expires</var> is specified in milliseconds
-                          since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. if <var>cookie.expires</var> is undefined it MUST be null.</p></li>
-                      </ul>
-                    </li>
+                    <li><p>Append a <a>serialised cookie</a> to <var>result</var>.</p></li>
                   </ol>
                 </li>
-                <li><p>if <var>name</var> is defined and is equal to <var>cookie.name</var>:</p>
+                <li><p>if <var>name</var> is defined and is equal to <var>cookie-name</var>:</p>
                   <ol>
-                    <li><p>Append an object with the following keys and values:</p>
-                      <ul>
-                        <li><p><var>name</var> = <var>cookie.name</var></p></li>
-                        <li><p><var>value</var> = <var>cookie.value</var></p></li>
-                        <li><p><var>path</var> = <var>cookie.path</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
-                        <li><p><var>domain</var> = <var>cookie.domain</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
-                        <li><p><var>secure</var> = <var>cookie.isSecure</var> if <var>cookie.isSecure</var> is defined else it MUST be false.</p></li>
-                        <li><p><var>expiry</var> = <var>cookie.expires</var> where <var>cookie.expires</var> is specified in milliseconds
-                          since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. if <var>cookie.expires</var> is undefined it MUST be null.</p></li>
-                      </ul>
-                    </li>
+                    <li><p>Append a <a>serialised cookie</a> to <var>result</var>.</p></li>
                   </ol>
                 </li>
                 <li><p>Increase the value of <var>k</var> by 1</p></li>
@@ -72,6 +52,22 @@
             </li>
             <li><p>Return <a>success</a> with data <var>result</var></p></li>
           </ol>
+          <p>A <dfn>serialised cookie</dfn> is created with the following algorithm:</p>
+          <p>
+            <ol>
+              <li><p>Let <var>serialisedCookie</var> be an empty map.</p></li>
+              <ul>
+                <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var> be  as defined in [[!RFC6265]]</p></li>
+                <li><p>Add an entry whose key is <var>value</var> and value is <var>cookie-value</var> as defined in [[!RFC6265]]</p></li>
+                <li><p>Add an entry whose key is <var>path</var> and value is <var>path attribute</var> from cookie-attribute-list if defined else it MUST be null.</p></li>
+                <li><p>Add an entry whose key is <var>domain</var> and value is <var>Domain attribute</var> from cookie-attribute-list if defined else it MUST be null.</p></li>
+                <li><p>Add an entry whose key is <var>secure</var> and value is <var>Secure attribute</var> from cookie-attribute-list if defined else it MUST be false.</p></li>
+                <li><p>Add an entry whose key is <var>expiry</var> and value is <var>Expires attribute</var> from cookie-attribute-list where <var>Expires attribute</var>
+                  is specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. If <var>Expires attribute</var> is undefined it MUST be null.</p></li>
+              </ul>
+              <li>Return <var>serialisedCookie</var></li>
+            </ol>
+          </p>
       </section>
       <section>
       <h3>addCookie()</h3>

--- a/12_cookies.html
+++ b/12_cookies.html
@@ -9,24 +9,6 @@
   <section>
     <h2>Cookie</h2>
     <p>When returning Cookie objects, the server SHOULD include all optional fields it is capable of providing the information for.</p>
-    <dl class="idl" title='dictionary Cookie'>
-      <dt>DOMString name</dt>
-      <dd>The name of the cookie. This MUST be set.</dd>
-      <dt>DOMString value</dt>
-      <dd>The cookie value. This MUST be set.</dd>
-      <dt>DOMString path</dt>
-      <dd>The cookie path. This SHOULD be set or MUST be the null value if unknown.</dd>
-      <dt>DOMString domain</dt>
-      <dd>The domain the cookie is visible to. This SHOULD be set or MUST be the null value if unknown.</dd>
-      <dt>Date expiry</dt>
-      <dd>When the cookie expires, specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. This SHOULD be set or MUST be null if unknown.</dd>
-      <dt>Date maxAge</dt>
-      <dd>The value of the Max-Age attribute to set the cookie’s expiration as an interval of seconds in the future</dd>
-      <dt>boolean secure</dt>
-      <dd>True if this represents a Secure cookie, false otherwise. If this attribute is missing, the local ends MUST interpret this as being false.</dd>
-      <dt>boolean httpOnly</dt>
-      <dd>True if this represents an HTTP-Only cookie, false otherwise. If this attribute is missing, local ends MUST interpret this as being false.</dd>
-    </dl>
     <section>
       <!-- getCookie() -->
       <h3>getCookie()</h3>
@@ -38,20 +20,58 @@
               <th>Notes</th>
             </tr>
             <tr>
-              <td>GET</td>
-              <td id='get-cookie'>/session/{sessionId}/cookie</td>
+              <td>POST</td>
+              <td id='post-cookie'>/session/{sessionId}/cookie</td>
               <td></td>
             </tr>
           </table>
-          <p>Remote ends MUST return all cookies that are available in document.cookie via Javascript. In addition, remote ends SHOULD return any HTTP-Only cookies that are associated with the current page.
-        Possible errors that can be returned:
-        <ul>
-          <li><code><a href="#status-invalid-cookie-domain">invalid cookie domain</a></code> - If the cookie's domain is not visible from the current page.<br />
-        </ul>
-        <dl class='parameters'>
-          <dt>optional DOMString? name</dt>
-          <dd>The name (e.g. <code>name=</code>) of the cookie that needs to be returned.</dd>
-        </dl>
+          <p>The <a>remote end steps</a> for the <a>getCookie</a> command are:</p>
+          <ol>
+            <li><p>If the <a>current browsing context</a> is no longer open, return an error with code <a>no such window</a>.</p></li>
+            <li><p>Let <var>name</var> be the result of <a>getting a property</a> named "name" from the <var>parameters</var> argument.</p></li>
+            <li><p>Let <var>result</var> be an empty sequence</p></li>
+            <li><p>Let <var>cookies</var> be all cookies of the resource represented by the idenfied by <a href="https://dom.spec.whatwg.org/#concept-document-url"> the document's address</a></p></li>
+            <li><p>Let <var>cookies</var> be the list of <a href='http://heycam.github.io/webidl/#dfn-values-to-iterate-over'>values to iterate over</a></p></li>
+            <li><p>Let <var>len</var> be the length of <var>cookies</var>.</p></li>
+            <li><p>Initialize <var>k</var> to 0</p></li>
+            <li><p>While <var>k</var> < <var>len</var>: </p>
+              <ol>
+                <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
+                <li><p>If <var>name</var> is undefined:</p>
+                  <ol>
+                    <li><p>Append an object with the following keys and values:</p>
+                      <ul>
+                        <li><p><var>name</var> = <var>cookie.name</var></p></li>
+                        <li><p><var>value</var> = <var>cookie.value</var></p></li>
+                        <li><p><var>path</var> = <var>cookie.path</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
+                        <li><p><var>domain</var> = <var>cookie.domain</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
+                        <li><p><var>secure</var> = <var>cookie.isSecure</var> if <var>cookie.isSecure</var> is defined else it MUST be false.</p></li>
+                        <li><p><var>expiry</var> = <var>cookie.expires</var> where <var>cookie.expires</var> is specified in milliseconds
+                          since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. if <var>cookie.expires</var> is undefined it MUST be null.</p></li>
+                      </ul>
+                    </li>
+                  </ol>
+                </li>
+                <li><p>if <var>name</var> is defined and is equal to <var>cookie.name</var>:</p>
+                  <ol>
+                    <li><p>Append an object with the following keys and values:</p>
+                      <ul>
+                        <li><p><var>name</var> = <var>cookie.name</var></p></li>
+                        <li><p><var>value</var> = <var>cookie.value</var></p></li>
+                        <li><p><var>path</var> = <var>cookie.path</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
+                        <li><p><var>domain</var> = <var>cookie.domain</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
+                        <li><p><var>secure</var> = <var>cookie.isSecure</var> if <var>cookie.isSecure</var> is defined else it MUST be false.</p></li>
+                        <li><p><var>expiry</var> = <var>cookie.expires</var> where <var>cookie.expires</var> is specified in milliseconds
+                          since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. if <var>cookie.expires</var> is undefined it MUST be null.</p></li>
+                      </ul>
+                    </li>
+                  </ol>
+                </li>
+                <li><p>Increase the value of <var>k</var> by 1</p></li>
+              </ol>
+            </li>
+            <li><p>Return <a>success</a> with data <var>result</var></p></li>
+          </ol>
       </section>
       <section>
       <h3>addCookie()</h3>

--- a/12_cookies.html
+++ b/12_cookies.html
@@ -29,11 +29,11 @@
           <ol>
             <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
             <li><p>Let <var>name</var> be the result of <a>getting a property</a> named "name" from the <var>parameters</var> argument.</p></li>
-            <li><p>Let <var>result</var> be an empty JSON List</p></li>
-            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://dom.spec.whatwg.org/#concept-document-url"> the current document or frame address</a></p></li>
+            <li><p>Let <var>result</var> be an empty JSON list.</p></li>
+            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://dom.spec.whatwg.org/#concept-document-url"> the current document or frame address.</a></p></li>
             <li><p>Let <var>length</var> be the length of <var>cookies</var>.</p></li>
             <li><p>Let <var>k</var> be 0</p></li>
-            <li><p>While <var>k</var> < <var>length</var>: </p>
+            <li><p>While <var>k</var> &lt; <var>length</var>:</p>
               <ol>
                 <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
                 <li><p>If <var>name</var> is undefined:</p>
@@ -41,22 +41,22 @@
                     <li><p>Append a <a>serialised cookie</a> to <var>result</var>.</p></li>
                   </ol>
                 </li>
-                <li><p>if <var>name</var> is defined and is equal to <var>cookie-name</var>:</p>
+                <li><p>If <var>name</var> is defined and is equal to <var>cookie-name</var>:</p>
                   <ol>
                     <li><p>Append a <a>serialised cookie</a> to <var>result</var>.</p></li>
                   </ol>
                 </li>
-                <li><p>Increase the value of <var>k</var> by 1</p></li>
+                <li><p>Increase the value of <var>k</var> by 1.</p></li>
               </ol>
             </li>
-            <li><p>Return <a>success</a> with data <var>result</var></p></li>
+            <li><p>Return <a>success</a> with data <var>result.</var></p></li>
           </ol>
-          <p>A <dfn>serialised cookie</dfn> is created with the following algorithm:</p>
+          <p>A <dfn>serialized cookie</dfn> is created with the following algorithm:</p>
           <p>
             <ol>
-              <li><p>Let <var>serialised cookie</var> be an empty map.</p></li>
+              <li><p>Let <var>serialized cookie</var> be an empty map.</p></li>
               <ul>
-                <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var> be  as defined in [[!RFC6265]]</p></li>
+                <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var>  as defined in [[!RFC6265]]</p></li>
                 <li><p>Add an entry whose key is <var>value</var> and value is <var>cookie-value</var> as defined in [[!RFC6265]]</p></li>
                 <li><p>If cookie's attribute-list contains an attribute with attribute-name of Path, let <var>path</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Path". Otherwise let <var>path</var> be null</p>
                   <p>Add an entry to <var>serialized cookie</var> with key "path" and value <var>path</var></p></li>
@@ -64,8 +64,7 @@
                   <p>Add an entry to <var>serialized cookie</var> with key "domain" and value <var>domain</var></p></li>
                 <li><p>If cookie's attribute-list contains an attribute with attribute-name of Secure, let <var>secure</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Secure". Otherwise let <var>secure</var> be null</p>
                   <p>Add an entry to <var>serialized cookie</var> with key "secure" and value <var>secure</var></p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires, let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Expires". Otherwise let <var>expiry</var> be null</p>
-                  <p>Add an entry to <var>serialized cookie</var> with key "expiry" and value <var>expiry</var> where <var>expiry</var> is specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. If <var>Expires attribute</var> is undefined it MUST be null.</p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires, let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Expires" specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. Otherwise let <var>expiry</var> be null</p>
               </ul>
               <li>Return <var>serialised cookie</var></li>
             </ol>

--- a/12_cookies.html
+++ b/12_cookies.html
@@ -58,15 +58,24 @@
               <ul>
                 <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var>  as defined in [[!RFC6265]]</p></li>
                 <li><p>Add an entry whose key is <var>value</var> and value is <var>cookie-value</var> as defined in [[!RFC6265]]</p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Path, let <var>path</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Path". Otherwise let <var>path</var> be null</p>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Path,
+                  let <var>path</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                   with an attribute-name of "Path". Otherwise let <var>path</var> be null</p>
                   <p>Add an entry to <var>serialized cookie</var> with key "path" and value <var>path</var></p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Domain, let <var>domain</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Domain". Otherwise let <var>domain</var> be null</p>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Domain,
+                  let <var>domain</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                  with an attribute-name of "Domain". Otherwise let <var>domain</var> be null</p>
                   <p>Add an entry to <var>serialized cookie</var> with key "domain" and value <var>domain</var></p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Secure, let <var>secure</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Secure". Otherwise let <var>secure</var> be null</p>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Secure,
+                  let <var>secure</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                  with an attribute-name of "Secure". Otherwise let <var>secure</var> be null</p>
                   <p>Add an entry to <var>serialized cookie</var> with key "secure" and value <var>secure</var></p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires, let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Expires" specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. Otherwise let <var>expiry</var> be null</p>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires,
+                  let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                   with an attribute-name of "Expires" specified in milliseconds since midnight, January 1, 1970 UTC
+                    using the format described in [[!RFC1123]]. Otherwise let <var>expiry</var> be null</p>
               </ul>
-              <li>Return <var>serialised cookie</var></li>
+              <li>Return <var>serialized cookie</var></li>
             </ol>
           </p>
       </section>

--- a/12_cookies.html
+++ b/12_cookies.html
@@ -30,11 +30,10 @@
             <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
             <li><p>Let <var>name</var> be the result of <a>getting a property</a> named "name" from the <var>parameters</var> argument.</p></li>
             <li><p>Let <var>result</var> be an empty JSON List</p></li>
-            <li><p>Let <var>cookies</var> be all cookies [[!RFC6265]] of the resource represented by the idenfied by <a href="https://dom.spec.whatwg.org/#concept-document-url"> the document's address</a></p></li>
-            <li><p>Let <var>cookies</var> be the list of values to iterate over</p></li>
-            <li><p>Let <var>len</var> be the length of <var>cookies</var>.</p></li>
+            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://dom.spec.whatwg.org/#concept-document-url"> the current document or frame address</a></p></li>
+            <li><p>Let <var>length</var> be the length of <var>cookies</var>.</p></li>
             <li><p>Let <var>k</var> be 0</p></li>
-            <li><p>While <var>k</var> < <var>len</var>: </p>
+            <li><p>While <var>k</var> < <var>length</var>: </p>
               <ol>
                 <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
                 <li><p>If <var>name</var> is undefined:</p>
@@ -55,17 +54,20 @@
           <p>A <dfn>serialised cookie</dfn> is created with the following algorithm:</p>
           <p>
             <ol>
-              <li><p>Let <var>serialisedCookie</var> be an empty map.</p></li>
+              <li><p>Let <var>serialised cookie</var> be an empty map.</p></li>
               <ul>
                 <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var> be  as defined in [[!RFC6265]]</p></li>
                 <li><p>Add an entry whose key is <var>value</var> and value is <var>cookie-value</var> as defined in [[!RFC6265]]</p></li>
-                <li><p>Add an entry whose key is <var>path</var> and value is <var>path attribute</var> from cookie-attribute-list if defined else it MUST be null.</p></li>
-                <li><p>Add an entry whose key is <var>domain</var> and value is <var>Domain attribute</var> from cookie-attribute-list if defined else it MUST be null.</p></li>
-                <li><p>Add an entry whose key is <var>secure</var> and value is <var>Secure attribute</var> from cookie-attribute-list if defined else it MUST be false.</p></li>
-                <li><p>Add an entry whose key is <var>expiry</var> and value is <var>Expires attribute</var> from cookie-attribute-list where <var>Expires attribute</var>
-                  is specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. If <var>Expires attribute</var> is undefined it MUST be null.</p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Path, let <var>path</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Path". Otherwise let <var>path</var> be null</p>
+                  <p>Add an entry to <var>serialized cookie</var> with key "path" and value <var>path</var></p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Domain, let <var>domain</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Domain". Otherwise let <var>domain</var> be null</p>
+                  <p>Add an entry to <var>serialized cookie</var> with key "domain" and value <var>domain</var></p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Secure, let <var>secure</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Secure". Otherwise let <var>secure</var> be null</p>
+                  <p>Add an entry to <var>serialized cookie</var> with key "secure" and value <var>secure</var></p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires, let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Expires". Otherwise let <var>expiry</var> be null</p>
+                  <p>Add an entry to <var>serialized cookie</var> with key "expiry" and value <var>expiry</var> where <var>expiry</var> is specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. If <var>Expires attribute</var> is undefined it MUST be null.</p></li>
               </ul>
-              <li>Return <var>serialisedCookie</var></li>
+              <li>Return <var>serialised cookie</var></li>
             </ol>
           </p>
       </section>

--- a/12_cookies.html
+++ b/12_cookies.html
@@ -30,7 +30,7 @@
             <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
             <li><p>Let <var>name</var> be the result of <a>getting a property</a> named "name" from the <var>parameters</var> argument.</p></li>
             <li><p>Let <var>result</var> be an empty JSON list.</p></li>
-            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://dom.spec.whatwg.org/#concept-document-url"> the current document or frame address.</a></p></li>
+            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://html.spec.whatwg.org/#active-document">active document</a> <a href="https://dom.spec.whatwg.org/#concept-document-url">address</a>.</p></li>
             <li><p>Let <var>length</var> be the length of <var>cookies</var>.</p></li>
             <li><p>Let <var>k</var> be 0</p></li>
             <li><p>While <var>k</var> &lt; <var>length</var>:</p>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -168,7 +168,7 @@ code a:visited, code a:link {
    <h3>Terminology</h3>
 
    <p>In equations, all numbers are integers,
-    subtraction is represented by “−”, and bitwise OR by “|”. 
+    subtraction is represented by “−”, and bitwise OR by “|”.
     The characters “(” and “)” are used to provide logical grouping in these contexts.
   </section>
 
@@ -217,6 +217,9 @@ code a:visited, code a:link {
     and <code><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.3>parseFloat</a></code>
     from [[!ECMA-262]] with the exception that non-valid integer
     or float return values are returned as 0 or 0.0.
+
+    <h4>Top Browsing content no longer open</h4>
+    <p>A top browsing context is <dfn>no longer open</dfn> if it has been <a href="https://html.spec.whatwg.org/#a-browsing-context-is-discarded">discarded</a>
   </section>
 </section>
 <section>
@@ -516,7 +519,7 @@ code a:visited, code a:link {
         <td><a>Execute Async Script</a></td>
       </tr>
       <tr>
-        <td>GET</td>
+        <td>POST</td>
         <td>/session/{sessionId}/cookie</td>
         <td><a>Get Cookie</a></td>
       </tr>
@@ -1043,7 +1046,7 @@ code a:visited, code a:link {
 
     <p>The <a>remote end steps</a> for the <a>get</a> command are:</p>
     <ol>
-      <li><p>If the <a>current browsing context</a> is no longer open, return an error with code <a>no such window</a>.</p></li>
+      <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
       <li><p>Let <var>url</var> be the result of <a>getting a property</a> named "url" from the <var>parameters</var> argument.</p></li>
       <li><p>If <var>url</var> is undefined, return an <a>error</a> with code <a>invalid argument</a></p></li>
       <li><p><a href="">Navigate</a> the <a>current browsing context</a>'s to <var>url</var>. If this navigation results in a HTTP 401 response, the <a>remote end</a> must proceed with the steps below, irrespective of how the authentication challenge is handled.</p></li>
@@ -2508,7 +2511,7 @@ code a:visited, code a:link {
     <p>When returning Cookie objects, the server SHOULD include all optional fields it is capable of providing the information for.</p>
     <section>
       <!-- getCookie() -->
-      <h3>getCookie()</h3>
+      <h3>getCookie</h3>
         <p>
           <table class="simple jsoncommand">
             <tr>
@@ -2524,44 +2527,24 @@ code a:visited, code a:link {
           </table>
           <p>The <a>remote end steps</a> for the <a>getCookie</a> command are:</p>
           <ol>
-            <li><p>If the <a>current browsing context</a> is no longer open, return an error with code <a>no such window</a>.</p></li>
+            <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
             <li><p>Let <var>name</var> be the result of <a>getting a property</a> named "name" from the <var>parameters</var> argument.</p></li>
-            <li><p>Let <var>result</var> be an empty sequence</p></li>
-            <li><p>Let <var>cookies</var> be all cookies of the resource represented by the idenfied by <a href="https://dom.spec.whatwg.org/#concept-document-url"> the document's address</a></p></li>
-            <li><p>Let <var>cookies</var> be the list of <a href='http://heycam.github.io/webidl/#dfn-values-to-iterate-over'>values to iterate over</a></p></li>
+            <li><p>Let <var>result</var> be an empty JSON List</p></li>
+            <li><p>Let <var>cookies</var> be all cookies [[!RFC6265]] of the resource represented by the idenfied by <a href="https://dom.spec.whatwg.org/#concept-document-url"> the document's address</a></p></li>
+            <li><p>Let <var>cookies</var> be the list of values to iterate over</p></li>
             <li><p>Let <var>len</var> be the length of <var>cookies</var>.</p></li>
-            <li><p>Initialize <var>k</var> to 0</p></li>
+            <li><p>Let <var>k</var> be 0</p></li>
             <li><p>While <var>k</var> < <var>len</var>: </p>
               <ol>
                 <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
                 <li><p>If <var>name</var> is undefined:</p>
                   <ol>
-                    <li><p>Append an object with the following keys and values:</p>
-                      <ul>
-                        <li><p><var>name</var> = <var>cookie.name</var></p></li>
-                        <li><p><var>value</var> = <var>cookie.value</var></p></li>
-                        <li><p><var>path</var> = <var>cookie.path</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
-                        <li><p><var>domain</var> = <var>cookie.domain</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
-                        <li><p><var>secure</var> = <var>cookie.isSecure</var> if <var>cookie.isSecure</var> is defined else it MUST be false.</p></li>
-                        <li><p><var>expiry</var> = <var>cookie.expires</var> where <var>cookie.expires</var> is specified in milliseconds
-                          since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. if <var>cookie.expires</var> is undefined it MUST be null.</p></li>
-                      </ul>
-                    </li>
+                    <li><p>Append a <a>serialised cookie</a> to <var>result</var>.</p></li>
                   </ol>
                 </li>
-                <li><p>if <var>name</var> is defined and is equal to <var>cookie.name</var>:</p>
+                <li><p>if <var>name</var> is defined and is equal to <var>cookie-name</var>:</p>
                   <ol>
-                    <li><p>Append an object with the following keys and values:</p>
-                      <ul>
-                        <li><p><var>name</var> = <var>cookie.name</var></p></li>
-                        <li><p><var>value</var> = <var>cookie.value</var></p></li>
-                        <li><p><var>path</var> = <var>cookie.path</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
-                        <li><p><var>domain</var> = <var>cookie.domain</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
-                        <li><p><var>secure</var> = <var>cookie.isSecure</var> if <var>cookie.isSecure</var> is defined else it MUST be false.</p></li>
-                        <li><p><var>expiry</var> = <var>cookie.expires</var> where <var>cookie.expires</var> is specified in milliseconds
-                          since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. if <var>cookie.expires</var> is undefined it MUST be null.</p></li>
-                      </ul>
-                    </li>
+                    <li><p>Append a <a>serialised cookie</a> to <var>result</var>.</p></li>
                   </ol>
                 </li>
                 <li><p>Increase the value of <var>k</var> by 1</p></li>
@@ -2569,6 +2552,22 @@ code a:visited, code a:link {
             </li>
             <li><p>Return <a>success</a> with data <var>result</var></p></li>
           </ol>
+          <p>A <dfn>serialised cookie</dfn> is created with the following algorithm:</p>
+          <p>
+            <ol>
+              <li><p>Let <var>serialisedCookie</var> be an empty map.</p></li>
+              <ul>
+                <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var> be  as defined in [[!RFC6265]]</p></li>
+                <li><p>Add an entry whose key is <var>value</var> and value is <var>cookie-value</var> as defined in [[!RFC6265]]</p></li>
+                <li><p>Add an entry whose key is <var>path</var> and value is <var>path attribute</var> from cookie-attribute-list if defined else it MUST be null.</p></li>
+                <li><p>Add an entry whose key is <var>domain</var> and value is <var>Domain attribute</var> from cookie-attribute-list if defined else it MUST be null.</p></li>
+                <li><p>Add an entry whose key is <var>secure</var> and value is <var>Secure attribute</var> from cookie-attribute-list if defined else it MUST be false.</p></li>
+                <li><p>Add an entry whose key is <var>expiry</var> and value is <var>Expires attribute</var> from cookie-attribute-list where <var>Expires attribute</var>
+                  is specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. If <var>Expires attribute</var> is undefined it MUST be null.</p></li>
+              </ul>
+              <li>Return <var>serialisedCookie</var></li>
+            </ol>
+          </p>
       </section>
       <section>
       <h3>addCookie()</h3>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2506,24 +2506,6 @@ code a:visited, code a:link {
   <section>
     <h2>Cookie</h2>
     <p>When returning Cookie objects, the server SHOULD include all optional fields it is capable of providing the information for.</p>
-    <dl class="idl" title='dictionary Cookie'>
-      <dt>DOMString name</dt>
-      <dd>The name of the cookie. This MUST be set.</dd>
-      <dt>DOMString value</dt>
-      <dd>The cookie value. This MUST be set.</dd>
-      <dt>DOMString path</dt>
-      <dd>The cookie path. This SHOULD be set or MUST be the null value if unknown.</dd>
-      <dt>DOMString domain</dt>
-      <dd>The domain the cookie is visible to. This SHOULD be set or MUST be the null value if unknown.</dd>
-      <dt>Date expiry</dt>
-      <dd>When the cookie expires, specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. This SHOULD be set or MUST be null if unknown.</dd>
-      <dt>Date maxAge</dt>
-      <dd>The value of the Max-Age attribute to set the cookie’s expiration as an interval of seconds in the future</dd>
-      <dt>boolean secure</dt>
-      <dd>True if this represents a Secure cookie, false otherwise. If this attribute is missing, the local ends MUST interpret this as being false.</dd>
-      <dt>boolean httpOnly</dt>
-      <dd>True if this represents an HTTP-Only cookie, false otherwise. If this attribute is missing, local ends MUST interpret this as being false.</dd>
-    </dl>
     <section>
       <!-- getCookie() -->
       <h3>getCookie()</h3>
@@ -2535,20 +2517,58 @@ code a:visited, code a:link {
               <th>Notes</th>
             </tr>
             <tr>
-              <td>GET</td>
-              <td id='get-cookie'>/session/{sessionId}/cookie</td>
+              <td>POST</td>
+              <td id='post-cookie'>/session/{sessionId}/cookie</td>
               <td></td>
             </tr>
           </table>
-          <p>Remote ends MUST return all cookies that are available in document.cookie via Javascript. In addition, remote ends SHOULD return any HTTP-Only cookies that are associated with the current page.
-        Possible errors that can be returned:
-        <ul>
-          <li><code><a href="#status-invalid-cookie-domain">invalid cookie domain</a></code> - If the cookie's domain is not visible from the current page.<br />
-        </ul>
-        <dl class='parameters'>
-          <dt>optional DOMString? name</dt>
-          <dd>The name (e.g. <code>name=</code>) of the cookie that needs to be returned.</dd>
-        </dl>
+          <p>The <a>remote end steps</a> for the <a>getCookie</a> command are:</p>
+          <ol>
+            <li><p>If the <a>current browsing context</a> is no longer open, return an error with code <a>no such window</a>.</p></li>
+            <li><p>Let <var>name</var> be the result of <a>getting a property</a> named "name" from the <var>parameters</var> argument.</p></li>
+            <li><p>Let <var>result</var> be an empty sequence</p></li>
+            <li><p>Let <var>cookies</var> be all cookies of the resource represented by the idenfied by <a href="https://dom.spec.whatwg.org/#concept-document-url"> the document's address</a></p></li>
+            <li><p>Let <var>cookies</var> be the list of <a href='http://heycam.github.io/webidl/#dfn-values-to-iterate-over'>values to iterate over</a></p></li>
+            <li><p>Let <var>len</var> be the length of <var>cookies</var>.</p></li>
+            <li><p>Initialize <var>k</var> to 0</p></li>
+            <li><p>While <var>k</var> < <var>len</var>: </p>
+              <ol>
+                <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
+                <li><p>If <var>name</var> is undefined:</p>
+                  <ol>
+                    <li><p>Append an object with the following keys and values:</p>
+                      <ul>
+                        <li><p><var>name</var> = <var>cookie.name</var></p></li>
+                        <li><p><var>value</var> = <var>cookie.value</var></p></li>
+                        <li><p><var>path</var> = <var>cookie.path</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
+                        <li><p><var>domain</var> = <var>cookie.domain</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
+                        <li><p><var>secure</var> = <var>cookie.isSecure</var> if <var>cookie.isSecure</var> is defined else it MUST be false.</p></li>
+                        <li><p><var>expiry</var> = <var>cookie.expires</var> where <var>cookie.expires</var> is specified in milliseconds
+                          since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. if <var>cookie.expires</var> is undefined it MUST be null.</p></li>
+                      </ul>
+                    </li>
+                  </ol>
+                </li>
+                <li><p>if <var>name</var> is defined and is equal to <var>cookie.name</var>:</p>
+                  <ol>
+                    <li><p>Append an object with the following keys and values:</p>
+                      <ul>
+                        <li><p><var>name</var> = <var>cookie.name</var></p></li>
+                        <li><p><var>value</var> = <var>cookie.value</var></p></li>
+                        <li><p><var>path</var> = <var>cookie.path</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
+                        <li><p><var>domain</var> = <var>cookie.domain</var> if <var>cookie.path</var> is defined else it MUST be null.</p></li>
+                        <li><p><var>secure</var> = <var>cookie.isSecure</var> if <var>cookie.isSecure</var> is defined else it MUST be false.</p></li>
+                        <li><p><var>expiry</var> = <var>cookie.expires</var> where <var>cookie.expires</var> is specified in milliseconds
+                          since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. if <var>cookie.expires</var> is undefined it MUST be null.</p></li>
+                      </ul>
+                    </li>
+                  </ol>
+                </li>
+                <li><p>Increase the value of <var>k</var> by 1</p></li>
+              </ol>
+            </li>
+            <li><p>Return <a>success</a> with data <var>result</var></p></li>
+          </ol>
       </section>
       <section>
       <h3>addCookie()</h3>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -218,8 +218,8 @@ code a:visited, code a:link {
     from [[!ECMA-262]] with the exception that non-valid integer
     or float return values are returned as 0 or 0.0.
 
-    <h4>Top Browsing content no longer open</h4>
-    <p>A top browsing context is <dfn>no longer open</dfn> if it has been <a href="https://html.spec.whatwg.org/#a-browsing-context-is-discarded">discarded</a>
+    <h4>Top Level Browsing Context no longer open</h4>
+    <p>A top level browsing context is <dfn>no longer open</dfn> if it has been <a href="https://html.spec.whatwg.org/#a-browsing-context-is-discarded">discarded</a>
   </section>
 </section>
 <section>
@@ -2530,11 +2530,10 @@ code a:visited, code a:link {
             <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
             <li><p>Let <var>name</var> be the result of <a>getting a property</a> named "name" from the <var>parameters</var> argument.</p></li>
             <li><p>Let <var>result</var> be an empty JSON List</p></li>
-            <li><p>Let <var>cookies</var> be all cookies [[!RFC6265]] of the resource represented by the idenfied by <a href="https://dom.spec.whatwg.org/#concept-document-url"> the document's address</a></p></li>
-            <li><p>Let <var>cookies</var> be the list of values to iterate over</p></li>
-            <li><p>Let <var>len</var> be the length of <var>cookies</var>.</p></li>
+            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://dom.spec.whatwg.org/#concept-document-url"> the document's address</a></p></li>
+            <li><p>Let <var>length</var> be the length of <var>cookies</var>.</p></li>
             <li><p>Let <var>k</var> be 0</p></li>
-            <li><p>While <var>k</var> < <var>len</var>: </p>
+            <li><p>While <var>k</var> < <var>length</var>: </p>
               <ol>
                 <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
                 <li><p>If <var>name</var> is undefined:</p>
@@ -2555,17 +2554,20 @@ code a:visited, code a:link {
           <p>A <dfn>serialised cookie</dfn> is created with the following algorithm:</p>
           <p>
             <ol>
-              <li><p>Let <var>serialisedCookie</var> be an empty map.</p></li>
+              <li><p>Let <var>serialised cookie</var> be an empty map.</p></li>
               <ul>
                 <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var> be  as defined in [[!RFC6265]]</p></li>
                 <li><p>Add an entry whose key is <var>value</var> and value is <var>cookie-value</var> as defined in [[!RFC6265]]</p></li>
-                <li><p>Add an entry whose key is <var>path</var> and value is <var>path attribute</var> from cookie-attribute-list if defined else it MUST be null.</p></li>
-                <li><p>Add an entry whose key is <var>domain</var> and value is <var>Domain attribute</var> from cookie-attribute-list if defined else it MUST be null.</p></li>
-                <li><p>Add an entry whose key is <var>secure</var> and value is <var>Secure attribute</var> from cookie-attribute-list if defined else it MUST be false.</p></li>
-                <li><p>Add an entry whose key is <var>expiry</var> and value is <var>Expires attribute</var> from cookie-attribute-list where <var>Expires attribute</var>
-                  is specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. If <var>Expires attribute</var> is undefined it MUST be null.</p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Path, let <var>path</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Path". Otherwise let <var>path</var> be null</p>
+                  <p>Add an entry to <var>serialized cookie</var> with key "path" and value <var>path</var></p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Domain, let <var>domain</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Domain". Otherwise let <var>domain</var> be null</p>
+                  <p>Add an entry to <var>serialized cookie</var> with key "domain" and value <var>domain</var></p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Secure, let <var>secure</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Secure". Otherwise let <var>secure</var> be null</p>
+                  <p>Add an entry to <var>serialized cookie</var> with key "secure" and value <var>secure</var></p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires, let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Expires". Otherwise let <var>expiry</var> be null</p>
+                  <p>Add an entry to <var>serialized cookie</var> with key "expiry" and value <var>expiry</var> where <var>expiry</var> is specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. If <var>Expires attribute</var> is undefined it MUST be null.</p></li>
               </ul>
-              <li>Return <var>serialisedCookie</var></li>
+              <li>Return <var>serialised cookie</var></li>
             </ol>
           </p>
       </section>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2530,7 +2530,7 @@ code a:visited, code a:link {
             <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
             <li><p>Let <var>name</var> be the result of <a>getting a property</a> named "name" from the <var>parameters</var> argument.</p></li>
             <li><p>Let <var>result</var> be an empty JSON list.</p></li>
-            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://dom.spec.whatwg.org/#concept-document-url"> the current document or frame address.</a></p></li>
+            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://html.spec.whatwg.org/#active-document">active document</a> <a href="https://dom.spec.whatwg.org/#concept-document-url">address</a>.</p></li>
             <li><p>Let <var>length</var> be the length of <var>cookies</var>.</p></li>
             <li><p>Let <var>k</var> be 0</p></li>
             <li><p>While <var>k</var> &lt; <var>length</var>:</p>
@@ -2558,15 +2558,24 @@ code a:visited, code a:link {
               <ul>
                 <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var>  as defined in [[!RFC6265]]</p></li>
                 <li><p>Add an entry whose key is <var>value</var> and value is <var>cookie-value</var> as defined in [[!RFC6265]]</p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Path, let <var>path</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Path". Otherwise let <var>path</var> be null</p>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Path,
+                  let <var>path</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                   with an attribute-name of "Path". Otherwise let <var>path</var> be null</p>
                   <p>Add an entry to <var>serialized cookie</var> with key "path" and value <var>path</var></p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Domain, let <var>domain</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Domain". Otherwise let <var>domain</var> be null</p>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Domain,
+                  let <var>domain</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                  with an attribute-name of "Domain". Otherwise let <var>domain</var> be null</p>
                   <p>Add an entry to <var>serialized cookie</var> with key "domain" and value <var>domain</var></p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Secure, let <var>secure</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Secure". Otherwise let <var>secure</var> be null</p>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Secure,
+                  let <var>secure</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                  with an attribute-name of "Secure". Otherwise let <var>secure</var> be null</p>
                   <p>Add an entry to <var>serialized cookie</var> with key "secure" and value <var>secure</var></p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires, let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Expires" specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. Otherwise let <var>expiry</var> be null</p>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires,
+                  let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                   with an attribute-name of "Expires" specified in milliseconds since midnight, January 1, 1970 UTC
+                    using the format described in [[!RFC1123]]. Otherwise let <var>expiry</var> be null</p>
               </ul>
-              <li>Return <var>serialised cookie</var></li>
+              <li>Return <var>serialized cookie</var></li>
             </ol>
           </p>
       </section>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2529,11 +2529,11 @@ code a:visited, code a:link {
           <ol>
             <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
             <li><p>Let <var>name</var> be the result of <a>getting a property</a> named "name" from the <var>parameters</var> argument.</p></li>
-            <li><p>Let <var>result</var> be an empty JSON List</p></li>
-            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://dom.spec.whatwg.org/#concept-document-url"> the document's address</a></p></li>
+            <li><p>Let <var>result</var> be an empty JSON list.</p></li>
+            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://dom.spec.whatwg.org/#concept-document-url"> the current document or frame address.</a></p></li>
             <li><p>Let <var>length</var> be the length of <var>cookies</var>.</p></li>
             <li><p>Let <var>k</var> be 0</p></li>
-            <li><p>While <var>k</var> < <var>length</var>: </p>
+            <li><p>While <var>k</var> &lt; <var>length</var>:</p>
               <ol>
                 <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
                 <li><p>If <var>name</var> is undefined:</p>
@@ -2541,22 +2541,22 @@ code a:visited, code a:link {
                     <li><p>Append a <a>serialised cookie</a> to <var>result</var>.</p></li>
                   </ol>
                 </li>
-                <li><p>if <var>name</var> is defined and is equal to <var>cookie-name</var>:</p>
+                <li><p>If <var>name</var> is defined and is equal to <var>cookie-name</var>:</p>
                   <ol>
                     <li><p>Append a <a>serialised cookie</a> to <var>result</var>.</p></li>
                   </ol>
                 </li>
-                <li><p>Increase the value of <var>k</var> by 1</p></li>
+                <li><p>Increase the value of <var>k</var> by 1.</p></li>
               </ol>
             </li>
-            <li><p>Return <a>success</a> with data <var>result</var></p></li>
+            <li><p>Return <a>success</a> with data <var>result.</var></p></li>
           </ol>
-          <p>A <dfn>serialised cookie</dfn> is created with the following algorithm:</p>
+          <p>A <dfn>serialized cookie</dfn> is created with the following algorithm:</p>
           <p>
             <ol>
-              <li><p>Let <var>serialised cookie</var> be an empty map.</p></li>
+              <li><p>Let <var>serialized cookie</var> be an empty map.</p></li>
               <ul>
-                <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var> be  as defined in [[!RFC6265]]</p></li>
+                <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var>  as defined in [[!RFC6265]]</p></li>
                 <li><p>Add an entry whose key is <var>value</var> and value is <var>cookie-value</var> as defined in [[!RFC6265]]</p></li>
                 <li><p>If cookie's attribute-list contains an attribute with attribute-name of Path, let <var>path</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Path". Otherwise let <var>path</var> be null</p>
                   <p>Add an entry to <var>serialized cookie</var> with key "path" and value <var>path</var></p></li>
@@ -2564,8 +2564,7 @@ code a:visited, code a:link {
                   <p>Add an entry to <var>serialized cookie</var> with key "domain" and value <var>domain</var></p></li>
                 <li><p>If cookie's attribute-list contains an attribute with attribute-name of Secure, let <var>secure</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Secure". Otherwise let <var>secure</var> be null</p>
                   <p>Add an entry to <var>serialized cookie</var> with key "secure" and value <var>secure</var></p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires, let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Expires". Otherwise let <var>expiry</var> be null</p>
-                  <p>Add an entry to <var>serialized cookie</var> with key "expiry" and value <var>expiry</var> where <var>expiry</var> is specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. If <var>Expires attribute</var> is undefined it MUST be null.</p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires, let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list with an attribute-name of "Expires" specified in milliseconds since midnight, January 1, 1970 UTC using the format described in [[!RFC1123]]. Otherwise let <var>expiry</var> be null</p>
               </ul>
               <li>Return <var>serialised cookie</var></li>
             </ol>


### PR DESCRIPTION
...e

The change allows us to getCookies and getCookies(name) and return them to the remote end. The notable change is the change from
GET to POST to allow a body that can be parsed to get the cookie name