### PR TITLE
Add stacktrace field to error responses

### DIFF
--- a/02_commands.html
+++ b/02_commands.html
@@ -75,6 +75,8 @@
 
       <li><p>Let <var>message</var> be an implementation-defined string containing a human-readable description of the reason for the error.</p></li>
 
+      <li><p>Let <var>stacktrace</var> be an implementation-defined string containing a stack trace report of the active stack frames at the time when the error occurred.</p></li>
+
         <!-- TODO: really need a better way of constructing JSON literals -->
       <li><p><a>Set the properties</a> of <var>data</var> with values ("error", <var>name</var>), ("message", <var>message</var>).</p></li>
 


### PR DESCRIPTION
According to [discussion on mailing list](https://lists.w3.org/Archives/Public/public-browser-tools-testing/2015AprJun/0008.html).