### PR TITLE
Remove a sentence that has unclear purpose and other issues.

### DIFF
--- a/09_elements.html
+++ b/09_elements.html
@@ -484,7 +484,5 @@
    <p>If the steps above return true, then the element MUST also
     be <a href=#interactable-elements>interactable</a> should it
     meet the other criteria for being interactable.
-    If any part of the <code>BODY</code> can be brought into the current viewport,
-    the return value MUST be true.
   </section>
 </section>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1961,8 +1961,6 @@ code a:visited, code a:link {
    <p>If the steps above return true, then the element MUST also
     be <a href=#interactable-elements>interactable</a> should it
     meet the other criteria for being interactable.
-    If any part of the <code>BODY</code> can be brought into the current viewport,
-    the return value MUST be true.
   </section>
 </section>
 <section>


### PR DESCRIPTION
Other issues:
- 'any part of the BODY' is not specific enough?
- 'can be brought into the current viewport' allows (I believe, unintentionally) doing anything in order to bring the thing into the viewport, e.g. modifying current page's DOM.