### PR TITLE
Add Firefox OS to platformName capability and remove omission of dash

### DIFF
--- a/04_sessions.html
+++ b/04_sessions.html
@@ -159,23 +159,32 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
 
       <section>
         <h3>Platform Names</h3>
-        <p>The following platform names are defined and MUST be used, case sensitively, for the "platformName" unless the actual platform being used is not given in this list:</p>
+
+        <p>The following platform names are defined and MUST be used,
+         case sensitively, for the <code>platformName</code> capability
+         unless the actual platform being used is not given in this list:
+
         <ul>
-          <li>android</li>
-          <li>ios</li>
-          <li>linux</li>
-          <li>mac</li>
-          <li>unix</li>
-          <li>windows</li>
+          <li>"<code>android</code>"
+          <li>"<code>firefoxos</code>"
+          <li>"<code>ios</code>"
+          <li>"<code>linux</code>"
+          <li>"<code>mac</code>"
+          <li>"<code>unix</code>"
+          <li>"<code>windows</code>"
         </ul>
-        <p>In addition "any" MAY be used to indicate the underlying OS is either unknown or does not matter.</p>
 
-        <p>Implementors MAY add additional platform names. Until these are standardized, these MUST follow the conventions outlined in <a href="#extending-the-protocol">extending the protocol</a> section with the exception that the vendor prefix SHOULD omit the leading "-" character.<p>
+        <p>In addition "<code>any</code>" MAY be used
+         to indicate the underlying OS is either unknown or does not matter.
 
-        <p class="note">For example, Mozilla's Firefox OS could be described as either "-MOZ-FIREFOXOS". The latter makes it easier for local ends to specify an enum of supported platforms and is therefore recommended in this case.</p>
+        <p>Implementors MAY add additional platform names.
+         Until these are standardized, these MUST follow the conventions outlined in
+         <a href=#extending-the-protocol>extending the protocol</a> section.
+
+        <p class=note>For example, Mozilla's Firefox OS
+         could be described as "<code>-moz-firefoxos</code>".
 
         <!-- TODO: Add section on comparing platforms -->
-
       </section>
     </section>
     <section>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1,227 +1,3 @@
-<!DOCTYPE html>
-<html data-bug-blocked=20860
-      data-bug-product="Browser Test/Tools WG"
-      data-bug-component=WebDriver>
-  <head>
-    <title>WebDriver</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-
-    <style type="text/css">
-    /* --- WEB IDL --- */
-pre.IDL {
-    border-top: 1px solid #90b8de;
-    border-bottom: 1px solid #90b8de;
-    padding:    1em;
-    line-height:    120%;
-}
-
-pre.IDL::before {
-    content:    "WebIDL";
-    display:    block;
-    width:      150px;
-    background: #90b8de;
-    color:  #fff;
-    font-family:    initial;
-    padding:    3px;
-    font-weight:    bold;
-    margin: -1em 0 1em -1em;
-}
-
-code a:visited, code a:link {
-  color:  #ff4500;
-}
-
-     #respec-ui { top: 80px !important }
-    </style>
-
-    <!--
-      === NOTA BENE ===
-      For the three scripts below, if your spec resides on dev.w3 you can check them
-      out in the same tree and use relative links so that they'll work offline,
-     -->
-    <script src='respec-w3c-common.js' class='remove' async></script>
-    <script class='remove'>
-      var respecConfig = {
-          specStatus:           "ED",
-
-          shortName:            "webdriver",
-
-          // publishDate:  "2009-08-06",
-
-          // copyrightStart: "2005"
-
-          // previousPublishDate:  "1977-03-15",
-
-          // previousMaturity:  "WD",
-
-          edDraftURI:           "https://w3c.github.io/webdriver/webdriver-spec.html",
-
-          // lcEnd: "2009-08-05",
-
-          editors:  [
-              { name: "Simon Stewart", url: "http://www.rocketpoweredjetpants.com/",
-                company: "Facebook", companyURL: "http://www.facebook.com/"
-              },
-              { name: "David Burns", url: "http://www.theautomatedtester.co.uk/",
-                company: "Mozilla", companyURL: "http://www.mozilla.org/" },
-          ],
-
-          otherLinks: [{
-            key: "Raising issues with the specification",
-            data: [{
-                    value: "W3 Bug Tracker",
-                    href: "https://www.w3.org/Bugs/Public/enter_bug.cgi?comment=&blocked=20860&short_desc=[WebDriver%20Spec]%3A%20&product=Browser%20Test%2FTools%20WG&component=WebDriver"
-                  }]
-          }],
-
-          wg:           "Browser Testing and Tools Working Group",
-
-          wgURI:        "http://www.w3.org/testing/browser/",
-
-          wgPublicList: "public-browser-tools-testing",
-
-          wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/49799/status",
-
-          noIDLSorting: true,
-      };
-    </script>
-    <script src=bug-assist.js></script>
-  </head>
-  <body>
-
-<section id="abstract">
-<p>This specification defines the WebDriver API, a platform and language-neutral interface and associated wire protocol that allows programs or scripts to introspect into, and control the behaviour of, a web browser. The WebDriver API is primarily intended to allow developers to write tests that automate a browser from a separate controlling process, but may also be implemented in such a way as to allow in-browser scripts to control a &mdash; possibly separate &mdash; browser.</p>
-
-<p>The WebDriver API is defined by a wire protocol and a set of interfaces to discover and manipulate DOM elements on a page, and to control the behaviour of the containing browser.</p>
-
-<p>This specification also includes a normative reference serialisation (to JSON over HTTP) of the interface's invocations and responses that are to be used by browser vendors to ensure interoperability.</p>
-</section>
-
-<section id="sotd">
-<p>If you wish to make comments regarding this document, please email feedback to <a href="mailto:public-browser-tools-testing@w3.org">public-browser-tools-testing@w3.org</a>. All feedback is welcome, and the editors will read and consider all feedback.</p>
-
-<p>This specification is still under active development and may not be stable. Any implementors who are not actively participating in the preparation of this specification may find unexpected changes occurring. It is suggested that any implementors join the WG for this specification. Despite not being stable, it should be noted that this specification is strongly based on an existing Open Source project &mdash; <a href="http://selenium.googlecode.com/">Selenium WebDriver</a> &mdash; and the existing implementations of the API defined within that project.</p>
-</section>
-<section>
-  <h2>Introduction</h2>
-  <p>The WebDriver API aims to provide a synchronous API that can be used for a variety of use cases, though
-  it is primarily designed to support automated testing of web apps.</p>
-  <section>
-    <h3>Intended Audience</h3>
-    <p>This specification is intended for implementors of the WebDriver API. It is not intended as light bed
-    time reading.</p>
-  </section>
-  <section>
-    <h3>Relationship of WebDriver API and Existing Specifications</h3>
-    <p>Where possible and appropriate, the WebDriver API references existing specifications. For example, the
-    list of boolean attributes for elements is drawn from the
-    <a href="http://dev.w3.org/html5/spec/Overview.html">HTML specification</a>. When references are made, this
-    specification will link to the relevant sections.</p>
-  </section>
-
-  <section>
-    <h3>Naming the Two Sides of the API</h3>
-
-    <p>The WebDriver API can be thought of as a client/server process. However, implementation details can mean that this terminology becomes confusing. For this reason, the two sides of the API are called the "local" and the "remote" ends.</p>
-    <dl>
-      <dt><dfn id="local-end">Local</dfn></dt>
-      <dd>The user-facing API. <code><a href="#command-1">Command</a></code> objects are sent and <code><a href="#response">Response</a></code> objects are
-      consumed by the local end of the WebDriver API. It can be thought of as
-      being "local" to the user of the API.</dd>
-
-      <dt><dfn id="remote-end">Remote</dfn></dt>
-      <dd>The implementation of the user-facing API. <code><a href="#command-1">Command</a></code> objects are
-      consumed and <code><a href="#response">Response</a></code> objects are sent by the remote end of the WebDriver
-      API. The implementation of the remote end may be on a machine remote from
-      the user of the local end.</dd>
-
-    </dl>
-
-    <p>There is no requirement that the local and remote ends be in different processes. The IDLs given in this specification SHOULD be used as the basis for any conforming local end implementation.</p>
-  </section>
-
-  <section>
-    <h3>Conformance Requirements</h3>
-
-    <p>All diagrams, examples, and notes in this specification are non-normative, as are all sections explicitly marked non-normative. Everything else in this specification is normative.</p>
-
-    <p>The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this document are to be interpreted as described in [[!RFC2119]]. The key word "OPTIONALLY" in the normative parts of this document is to be interpreted with the same normative meaning as "MAY" and "OPTIONAL".</p>
-
-    <p>Conformance requirements phrased as algorithms or specific steps may be implemented in any manner, so long as the end result is equivalent.</p>
-  </section>
-
-  <section>
-    <h3>Conformance Classes</h3>
-
-    <p>This specification defines three broad conformance classes:</p>
-    <dl>
-      <dt><dfn>Local End</dfn>
-      <dd>This represents the client side of the protocol, which is usually in the form of language-specific libraries providing an API on top of the WebDriver protocol. This specification does not place any restrictions on the details of those libraries above the level of the wire protocol. <!-- TODO: define the requirements on the local end somewhere -->
-      <dt><dfn>Remote End</dfn>
-      <dd>This is the server side of the protocol, which is usually implemented by a web browser or similar user agent. Defining the behaviour of the remote end in response to the WebDriver protocol forms the largest part of this specification.
-      <dt><dfn>Intermediary Node</dfn>
-      <dd>Intermediary nodes are those that act as proxies, implementing both the client and server sides of the protocol. Intermediary nodes must be black-box indistinguishable from <a>remote ends</a> from the point of view of <a>local end</a> and so are bound by the requirements on <a>remote ends</a> in terms of the wire protocol. However they are not expected to implement <a>commands</a> directly.
-    </dl>
-  </section>
-
-  <section>
-   <h3>Terminology</h3>
-
-   <p>In equations, all numbers are integers,
-    subtraction is represented by “−”, and bitwise OR by “|”.
-    The characters “(” and “)” are used to provide logical grouping in these contexts.
-  </section>
-
-  <section>
-   <h3>Common Infrastructure</h3>
-
-   <h4>Style Pixel Values</h4>
-
-   <p>When asked to <dfn>normalize style pixel values to integer</dfn>
-    for a value <var>s</var>:
-
-   <ol>
-    <li>Let <var>trimmed string</var> be a substring of <var>s</var>
-     where the suffix "px" is removed.
-
-    <li>Let <var>pixels</var> be the result of parsing
-     <var>trimmed string</var> as an integer.
-
-    <li>If <var>pixels</var> is not a valid integer or the previous
-     operation did not succeed, return 0.
-
-    <li>Return <var>pixels</var>.
-   </ol>
-
-   <p>When asked to <dfn>normalize style pixel values to floating
-    point</dfn> for a value <var>s</var>:
-
-   <ol>
-    <li>Let <var>trimmed string</var> be a substring of <var>s</var>
-     where the suffix "px" is removed.
-
-    <li>Let <var>pixels</var> be the result of parsing
-     <var>trimmed string</var> as a float.
-
-    <li>If <var>pixels</var> is not a valid float
-     or the previous operation did not succeed, return 0.0.
-
-    <li>Round off <var>pixels</var> using <code>ceil</code>
-     so that it has no more than four decimals.
-
-    <li>Return <var>pixels</var>.
-   </ol>
-
-   <p class=note>These operations are almost equivalent to calling
-    <code><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.2>parseInt</a></code>
-    and <code><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.3>parseFloat</a></code>
-    from [[!ECMA-262]] with the exception that non-valid integer
-    or float return values are returned as 0 or 0.0.
-
-    <h4>Top Level Browsing Context no longer open</h4>
-    <p>A top level browsing context is <dfn>no longer open</dfn> if it has been <a href="https://html.spec.whatwg.org/#a-browsing-context-is-discarded">discarded</a>
-  </section>
-</section>
 <section>
   <h2>The WebDriver Protocol</h2>
   <section>
@@ -783,7 +559,7 @@ code a:visited, code a:link {
   </section>
 
 </section>
-<!-- Section removed as it was describing specific local end implementations --><section>
+<section>
 
 <h2>Sessions</h2>
 
@@ -944,23 +720,32 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
 
       <section>
         <h3>Platform Names</h3>
-        <p>The following platform names are defined and MUST be used, case sensitively, for the "platformName" unless the actual platform being used is not given in this list:</p>
+
+        <p>The following platform names are defined and MUST be used,
+         case sensitively, for the <code>platformName</code> capability
+         unless the actual platform being used is not given in this list:
+
         <ul>
-          <li>android</li>
-          <li>ios</li>
-          <li>linux</li>
-          <li>mac</li>
-          <li>unix</li>
-          <li>windows</li>
+          <li>"<code>android</code>"
+          <li>"<code>firefoxos</code>"
+          <li>"<code>ios</code>"
+          <li>"<code>linux</code>"
+          <li>"<code>mac</code>"
+          <li>"<code>unix</code>"
+          <li>"<code>windows</code>"
         </ul>
-        <p>In addition "any" MAY be used to indicate the underlying OS is either unknown or does not matter.</p>
 
-        <p>Implementors MAY add additional platform names. Until these are standardized, these MUST follow the conventions outlined in <a href="#extending-the-protocol">extending the protocol</a> section with the exception that the vendor prefix SHOULD omit the leading "-" character.<p>
+        <p>In addition "<code>any</code>" MAY be used
+         to indicate the underlying OS is either unknown or does not matter.
 
-        <p class="note">For example, Mozilla's Firefox OS could be described as either "-MOZ-FIREFOXOS". The latter makes it easier for local ends to specify an enum of supported platforms and is therefore recommended in this case.</p>
+        <p>Implementors MAY add additional platform names.
+         Until these are standardized, these MUST follow the conventions outlined in
+         <a href=#extending-the-protocol>extending the protocol</a> section.
+
+        <p class=note>For example, Mozilla's Firefox OS
+         could be described as "<code>-moz-firefoxos</code>".
 
         <!-- TODO: Add section on comparing platforms -->
-
       </section>
     </section>
     <section>
@@ -1015,35 +800,71 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
   </section>
 </section>
 <section>
-  <h2>Navigation</h2>
+  <h2>Screenshots</h2>
+  <p>Screenshots are a powerful mechanism for providing information to users of WebDriver, particularly once a particular WebDriver instance has been disposed of. In different circumstances, users want different types of screenshot. Note that the WebDriver spec does not provide a mechanism for taking a screenshot of the entire screen.</p>
+
+  <p>In all cases, screenshots MUST be returned as lossless PNG images encoded using Base64. Local ends MUST provide the user with access to the PNG images without requiring the user to decode the Base64. This access MUST be via at least one of a binary blob or a file.</p>
+
+  <p>All commands within this section are implemented using the "TakesScreenshot" interface:</p>
+
   <section>
-    <h3>Introduction</h3>
-    <p>Almost all usages of the WebDriver API begin by navigating to a particular URL. This section not only describes the commands used for navigation, but also describes when commands must be processed.</p>
+    <h3>takeScreenshot()</h3>
+      <p>
+        <table class="simple jsoncommand">
+          <tr>
+            <th>HTTP Method</th>
+            <th>Path Template</th>
+            <th>Notes</th>
+          </tr>
+          <tr>
+            <td>GET</td>
+            <td id='get-screenshot'>/session/{sessionId}/screenshot</td>
+            <td></td>
+          </tr>
+        </table>
+      <p>
+      Take a screenshot and return a lossless PNG encoded using Base64. If
+      <code>element</code> is not populated or is <code>null</code> then the User Agent MUST return the screenshot of the current state of the document at the top level browsing context.
+      <p>The possible errors for this command:
+      <ul>
+        <li><code><a href="#unknown-error">unknown error</a></code> if the if the screenshot cannot be taken.</li>
+      </ul>
+      <p>Leaving below until <a href='https://www.w3.org/Bugs/Public/show_bug.cgi?id=27920'>Bug 27920</a> has a consensus</p>
+      <dl class='parameters'>
+        <dt>optional WebElement? element</dt>
+        <dd>The <a>WebElement</a> on which to operate. If <code>element</code> is not populated or is <code>null</code>
+          then the User Agent MUST return the screenshot of the current state of the document at the top level browsing context.</dd>
+      </dl>
+    </dd>
   </section>
 
   <section>
-    <h3 id="page-load-strategies">The Page Load Strategy</h3>
+    <h2>Current Top Level Browsing Context</h2>
+    <table class="simple">
+      <tr><th>Capability Name</th><th>Type</th></tr>
+      <tr><td><span id="capability-takesScreenshot">takesScreenshot</span></td><td>boolean</td></tr>
+    </table>
 
-    <p><a>Local ends</a> may choose at what point during the page load cycle the remote end returns a response to navigation commands by requesting a particular <dfn>page load strategy</dfn> when creating a <a>new session</a>. The available page load strategies are:
+    <p>If this capability is supported, local end MUST add the <code>TakesScreenshot</code> interface to the <code>WebDriver</code> interface.</p>
 
-    <dl>
-      <dt><dfn>normal</dfn></dt>
-      <dd><p>The response is sent when the <code>document.readyState</code> of the frame currently handling commands equals <code>complete</code>.</p>
+    <p>This command will take a screenshot of the return the screenshot of the current state of the document at the top level browsing context. Implementations of the remote end SHOULD capture the entire document, even if this would require a user to scroll the browser window. That is, the returned PNG SHOULD have the same width and height as returned by a call to <code>getSize</code> of the BODY element and MUST contain all visible content on the page, and this SHOULD be done without resizing the browser window. If the remote end is unable to capture the entire Document, then the part of the Document currently displayed in UI of the browser MUST be captured without additional chrome such as scrollbars and browser chrome.</p>
 
-      <dt><dfn>eager</dfn></dt>
-      <dd><p>The response is sent when the <code>document.readyState</code> of frame currently handling reaches <code>interactive</code> or <code>complete</code>.</p>
+    <div class="note">
+      <p>One way to think of capturing the entire Document is that the user has an infinitely large monitor and has resized the window to allow all content to be visible. One of those monitors would be very cool.</p>
+    </div>
 
-      <dt><dfn>none</dfn></dd>
-      <dd><p>The response is sent immediately after initiating the navigation.</p>
-    </dl>
+    <p>Nested frames MUST be sized as if the user has resized the window to the dimensions of the PNG being returned. This often means that not all potentially visible content within the nested frames is captured.</p>
 
-    <!-- Todo: most of this should be elsewhere -->
-    <p>All WebDriver implementations MUST support the <a>normal</a> and <a>eager</a> modes and SHOULD support the <a>none</a> mode. If no page loading strategy is chosen, then <a>normal</a> MUST be the default.
-    In addition, implementors MAY add additional page loading strategies.</p>
+    <p>Remote ends MUST NOT attempt to track changes in window size as the screenshot is being taken. In particular this means that in the case of a page that makes use of "infinite scrolling" (where an AJAX call is used to populate additional content as the user scrolls down) or in some other way resizes content as the window size is changed only the content that was originally contained in the Document when the command is executed will be captured.</p>
   </section>
-
   <section>
-    <h3>get</h3>
+    <h2>Element</h2>
+      <table class="simple">
+        <tr><th>Capability Name</th><th>Type</th></tr>
+        <tr><td><span id="capability-takesElementScreenshot">takesElementScreenshot</span></td><td>boolean</td></tr>
+      </table>
+
+  	<p>If this capability is supported, local end MUST add the <code>TakesScreenshot</code> interface to the <code>WebElement</code> interface.</p>
     <table class="simple jsoncommand">
       <tr>
         <th>HTTP Method</th>
@@ -1051,237 +872,38 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
         <th>Notes</th>
       </tr>
       <tr>
-        <td>POST</td>
-        <td id='post-url'>/session/{sessionId}/url</td>
+        <td>GET</td>
+        <td id='get-screenshot'>/session/{sessionId}/screenshot/{ELEMENT}</td>
         <td></td>
       </tr>
     </table>
-    <p>The <dfn>get</dfn> command is used to cause the browser to navigate to a new location. From a user's point of view, it is as if they have entered the "url" into the URL bar.</p>
-
-    <aside class="example">
-        <p>To navigate the current top level browsing context of the session with id <code>1</code> to <code>http://example.com/</code>, the local end would send a <code>POST</code> to <code>/session/1/url</code> with body:</p>
-        <pre class="highlight">
-          {
-              "url": "http://example.com",
-          }
-        </pre>
-    </aside>
-
-    <p>The <a>remote end steps</a> for the <a>get</a> command are:</p>
-    <ol>
-      <li><p>If the <a>current top level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
-      <li><p>Let <var>url</var> be the result of <a>getting a property</a> named "url" from the <var>parameters</var> argument.</p></li>
-      <li><p>If <var>url</var> is undefined, return an <a>error</a> with code <a>invalid argument</a></p></li>
-      <li><p><a href="">Navigate</a> the <a>current top level browsing context</a>'s to <var>url</var>. If this navigation results in a HTTP 401 response, the <a>remote end</a> must proceed with the steps below, irrespective of how the authentication challenge is handled.</p></li>
-      <li><p>If the <a>current session</a>'s <a>page load strategy</a> is <a>none</a> jump to the next step in this overall set of steps. Otherwise:</p>
-        <ol>
-          <li><p>Let <var>readiness target</var> be <code>"interactive"</code> if the <a>current session</a>'s <a>page load strategy is <a>eager</a>, or <code>"complete"</code> if it is <a>normal</a>.</p></li>
-          <li><p>Wait for the <a href="">current document readiness</a> to reach <var>readiness target</var>, or for the <a>current session</a>'s <a>load timeout</a> milliseconds to pass, whichever occurs sooner.</p></li>
-          <li><p>If the previous step completed by the <a>load timeout</a> being reached, and the browser is not currently displaying an alert<!-- perhaps? Not sure if this is what the spec is trying to say -->, return an <a>error</a> with code <a>timeout</a>.</p></li>
-        </ol>
-      <li><p>Return <a>success</a> with data null</p></li>
-    </ol>
-        <!-- TODO: Figure out if next paragraph is actually required -->
-          <!--li>When a page contains a META tag with the "http-equiv" attribute set to "refresh", a response MUST be returned if the timeout is greater than 1 second and the other criteria for determining whether a page is loaded are met. When the refresh period is 1 second or less and the page loading strategy is "normal" or "conservative" implementations MUST wait for the refresh to complete before responding.</li-->
-
-      </section>
-      <!-- getCurrentUrl() -->
-      <section>
-        <h3>getCurrentUrl</h3>
-
-        <table class="simple jsoncommand">
-          <tr>
-            <th>HTTP Method</th>
-            <th>Path Template</th>
-            <th>Notes</th>
-          </tr>
-          <tr>
-            <td>GET</td>
-            <td id='get-url'>/session/{sessionId}/url</td>
-            <td></td>
-          </tr>
-        </table>
-        <p>The <dfn>getCurrentUrl</dfn> command returns the url of the <a>current top level browsing context</a>
-        <p>The <a>remote end steps</a> for the <a>getCurrentUrl</a> command are:</p>
-        <ol>
-          <li><p>If the <a>current top level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
-          <li><p>Let <var>url</var> be the <a href="https://url.spec.whatwg.org/#concept-url-serializer">serialization</a> of the <a>current top level browsing context</a>'s <a href="https://html.spec.whatwg.org/#active-document">active document</a>'s <a href="https://dom.spec.whatwg.org/#concept-document-url">url</a>.</p></li>
-          <li><p>Let <var>data</var> be a <a>new JSON Object</a>.</p>
-          <li><p><a>Set the properties</a> of <var>data</var> with values ("value", <var>url</var>)</p></li>
-          <li><p>Return <a>success</a> with data <var>data</var></p></li>
-      </section>
-      <!-- goBack() -->
-      <section>
-        <h3>goBack()</h3>
-
-        <table class="simple jsoncommand">
-          <tr>
-            <th>HTTP Method</th>
-            <th>Path Template</th>
-            <th>Notes</th>
-          </tr>
-          <tr>
-            <td>POST</td>
-            <td id='post-back'>/session/{sessionId}/back</td>
-            <td></td>
-          </tr>
-        </table>
-        <p>The "goBack" command is equivalent to a user hitting the "back" button in their browser, and MUST behave as a <a href="http://www.w3.org/TR/html/browsers.html#traverse-the-history-by-a-delta">traversal of the browser history by a delta of -1</a> (as defined in [[!html51]]). If a user calls "<code>goBack</code>" when there are no further pages in the browser's history stack, then this call MUST be a no-op.
-        </p>
-        <p> If the page takes too long <a href="#timeouts">as specified by the timeouts</a> a <code><a href="#status-timeout">timeout</a></code> error MUST be raised. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
-      </section>
-      <section>
-        <h3>goForward()</h3>
-
-        <table class="simple jsoncommand">
-          <tr>
-            <th>HTTP Method</th>
-            <th>Path Template</th>
-            <th>Notes</th>
-          </tr>
-          <tr>
-            <td>POST</td>
-            <td id='post-forward'>/session/{sessionId}/forward</td>
-            <td></td>
-          </tr>
-        </table>
-        <p>The "goForward" command is equivalent to a user hitting the "forward" button in their browser, and MUST behave as a <a href="http://www.w3.org/TR/html/browsers.html#traverse-the-history-by-a-delta">traversal of the browser history by a delta of +1</a> (as defined in [[!html51]]). If a user calls "<code>goForward</code>" when there are no further pages in the browser's history stack, then this call MUST be a no-op.
-        <p> If the page takes too long <a href="#timeouts">as specified by the timeouts</a> a <code><a href="#status-timeout">timeout</a></code> error MUST be raised. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
-      </section>
-      <section>
-       <!-- refresh() -->
-        <h3>refresh()</h3>
-
-        <table class="simple jsoncommand">
-          <tr>
-            <th>HTTP Method</th>
-            <th>Path Template</th>
-            <th>Notes</th>
-          </tr>
-          <tr>
-            <td>POST</td>
-            <td id='post-refresh'>/session/{sessionId}/refresh</td>
-            <td></td>
-          </tr>
-        </table>
-        <p>"refresh" emulates the user hitting the "refresh" or "reload" button in their browser, causing the current page to be reloaded.</p>
-        <p> If the page takes too long <a href="#timeouts">as specified by the timeouts</a> a <code><a href="#status-timeout">timeout</a></code> error MUST be raised. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
-      </section>
-      <section>
-        <!-- getTitle() -->
-        <h3>getTitle()</h3>
-
-        <table class="simple jsoncommand">
-          <tr>
-            <th>HTTP Method</th>
-            <th>Path Template</th>
-            <th>Notes</th>
-          </tr>
-          <tr>
-            <td>POST</td>
-            <td id='get-title'>/session/{sessionId}/title</td>
-            <td></td>
-          </tr>
-        </table>
-        <p>
-          The "getTitle" command MUST return the contents of the <code>&lt;title&gt;</code> element like it would for <code>document.title</code>. In the case of a <a href='http://www.w3.org/TR/html5/browsers.html#nested-browsing-context'>Nested Browsing Context</a> WebDriver MUST return the title of the [[html51]] <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsering context</a>.
-
-          <p> If the page takes too long <a href="#timeouts">as specified by the timeouts</a> a <code><a href="#status-timeout">timeout</a></code> error MUST be raised. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
-        </p>
-      </section>
-  </section>
-
-    <section>
-      <h2>Invalid SSL Certificates</h2>
-
-      <table class="simple">
-        <tr><td>Capability Name</td><td>Type</td></tr>
-        <tr><td><span id="capability-securessl">secureSsl</span></td><td>boolean</td></tr>
-      </table>
-
-      <p>WebDriver implementations MUST support users accessing sites served via HTTPS. Access to those sites using self-signed or invalid certificates, and where the certificate does not match the serving domain MUST be the same as if the HTTPS was configured properly.</p>
-
-      <p class="note">The reason for this is that implementations of this spec are often used for testing. It's a sorry fact that many QA engineers and testers are asked to verify that apps work on sites that have insecure HTTPS configurations</p>
-
-
-      <p>The exception to requirement is if the <a>Capabilities</a> used to initialize has the WebDriver session had the capability <code>secureSsl</code> set to true. In this case, implementations MAY choose to make accessing a site with bad HTTPS configurations cause a <code>WebDriverException</code> to be thrown. Remote end implementations MUST return an <code><a href="#status-unknown-error">unknown error</a></code> status in this case. If this is the case, the <a>Capabilities</a> describing the session MUST also set the <code>secureSsl</code> capability to "true".</p>
-    </section>
-    <section>
-      <h3>Detecting When to Handle Commands</h3>
-
-      <p>Commands MUST only be processed when the <span id="page-loading-strategies">page loading strategy</span> being used indicates that page loading is complete.</p>
-
-      <p>Commands SHOULD be handled in a synchronous fashion. Requests should be received and then a response sent when the Command has completed.</p>
-    </section>
+    <p>
+      <ul>
+        <li>Let <var>element</var> be the value from <var><a href="#uri-template-element">element</a></var> from the URI-Template</li>
+        <li>Let <var>screenshot</var> be a be a Base64 encoded, lossless PNG representation of area bounded by the clientBoundingRect of the DOMElement.
+          <ol>
+            <li>If the element is not in the current viewport, the DOMElement must be scrolled into view.</li>
+            <li><If the <code>WebElement</code> represents a FRAME or IFRAME element, this is equivalent of taking a screenshot of the frame's BODY elemen</li>
+          </ol>
+        </li>
+        <li>Return <var>screenshot</var> to the local end.</li>
+      </ul>
   </section>
 </section>
 <section>
-  <h2>Controlling Windows</h2>
+  <h2>Cookies</h2>
 
+  <p>This section describes the interaction with
+  <a href='http://www.w3.org/TR/html5/dom.html#dom-document-cookie'>cookies</a>
+  as described in the HTML Specification ([[!html51]]). When retrieving
+  and setting a cookie it MUST be in the format of a <code>Cookie</code>.</p>
+  <p class="note">Conformance tests for this section can be found in the <a href="https://github.com/w3c/web-platform-tests/tree/master/webdriver/">webdriver module</a> under the "cookies" folder.</p>
   <section>
-    <h2>Definitions</h2>
-
-    <p>Within this specification, a window equates to [[!html51]]'s <a href="http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">top level browsing context</a>. Put another way, within this spec browser tabs are counted as separate windows.</p>
-
-    <p><strong>TODO: define "frame"</strong></p>
-
-    <p>A <dfn id='window-handle'>Window Handow</dfn> is an opaque string that MUST uniquely identify the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> and MUST NOT be "current". This MAY be a UUID.
-  </section>
-
-  <section>
-    <h2>Window Handles</h2>
+    <h2>Cookie</h2>
+    <p>When returning Cookie objects, the server SHOULD include all optional fields it is capable of providing the information for.</p>
     <section>
-      <h3>getWindowHandle()</h3>
-      <p>
-        <table class="simple jsoncommand">
-          <tr>
-            <th>HTTP Method</th>
-            <th>Path Template</th>
-            <th>Notes</th>
-          </tr>
-          <tr>
-            <td>GET</td>
-            <td id='get-window_handle'>/session/{sessionId}/window_handle</td>
-            <td></td>
-          </tr>
-        </table>
-        <p>Each <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> has a <a href='#window-handle'>window handle</a>. The "getWindowHandle" command can be used to obtain the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> handle for the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> that commands are currently acting upon.</p>
-
-    </section>
-  </section>
-
-  <section>
-    <h2 name="iterating-over-windows">Iterating Over <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a></h2>
-    <section>
-      <h3>getWindowHandles()</h3>
-
-      <p>
-        <table class="simple jsoncommand">
-          <tr>
-            <th>HTTP Method</th>
-            <th>Path Template</th>
-            <th>Notes</th>
-          </tr>
-          <tr>
-            <td>GET</td>
-            <td id='get-window_handles'>/session/{sessionId}/window_handles</td>
-            <td></td>
-          </tr>
-        </table>
-        <p>This array of returned strings MUST contain a handle for every <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> associated with the browser session and no others. For each returned <a href='#window-handle'>window handle</a> the javascript expression "window.top.closed" (or equivalent) MUST evaluate to false at the time the command is being executed.</p>
-
-    <p>The ordering of the sequence is not defined, but MAY be determined by iterating over each OS Window and returning the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> items within that OS window before iterating over the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing contexts</a> of the next OS window. For example, in the diagram below, the <a href='#window-handle'>window handle</a> should be returned as the handles for: win1tab1, win1tab2, win2.</p>
-
-    <img src="example-windows.png" alt="Two top level windows. The first window has two tabs, lablled win1tab1 and win1tab2. The second window has only one tab labelled win2"/>
-
-    <p class="note">This implies that the correct way to determine whether or not a particular interaction with the browser opens a new window is done by obtaining the set of <a href='#window-handle'>window handle</a> before the interaction is performed and comparing with the set after the action is performed.</p>
-    </section>
-  </section>
-
-  <section>
-    <h2>Closing Windows</h2>
-    <section>
-      <h3>close()</h3>
+      <!-- getCookie() -->
+      <h3>getCookie</h3>
         <p>
           <table class="simple jsoncommand">
             <tr>
@@ -1289,61 +911,6 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
               <th>Path Template</th>
               <th>Notes</th>
             </tr>
-            <tr>
-              <td>DELETE</td>
-              <td id='delete-window_handle'>/session/{sessionId}/window_handle</td>
-              <td></td>
-            </tr>
-          </table>
-
-        <p>The close command closes the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> that Commands are currently being sent to. If this means that a call to get the list of <a href='#window-handle'>window handle</a>s would return an empty list, then this close command MUST  <a href='removing-a-session'>remove the session</a>.</p>
-
-        <p>Once the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> has closed, future commands MUST return a status code of <code><a href="#status-no-such-window">no such window</a></code> until a new <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> is selected for receiving commands.</p>
-
-    </section>
-  </section>
-
-  <section>
-    <h2>Resizing and Positioning Windows</h2>
-    <p>All commands MUST be handled by the OS window that ultimately owns the current context.</p>
-    <dl class='idl' title='dictionary WindowSize'>
-      <dt>double height</dt>
-      <dd>The height of the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a></dd>.
-      <dt>double width</dt>
-      <dd>The width of the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a></dd>.
-    </dl>
-    <section>
-      <!-- setWindowSize() -->
-      <h3>setWindowSize()</h3>
-        <p>
-          <table class="simple jsoncommand">
-            <tr>
-              <th>HTTP Method</th>
-              <th>Path Template</th>
-              <th>Notes</th>
-            </tr>
-            <tr>
-              <td>POST</td>
-              <td id='post-window_handle-size'>/session/{sessionId}/window/size</td>
-              <td></td>
-            </tr>
-          </table>
-        <p>
-        Resizes the OS window currently receiving commands to have the <code>height</code> and <code>width</code> passed in as parameters.
-        <p>If a request is made to resize a OS window to a size which cannot be performed (e.g. the browser has a minimum, or fixed OS window size, or the operating system does not support resizing windows at all as is the case in many phone OSs), an <code><a href="#status-unsupported-operation">unsupported operation</a></code> status code MUST be returned.</p>
-        <p>After <code>setWindowSize</code>, the browser window MUST NOT be in the maximised state.</p>
-        <dl class='parameters'>
-          <dt>unsigned double width</dt>
-          <dd>The "width" value refer to the javascript <code>window.outerwidth</code> property. If the User Agent does not support this property, it represents the width of the whole OS window including window chrome and window resizing borders/handles.</li></dd>
-          <dt>unsigned double height</dt>
-          <dd>The "height" value refer to the javascript <code>window.outerheight</code> property. If the User Agent does not support this property, it represents the width of the whole OS window including window chrome and window resizing borders/handles.</li></dd>
-
-      </section>
-      <section>
-      <!-- getWindowSize() -->
-      <h3>getWindowSize()</h3>
-        <p>
-          <table class="simple jsoncommand">
             <tr>
               <th>HTTP Method</th>
               <th>Path Template</th>
@@ -1351,127 +918,111 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
             </tr>
             <tr>
               <td>GET</td>
-              <td id='get-window_handle-size'>/session/{sessionId}/window/size</td>
+              <td id='GET-cookie-name'>/session/{sessionId}/cookie/{name}</td>
               <td></td>
             </tr>
           </table>
-        <p>
-          A command named "getWindowSize()":
-        <ol>
-          <li>Create a <a>WindowSize</a> dictionary containing the <code><a href='#widl-WindowSize-height'>height</a></code> and <code><a href='#widl-WindowSize-width'>width</a></code> keys.
-          <li>Populate <code><a href='#widl-WindowSize-width'>width</a></code> with the value of <code>window.outerwidth</code> property of the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a>. If the User Agent does not support this property, it represents the width of the whole OS window including window chrome and window resizing borders/handles.</li>
-          <li>Populate <code><a href='#widl-WindowSize-height'>height</a></code> with the value of <code>window.outerheight</code> property of the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a>. If the User Agent does not support this property, it represents the width of the whole OS window including window chrome and window resizing borders/handles.</li>
-          <li>Return <a>WindowSize</a></li>
-        </ol>
-      </section>
-
-      <section>
-      <!-- maximizeWindow() -->
-      <h3>maximizeWindow()</h3>
-        <p>
-          <table class="simple jsoncommand">
-            <tr>
-              <th>HTTP Method</th>
-              <th>Path Template</th>
-              <th>Notes</th>
-            </tr>
-            <tr>
-              <td>POST</td>
-              <td id='get-window_handle-maximize'>/session/{sessionId}/window/maximize</td>
-              <td></td>
-            </tr>
-          </table>
-        <p>After  <code>maximizeWindow</code>, the OS window currently receving commands MUST be left as if the maximise button had been pressed if, and only if, the window manager of the OS supports this concept; it is not sufficient to leave the window "restored", but with the full screen dimensions.</p>
-        <p>If a request is made to resize a window to a size which cannot be performed (e.g. the browser has a minimum, or fixed window size, or the operating system does not support resizing windows at all as is the case in many phone OSs), an <code><a href="#status-unsupported-operation">unsupported operation</a></code> status code MUST be returned.</p>
-      </section>
-      <section>
-      <!-- fullscreenWindow -->
-      <h3>fullscreenWindow()</h3>
-        <p>After <code>fullscreenWindow</code>, the OS window currently receiving commands MUST be in full-screen mode. For those operating systems that support the concept, this MUST be equivalent to if the user requested the OS window be full screen.</p>
-
-        <p>If the User Agent or OS does not support switching to full-screen mode, an <code><a href="#status-unsupported-operation">unsupported operation</a></code> status code MUST be returned.</p>
-    </section>
-  </section>
-</section>
-<section>
-  <h2>Context of Commands</h2>
-
-  <p>Web applications can be composed of multiple <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> and/or frames. For a normal user, the context in which an operation is performed is obvious: it's the window or frame that currently has OS focus and which has just received user input. The WebDriver API does not follow this convention. There is an expectation that many browsers using the WebDriver API may be used at the same time on the same machine. This section describes how WebDriver tracks which window or frame is currently the context in which commands are being executed.</p>
-
-  <section>
-    <h2>Default Content</h2>
-
-    <p>WebDriver's <dfn id="default-content">default content</dfn> is [[!html51]]'s <a href="http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">top level browsing context</a> that is currently receiving WebDriver commands.</p>
-
-    <p>When a WebDriver instance is started and a single OS window is opened, the <a href="#default-content">default content</a> of that OS window is automatically selected for receiving further commands. If more than one OS window or multiple <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing contexts</a> are opened when the session starts, then the user MUST first select which <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> to act upon using the <code>switchToWindow</code> command. Until the user selects a <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a>, all commands must return a status code of <code><a href="#status-no-such-window">no such window</a></code>.</p>
-
-  </section>
-
-  <section>
-    <h2>Switching Windows</h2>
-
-    <section>
-      <h3>switchToWindow()</h3>
-        <dl class='parameters'>
-          <dt>DOMString handle</dt>
-          <dd>The identifier used for a <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a></dd>
-        </dl>
-        <p>
-          <table class="simple jsoncommand">
-            <tr>
-              <th>HTTP Method</th>
-              <th>Path Template</th>
-              <th>Notes</th>
-            </tr>
-            <tr>
-              <td>POST</td>
-              <td id='post-window'>/session/{sessionId}/window</td>
-              <td></td>
-            </tr>
-          </table>
+          <p>The <a>remote end steps</a> for the <dfn>Get Cookie</dfn> command are:</p>
+          <ol>
+            <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
+            <li><p>Let <var>name</var> be equal to "name" from <a>match a request</a>.</p></li>
+            <li><p>Let <var>result</var> be an empty JSON list.</p></li>
+            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://html.spec.whatwg.org/#active-document">active document</a> <a href="https://dom.spec.whatwg.org/#concept-document-url">address</a>.</p></li>
+            <li><p>Let <var>length</var> be the length of <var>cookies</var>.</p></li>
+            <li><p>Let <var>k</var> be 0</p></li>
+            <li><p>While <var>k</var> &lt; <var>length</var>:</p>
+              <ol>
+                <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
+                <li><p>If <var>name</var> is undefined:</p>
+                  <ol>
+                    <li><p>Append a <a>serialized cookie</a> to <var>result</var>.</p></li>
+                  </ol>
+                </li>
+                <li><p>If <var>name</var> is defined and is equal to <var>cookie-name</var>:</p>
+                  <ol>
+                    <li><p>Append a <a>serialized cookie</a> to <var>result</var>.</p></li>
+                  </ol>
+                </li>
+                <li><p>Increase the value of <var>k</var> by 1.</p></li>
+              </ol>
+            </li>
+            <li><p>Return <a>success</a> with data <var>result.</var></p></li>
+          </ol>
+          <p>A <dfn>serialized cookie</dfn> is created with the following algorithm:</p>
           <p>
-        <p>The "switchToWindow" command is used to select which <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> MUST be used as the context for processing commands. In order to determine which <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> should be used for accepting commands, the "switchToWindow" command MUST iterate over all <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> comparing the window handle.
-
-        <p>If no <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing contexts</a> match, then a "<code><a href="#status-no-such-window">no such window</a></code>" status code MUST be returned, otherwise the "<a href="#default-content">default content</a>" of the first match will be selected for accepting commands.</p>
-
-    </section>
-  </section>
-
-  <section>
-    <h2>Switching Frames</h2>
-    <section>
-      <h3>switchToFrame()</h3>
-        <table class="simple jsoncommand">
-          <tr>
-            <th>HTTP Method</th>
-            <th>Path Template</th>
-            <th>Notes</th>
-          </tr>
-          <tr>
-            <td>POST</td>
-            <td id='post-frame'>/session/{sessionId}/frame</td>
-            <td></td>
-          </tr>
-        </table>
-        <dl class='parameters'>
-          <dt><a>WebElement</a> or unsigned short? id</dt>
-          <dd>The identifier used for a frame.</dd>
-        </dl>
-        <p>The "switchToFrame" command is used to select which frame which is a child of the<a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> MUST be used as the context for handling future commands. All frame switching is taken from the current context from which commands are currently being handled. The "<code>id</code>" parameter can be an unsigned short or a <a>WebElement</a>. WebDriver implementations MUST determine which frame to select using the following algorithm:
-
-        <ol>
-          <li>If the "id" is a unsigned short the current context is set to the equivalent of the JS expression "window.frames[id]" where "id" is the number and "window" is the Document window represented by the current context.</li>
-          <li>If the "id" is null, the current context is set to the <a href='#default-content'>default content</a>.</li>
-          <li>If the "id" represents a <a>WebElement</a>, and the corresponding <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> represents a FRAME or an IFRAME, and the <a>WebElement</a> is part of the current context, the "window" property of that <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> becomes the current context.</li>
-        </ol>
-
-        <p>In all cases if no match is made a "<code><a href="#status-no-such-frame">no such frame</a></code>" status code MUST be returned.</p>
-
-        <p>If the indicated frame exists, frame switching MUST succeed even if doing so would violate the normal security constraints in place within the Javascript sandbox.</p>
+            <ol>
+              <li><p>Let <var>serialized cookie</var> be an empty map.</p></li>
+              <ul>
+                <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var>  as defined in [[!RFC6265]]</p></li>
+                <li><p>Add an entry whose key is <var>value</var> and value is <var>cookie-value</var> as defined in [[!RFC6265]]</p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Path,
+                  let <var>path</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                   with an attribute-name of "Path". Otherwise let <var>path</var> be null</p>
+                  <p>Add an entry to <var>serialized cookie</var> with key "path" and value <var>path</var></p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Domain,
+                  let <var>domain</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                  with an attribute-name of "Domain". Otherwise let <var>domain</var> be null</p>
+                  <p>Add an entry to <var>serialized cookie</var> with key "domain" and value <var>domain</var></p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Secure,
+                  let <var>secure</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                  with an attribute-name of "Secure". Otherwise let <var>secure</var> be null</p>
+                  <p>Add an entry to <var>serialized cookie</var> with key "secure" and value <var>secure</var></p></li>
+                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires,
+                  let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list
+                   with an attribute-name of "Expires" specified in milliseconds since midnight, January 1, 1970 UTC
+                    using the format described in [[!RFC1123]]. Otherwise let <var>expiry</var> be null</p>
+              </ul>
+              <li>Return <var>serialized cookie</var></li>
+            </ol>
+          </p>
       </section>
       <section>
-      <h3>switchToParentFrame()</h3>
-
+      <h3>addCookie</h3>
+        <p>
+          <table class="simple jsoncommand">
+            <tr>
+              <th>HTTP Method</th>
+              <th>Path Template</th>
+              <th>Notes</th>
+            </tr>
+            <tr>
+              <td>POST</td>
+              <td id='post-cookie'>/session/{sessionId}/cookie</td>
+              <td></td>
+            </tr>
+          </table>
+          <p>The <a>remote end steps</a> for the <dfn>Add Cookie</dfn> command are:</p>
+          <ol>
+            <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
+                return an error with code <a>no such window</a>.</p></li>
+            <li><p>Let <var>cookie</var> be the result of <a>getting a property</a>
+              named "cookie" from the <var>parameters</var> argument. If <var>cookie</var>
+              is not a map then return an error <a>unable to set cookie</a>.</p></li>
+            <li><p>If the <code>Document</code> is a <a href='http://www.w3.org/html/wg/drafts/html/master/single-page.html#cookie-averse-document-object'>
+              cookie-averse <code>Document</code> object</a> then return an error with code
+              <a>invalid cookie domain</a>.</p></li>
+            <li><p>Set the value is <var>cookie-name</var>, as defined in [[!RFC6265]], to the value of entry with key <var>name</var>.
+              If <var>name</var>is undefined return error <a>unable to set cookie</a></p></li>
+            <li><p>Set the value is <var>cookie-value</var>, as defined in [[!RFC6265]], to the value of entry with key <var>value</var>.
+                If <var>value</var>is undefined return error <a>unable to set cookie</a></p></li>
+            <li><p>If <var>cookie</var> has an entry with key <var>path</var> set attribute-value of the last attribute in the cookie-attribute-list
+             with an attribute-name of "Path".</p></li>
+            <li><p>If <var>cookie</var> has an entry with key <var>domain</var> set attribute-value of the last attribute in the cookie-attribute-list
+              with an attribute-name of "Domain".</p></li>
+            <li><p>If <var>cookie</var> has an entry with key <var>secure</var> set attribute-value of the last attribute in the cookie-attribute-list
+                with an attribute-name of "Secure".</p></li>
+            <li><p>If <var>cookie</var> has an entry with key <var>expiry</var> set attribute-value of the last attribute in the cookie-attribute-list
+                  with an attribute-name of "Expires".</p></li>
+            <li><p>Store the contents <var>cookie</var> in the user agent cookie manager
+              following the steps described in <a href='http://tools.ietf.org/html/rfc6265#section-5.3'>Storage Model</a>
+              in [[!RFC6265]]. If there is an error during this step return an error
+              with code <a>unable to set cookie</a>.</p></li>
+            <li><p>Return <a>success</a> with data null</p></li>
+          </ol>
+    </section>
+    <section>
+      <h3>deleteCookie</h3>
+      <p>
         <table class="simple jsoncommand">
           <tr>
             <th>HTTP Method</th>
@@ -1479,28 +1030,37 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
             <th>Notes</th>
           </tr>
           <tr>
-            <td>POST</td>
-            <td id='post-frame-parent'>/session/{sessionId}/frame/parent</td>
+            <td>DELETE</td>
+            <td id='delete-cookie'>/session/{sessionId}/cookie/{name}</td>
             <td></td>
           </tr>
         </table>
-        <p>The "switchToParentFrame" command MUST set the context of future commands to the <code>window.parent</code>. If the current context is the [[!html51]]'s <a href="http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">top level browsing context</a>, the context remains unchanged.</p>
-      </section>
+      </p>
+      <p>The <a>remote end steps</a> for the <dfn>Delete Cookie</dfn> command are:</p>
+      <ol>
+        <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
+        <li><p>Let <var>name</var> be equal to "name" from <a>match a request</a>.</p></li>
+        <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://html.spec.whatwg.org/#active-document">active document</a> <a href="https://dom.spec.whatwg.org/#concept-document-url">address</a>.</p></li>
+        <li><p>Let <var>length</var> be the length of <var>cookies</var>.</p></li>
+        <li><p>Let <var>k</var> be 0</p></li>
+        <li><p>While <var>k</var> &lt; <var>length</var>:</p>
+          <ol>
+            <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
+            <li><p>If <var>name</var> is undefined:</p>
+              <ol>
+                <li><p>Add an attribute to the attribute-list with attribute-name of Expires
+                  and set the value in the past.</p></li>
+              </ol>
+            <li><p>If <var>name</var> is defined and is equal to <var>cookie-name</var>:</p>
+              <ol>
+                <li><p>Add an attribute to the attribute-list with attribute-name of Expires
+                  and set the value in the past.</p></li>
+              </ol>
+          </ol>
+        <li><p>Return <a>success</a> with data null</p></li>
+      </ol>
     </section>
   </section>
-</section>
-<section>
-  <!-- TODO(simon): identify a better location for this -->
-  <h2>Running Without Window Focus</h2>
-  <p>All browsers must comply with the <a
-    href="http://www.w3.org/TR/html5/editing.html#focus">focus</a> section of
-  the [[!html51]] spec. In particular, the requirement that the active element within a top-level browsing
-  context be independent of whether or not the top-level browsing context itself
-  has system focus MUST be followed.</p>
-
-  <p class="note">This requirement is put in place to allow efficient machine
-  utilization when using the WebDriver API to control several browsers
-  independently on the same desktop</p>
 </section>
 <section>
   <h2>Elements</h2>
@@ -1990,754 +1550,6 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
     meet the other criteria for being interactable.
     If any part of the <code>BODY</code> can be brought into the current viewport,
     the return value MUST be true.
-  </section>
-</section>
-<section>
-  <h2>Element State</h2>
-    <section>
-      <h2>Reading current element state from the document</h2>
-      <p class="note">Conformance tests for this section can be found in the <a href="https://github.com/w3c/web-platform-tests/tree/master/webdriver/">webdriver module</a> under the "element_state" folder.</p>
-
-          <p>When we are returning an <a>ElementRect</a> to the local end it will need to be serialised</p>
-          <dl class='idl' title='dictionary ElementRect'>
-            <dt>double x</dt>
-            <dd>The x coordinate for the top left of the element</dd>
-            <dt>double y</dt>
-            <dd>The y coordinate for the top left of the element</dd>
-            <dt>double height</dt>
-            <dd>Height of the element in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a></dd>
-            <dt>double width</dt>
-            <dd>Width of the element in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a></dd>
-          </dl>
-    <section>
-      <!-- isDisplayed() -->
-      <h3>isDisplayed()</h3>
-
-      <table class="simple jsoncommand">
-        <tr>
-          <th>HTTP Method</th>
-          <th>Path Template</th>
-          <th>Notes</th>
-        </tr>
-        <tr>
-          <td>GET</td>
-          <td id='get-id-displayed'>/session/{sessionId}/element/{element}/displayed</td>
-          <td></td>
-        </tr>
-      </table>
-
-      <p>The command is used to determine the
-       <a rel="element displayed">element displayedness</a> of
-       the <a href=http://w3c.github.io/dom/#element>Document element</a>
-       connected with the <a>web element</a> reference given by
-       the <code>element</code> fragment in the path.
-
-      <p>The response is composed using the following algorithm:
-
-      <ol>
-       <li>Let <var>response</var> be an initially empty
-        <a>response</a>.
-
-       <li>Let <var>visible</var> be a boolean initially set to
-        false.
-
-       <li>Let <var>element</var> be an initially undefined
-        <a href="http://w3c.github.io/dom/#element">Document element</a>.
-
-       <li>Let <var>element reference</var> be a string with the
-        value of the <code>element</code> fragment from the path.
-
-       <li>If <var>element reference</var> is null or has a
-        length equal to 0, set <var>response</var>'s
-        <a href=#response-status>status</a> to
-        the <a>invalid argument</a> status and return <var>response</var>.
-
-       <li>If the <a>default content</a>'s <a
-        href=http.//www.w3.org/TR/html5/browser.html#top-level-browsing-context>top
-        level browsing context</a> is no longer open, set
-        <var>response</var>'s <a href=#response-status>status</a>
-        to the <a>no such window</a> status</a> and return
-        <var>response</var>.
-
-       <li>Set <var>element</var> be the <a
-        href=http://w3c.github.io/dom/#element>Document element</a>
-        found after applying the <a>web element lookup</a> algorithm
-        to the <a>element reference map</a>.
- 
-       <li>If <var>element</var> is null
-        or <var>element</var> does not represent a
-        <a href=http://w3c.github.io/dom/#element>Document element</a>,
-        set <var>response</var>'s <a href=#response-status>status</a>
-        to the <a>no such element</a> status
-        and return <var>response</var>.
-
-       <li>If <var>element</var> represents
-        <a href=http://w3c.github.io/dom/#element>Document element</a>
-        that is no longer attached to the document's node tree,
-        set <var>response</var>'s <a href=#response-status>status</a>
-        to the <a>stale element reference</a> status and return
-        <var>response</var>.
-
-       <li>Apply the <a>element displayed</a> algorithm to
-        <var>element</var> and set <var>visible</var> to its
-        return value.</li>
-
-       <li>Set <var>response</var>'s
-        <a href=#response-status>status</a> to <a>success</a>
-        and its <a href="#response-value">value</a> to <var>visible</var>.
-
-       <li>Return <var>response</var>.
-      </ol>
-    </section>
-
-      <section>
-        <!-- isSelected -->
-        <h3>isSelected()</h3>
-        <p>
-          <table class="simple jsoncommand">
-            <tr>
-              <th>HTTP Method</th>
-              <th>Path Template</th>
-              <th>Notes</th>
-            </tr>
-            <tr>
-              <td>GET</td>
-              <td id='get-id-selected'>/session/{sessionId}/element/{ELEMENT}/selected</td>
-              <td></td>
-            </tr>
-          </table>
-
-          <p>The remote end MUST determine whether a <code>WebElement</code> is selected using the following algorithm:
-          <ol>
-            <li id="is_selectable">If the item is not "<code title='selectable'>selectable</code>", the WebElement is not selected. A <dfn id="selectable" title="selectable">selectable</dfn> element is either an OPTION element or an INPUT element of type "<a href="http://www.w3.org/TR/html5/forms.html#checkbox-state-(type=checkbox)">checkbox</a>" or "<a href="http://www.w3.org/TR/html5/forms.html#radio-button-state-(type=radio)">radio</a>".</li>
-            <li>If the Document node represented by the WebElement is an OPTION element, the "<a href="http://www.w3.org/TR/html5/forms.html#concept-option-selectedness">selectedness</a>" of the element, as defined in [[!html51]] determines whether the element is selected.</li>
-            <li>Otherwise, the value of the Document node's "<a href="http://www.w3.org/TR/html5/forms.html#attr-input-checked">checked</a>" property determines whether the element is selected. This MUST reflect the element's "<a href="http://www.w3.org/TR/html5/forms.html#concept-fe-checked">checkedness</a>" as defined in [[!html51]].</li>
-          </ol>
-          <p>If <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
-      </section>
-      <section>
-        <!-- getElementAttribute() -->
-        <h3>getElementAttribute()</h3>
-        <p>
-          <table class="simple jsoncommand">
-            <tr>
-              <th>HTTP Method</th>
-              <th>Path Template</th>
-              <th>Notes</th>
-            </tr>
-            <tr>
-              <td>GET</td>
-              <td id='get-id-attribute'>/session/{sessionId}/element/{ELEMENT}/attribute/{name}</td>
-              <td></td>
-            </tr>
-          </table>
-          <div class="note">
-          <p>Although the [[!html51]] spec is very clear about the difference between the properties and attributes of a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, users are frequently confused between the two. Because of thisend point which covers the case of returning either of the value of a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> property or attribute. If a user wishes to refer specifically to an attribute or a property, they should evaluate Javascript in order to be unambiguous.</p>
-
-          <p>The end result of this algorithm are values that can be passed to other commands within this specification. Notably, this means that URLs that are returned can be passed to <a href="#widl-WebDriver-get-void-DOMString-url">get</a> and the expected URL will be navigated to.</p>
-          </div>
-
-          <p>To determine the <var>value</var> of the response, the following steps must be taken where <var>name</var> is the <code>name</code> property on the <code>parameters</code> dictionary in Command, and <var>element</var> is the <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> modeled by the <code>ELEMENT</code> parameter.:
-          <ol>
-            <li>Initially set <var>result</var> to null.
-            <li>Handle special-cases:
-              <ol>
-                <li>If "<var>name</var>" case insensitively matches "<code>style</code>", then store the value of the computed value of the <code>style</code> property of <var>element</var>, <a href="http://dev.w3.org/csswg/cssom/#serialize-a-css-rule">serialized as defined</a> in the [[!CSSOM-VIEW]] spec, as <var>result</var>. Notably, CSS property names must be cased as specified in in section 6.5.1 of the [[!CSSOM-VIEW]] spec. In addition, color property values must be standardized to <a href='http://www.w3.org/TR/css3-color/#rgba-color'>RGBA color format</a> as described in [[!css3-color]]. If a user agent does not support RGBA then it MUST return a value as 1 for opacity.</li>
-
-                <li>If "<var>name</var>" case insensitively matches "selected" or "checked", and the element is <a href="#is_selectable">selectable</a>:
-                  <ol>
-                    <li>If the element supports neither a <a href="http://www.w3.org/TR/html51/forms.html#concept-option-selectedness">selectedness</a> or <a href="http://www.w3.org/TR/html51/forms.html#concept-fe-checked">checkedness</a> check, then store null as <var>result</var>.</li>
-                    <li>For an <code>option</code> element, store the element's <a href="http://www.w3.org/TR/html51/forms.html#concept-option-selectedness">selectedness</a> as <var>result</var>.</li>
-                    <li>In all other cases, store the element's <a href="http://www.w3.org/TR/html51/forms.html#concept-fe-checked">checkedness</a> as <var>result</var>.</li>
-                  </ol>
-                </li>
-                <li>If any of the above steps have been executed, go to the <a href="#attribute-result-coercion">result coercion</a> step of this algorithm.
-              </ol>
-            </li>
-
-            <li>Obtain the property indexed by "<var>name</var>" from the element and store this as <var>result</var>. If <var>name</var> case insensitively matches "class" set <var>result</var> to be <var>element</var>'s <code>className</code> property. Similarly, if <var>name</var> case insensitively matches "readonly", set <var>result</var> to be the <var>element</var>'s <code>readOnly</code> property.</li>
-
-            <li>If <var>result</var> is null or undefined, or if it is an object, set the value of <var>result</var> to be the <code>value</code> of the Attr node obtained by calling <code>getAttributeNode</code> on <var>element</var> iff that Attr is <code>specified</code>. That is, <var>result</var> is the equivalent of executing the following Ecmascript: <code>var attr = element.getAttributeNode(name); var result = (attr &amp;&amp; attr.specified) ? attr.value : null;</code></li>
-
-            <li name="attribute-result-coercion">Coerce the return value to a DOMString:
-              <ol>
-                <li>If <var>result</var> is a boolean value, use the value "true" if <var>result</var> is true, or null otherwise.</li>
-                <li>if <var>result</var> is null or undefined, set <var>result</var> to be null.</li>
-                <li>In all other cases, coerce <var>result</var> to a DOMString.</li>
-              </ol>
-            </li>
-          </ol>
-          <dl class='parameters'>
-            <dt>DOMString name</dt>
-            <dd>The name of the property or attribute to return.</dd>
-          </dl>
-          <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
-      </section>
-      <section>
-        <!-- getCssValue() -->
-        <h3>getCssValue()</h3>
-        <p>
-          <table class="simple jsoncommand">
-            <tr>
-              <th>HTTP Method</th>
-              <th>Path Template</th>
-              <th>Notes</th>
-            </tr>
-            <tr>
-              <td>GET</td>
-              <td id='get-id-css-property'>/session/{sessionId}/element/{ELEMENT}/css/{propertyName}</td>
-              <td></td>
-            </tr>
-          </table>
-          <p>The "getCssValue" command will return a <code>DOMString</code> of the value of the property passed. It MUST return the value of <a href="http://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertyvalue"><code>getPropertyValue(propertyName)</code></a> returned from calling <a href='http://dev.w3.org/csswg/cssom/#dom-window-getcomputedstyle'><code>window.getComputedStyle(element)</code></a>. Color property values MUST be standardized to <a href='http://www.w3.org/TR/css3-color/#rgba-color'>RGBA color format</a> as described in [[!css3-color]]. If a user agent does not support RGBA then it MUST return a value as 1 for opacity. If the property is not present then return an empty string.
-          <dl class='parameters'>
-            <dt>DOMString propertyName</dt>
-            <dd>The name of the property whose value will be returned</dd>
-          </dl>
-          <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
-      </section>
-      <section>
-        <!-- getElementText() -->
-        <h3>getElementText()</h3>
-          <p>
-            <table class="simple jsoncommand">
-              <tr>
-                <th>HTTP Method</th>
-                <th>Path Template</th>
-                <th>Notes</th>
-              </tr>
-              <tr>
-                <td>GET</td>
-                <td id='get-id-text'>/session/{sessionId}/element/{ELEMENT}/text</td>
-                <td></td>
-              </tr>
-            </table>
-            <p>The following definitions are used in this section:
-          <dl>
-              <dt id="text.whitespace">Whitespace</dt>
-              <dd>Any text that matches the ECMAScript regular expression class <code>\s</code>.
-
-              <dt id="text.whitespace-nbsp">Whitespace excluding non-breaking spaces</dt>
-              <dd>Any text that matches the ECMAScript regular expression <code>[^\S\xa0]</code>
-
-              <dt id="text.blocklevel">Block level element</dt>
-              <dd>A block-level element is one which is not a table cell, and whose effective CSS display style is not in the set ['inline', 'inline-block', 'inline-table', 'none', 'table-cell', 'table-column', 'table-column-group']</dd>
-
-              <dt id="text.horizontal">Horizontal whitespace characters</dt>
-              <dd>Horizontal whitespace characters are defined by the ECMAScript regular expression <code>[\x20\t\u2028\u2029]</code>.</dd>
-             </dl>
-
-         <p>The expected return value is roughly what a text-only browser would display. The algorithm for determining this text is as follows:</p>
-
-         <p>Let <code>lines</code> equal an empty array. Then:
-         <ol>
-            <li>if the element is in the <code>head</code> element of the document, return an empty string otherwise carry on with the algorithm below.</li>
-             <li><span id="text.1">For</span> each descendent of node, at time of execution, in order:
-                 <ol>
-                     <li>Get whitespace, text-transform, and then, if descendent is:
-                         <ul>
-                             <li>a node which is not <a href="#determining-if-displayed">displayed</a>, do nothing</li>
-                             <li>a [[!DOM4]] <a href="http://www.w3.org/TR/2012/WD-dom-20120105/#interface-text">text node</a> let <code>text</code> equal the <code>nodeValue</code> property of descendent. Then:
-                                 <ol>
-                                     <li>Remove any zero-width spaces (\u200b, \u200e, \u200f), form feeds (\f) or vertical tab feeds (\v) from <code>text</code>.</li>
-                                     <li>Canonicalize any recognized single newline sequence in <code>text</code> to a single newline (greedily matching <code>(\r\n|\r|\n)</code> to a single \n)</li>
-                                     <li>If the parent's effective CSS whitespace style is 'normal' or 'nowrap' replace each newline (\n) in <code>text</code> with a single space character (\x20). If the parent's effective CSS whitespace style is 'pre' or 'pre-wrap' replace each <a href="#text.horizontal">horizontal whitespace character</a> with a non-breaking space character (\xa0). Otherwise replace each sequence of <a href="#text.horizontal">horizontal whitespace characters</a> except non-breaking spaces (\xa0) with a single space character</li>
-                                     <li>Apply the parent's effective CSS text-transform style as per the <a href="http://www.w3.org/TR/CSS21/text.html#propdef-text-transform">CSS 2.1 specification</a> ([[!CSS21]])</li>
-                                     <li>If <code>last(lines)</code> ends with a space character and <code>text</code> starts with a space character, trim the first character of <code>text</code>.</li>
-                                     <li>Append <code>text</code> to <code>last(lines)</code> in-place</li>
-                                 </ol>
-                             </li>
-                             <li>an element which is <a href="#determining-if-displayed">displayed</a>. If the element is a:
-                                 <ul>
-                                     <li>BR element: Push '' to <code>lines</code> and continue</li>
-                                     <li><a href="#text.blocklevel">Block-level</a> element and if <code>last(lines)</code> is not '', push '' to <code>lines</code>.</li>
-                                 </ul>
-                             And then recurse depth-first to <a href="#text.1">step 1</a> at the beginning of the algorithm with descendent set to the current element</li>
-                             <li>If element is a TD element, or the effective CSS display style is 'table-cell', and last(lines) is not '', and <code>last(lines)</code> does not end with whitespace append a single space character to <code>last(lines)</code> [Note: Most innerText implementations append a \t here]</li>
-                             <li>If element is a block-level element: push '' to <code>lines</code></li>
-                         </ul>
-                     </li>
-                 </ol>
-             </li>
-             <li>The string MUST then have the white space normalised as defined in the [[!XPATH]] <a href="http://www.w3.org/TR/xpath/#function-normalize-space">normalize-space function</a> which is then returned.</li>
-         </ol>
-         <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
-       </section>
-       <section>
-        <!-- getElementTagName() -->
-        <h3>getElementTagName()</h3>
-        <p>
-           <table class="simple jsoncommand">
-             <tr>
-               <th>HTTP Method</th>
-               <th>Path Template</th>
-               <th>Notes</th>
-             </tr>
-             <tr>
-               <td>GET</td>
-               <td id='get-id-displayed'>/session/{sessionId}/element/{ELEMENT}/name</td>
-               <td></td>
-             </tr>
-           </table>
-           <p>The "getElementTagName" command will return a <code>DOMString</code>
-            that is the <a href='http://www.w3.org/TR/DOM-Level-3-Core/glossary.html#dt-qualifiedname'>
-            qualified name</a> of the element.
-          <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
-       </section>
-       <section>
-        <h3>ElementRect getElementRect()</h3>
-        <p>
-         <table class="simple jsoncommand">
-           <tr>
-             <th>HTTP Method</th>
-             <th>Path Template</th>
-             <th>Notes</th>
-           </tr>
-           <tr>
-             <td>GET</td>
-             <td id='get-id-rect'>/session/{sessionId}/element/{ELEMENT}/rect</td>
-             <td></td>
-           </tr>
-         </table>
-
-        <p>The "getElementRect" command MUST return the <a>ElementRect</a> with:
-          <ul>
-            <li><code><a href='#widl-ElementRect-x'>x</a></code> and <code><a href='#widl-ElementRect-y'>y</a></code> represent the top left coordinates of the <a>WebElement</a> relative to top left corner of the document.
-            <li><code><a href='#widl-ElementRect-height'>height</a></code> and the <code><a href='#widl-ElementRect-width'>width</a></code> will contain the height and the width of the
-        <a href='http://dev.w3.org/fxtf/geometry/#dom-domrect'>DOMRect</a>
-        of the <a>WebElement</a>.
-          </ul>
-         <p>The point (0, 0) refers to the top left corner of the document.
-          <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
-      </section>
-      <section>
-        <h3>isEnabled()</h3>
-        <p>
-           <table class="simple jsoncommand">
-             <tr>
-               <th>HTTP Method</th>
-               <th>Path Template</th>
-               <th>Notes</th>
-             </tr>
-             <tr>
-               <td>GET</td>
-               <td id='get-id-enabled'>/session/{sessionId}/element/{ELEMENT}/enabled</td>
-               <td></td>
-             </tr>
-           </table>
-        <p>The "isEnabled" command MUST return false if all the following criteria are met otherwise return true:
-          <ul>
-            <li>A form control is <a href='http://www.w3.org/html/wg/drafts/html/master/forms.html#concept-fe-disabled'>disabled</a>
-            as described in [[!html51]].</li>
-            <li>A <a>WebElement</a> has a <code>disabled</code> <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#boolean-attribute">boolean attribute</a> as described in <a href='http://www.w3.org/html/wg/drafts/html/master/disabled-elements.html#disabled-elements'>disabled elements</a> of [[!html51]]</li>
-          </ul>
-
-        <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
-      </section>
-    </section>
-  </section>
-</section>
-<section>
-  <h2>Executing Javascript</h2>
-  <div class="note">
-    <p>Open questions: What happens if a user's JS triggers a modal dialog?
-      Blocking seems like a reasonable idea, but there is an assumption that
-      WebDriver is not threadsafe.
-
-      What happens to unhandled JS errors? Caused by a user's JS? Caused by JS
-      on a page? How does a user of the API obtain the list of errors? Is that
-      list cleared upon read?
-    </div>
-    <p class="note">Conformance tests for this section can be found in the <a href="https://github.com/w3c/web-platform-tests/tree/master/webdriver/">webdriver module</a> under the "ecmascript" folder.</p>
-
-    <section>
-      <h2>Javascript Command Parameters</h2>
-
-      <p>When calling <a href="#sync-js-execution">Synchronous JavaScript Execution</a> or calling <a href="async-js-execution">Asynchronous JavaScript Execution</a> we need to extract
-        the following from <var><a href="#post-payload">payload body</a></var> into <dfn>JavaScript Command Parameters</dfn>:</p>
-
-        <ul>
-          <li>let <var>script</var> be the JavaScript to execute, in the form of a Function body.</li>
-          <li>let <var>args</var> be an array that are used as the parameters to the function defined by <var>script</var>.
-            The <var>args</var> can contain the numbers, booleans, a WebElement, objects or arrays</li>
-        </ul>
-    </section>
-
-    <p>When executing Javascript, it MUST be possible to reference the <code>args</code> parameter using the function's <code>arguments</code> object. The arguments MUST be in the same order as defined in <code>args</code>. Each WebDriver implementation MUST preprocess the values in <code>args</code> using the following algorithm:
-
-      <p id="JS-args-preprocess">For each index, <code>index</code> in <code>args</code>, if <code>args[index]</code> is...
-        <ol>
-          <li>a long, boolean, DOMString, or <code>null</code>, then let <code>args[index] = args[index]</code>.</li>
-          <li>a sequence, then recursively apply this algorithm to <code>args[index]</code> and assign the result to <code>args[index]</code>.</li>
-          <li>an object, then recursively apply this algorithm to each value in <code>args[index]</code> and assign the result to <code>args[index]</code>.</li>
-          <li>a <a href="#elements">WebElement</a>, then:
-            <ol>
-              <li>If <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's tree, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error.</li>
-              <li>Otherwise, let <code>args[index]</code> be the underlying <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>.</li>
-            </ol>
-          </li>
-          <li>Otherwise WebDriver implementations MAY throw an <code><a href="#status-unknown-error">unknown error</a></code> indicating the index of the unhandled parameter but SHOULD attempt to convert the value into a <code>object</code>.</li>
-        </ol>
-        <section>
-          <h2 id="sync-js-execution">Synchronous Javascript Execution</h2>
-          <section>
-            <!-- executeScript() -->
-            <h3>executeScript()</h3>
-            <dd>
-              <dl class='parameters'>
-                <dt> DOMString script</dt>
-                <dd>The script to execute.</dd>
-                <dt>sequence&lt;Argument>? args</dt>
-                <dd>The script arguments.</dd>
-              </dl>
-              <p>
-                <table class="simple jsoncommand">
-                  <tr>
-                    <th>HTTP Method</th>
-                    <th>Path Template</th>
-                    <th>Notes</th>
-                  </tr>
-                  <tr>
-                    <td>POST</td>
-                    <td id='post-execute_script'>/session/{sessionId}/execute</td>
-                    <td></td>
-                  </tr>
-                </table>
-                <p>
-              <p>When executing JavaScript, the WebDriver implementations MUST use the following algorithm:
-                <ol>
-                  <li>Let <code>window</code> be the <a href="http://www.w3.org/TR/Window/">Window</a> object for WebDriver's current <a href="#where-commands-are-handled">command context</a>.
-                  <li>Let <code>script</code> be the DOMString from the command's <code>script</code> parameter.
-                  <li>Let <code>fn</code> be the Function object created by executing <code>new Function(script);</code>
-                  <li>Let <code>args</code> be the sequence created by the pre-processing algorithm defined <a href="#JS-args-preprocess">above</a>.
-                  <li>Invoke <code>fn.apply(window, args);</code>
-                  <li>If the previous step errors then:
-                  <ol>
-                    <li>Let <code>error</code> be the thrown value.
-                    <li>Set the response <a href="href=#response-status">status</a> to <code><a href="#status-javascript-error">javascript error</a></code>.
-                    <li>Set the response <a href="#response-value">value</a> to a <code>object</code>, <code>dict</code>.
-                    <li>If <code>error</code> is an Error, then set a "message" entry in <code>dict</code> whose value is the DOMString defined by <code>error.message</code>.
-                    <li>Otherwise, set a "message" entry in <code>dict</code> whose value is the DOMString representation of <code>error</code>.
-                  </ol>
-                  <li>Otherwise:
-                  <ol>
-                    <li>Let <code>result</code> be the value returned by the function in step #5.
-                    <li>Set the command's response <a href='#response-status'>status</a> to <code><a href="#status-success">success</a></code>.
-                    <li>Let <code>value</code> be the result of the following algorithm:
-                  <ol>
-                    <li>If <code>result</code> is:
-                    <ol>
-                      <li><code>undefined</code> or <code>null</code>, return <code> null</code>.
-                      <li>a long, boolean, or DOMString, return <code>result</code>.
-                      <li>a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, then return the corresponding WebElement for that <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>.
-                      <!-- Should there be a recursion limit? -->
-                      <li>a <code>Sequence &lt;Node&gt; nodes</code>, then return the result of recursively applying this algorithm to <code>result</code>.
-                      <!-- Should there be a limit? -->
-                      <li>an object, then return the <code>object</code> created by recursively applying this algorithm to each property in <code>result</code>.
-                    </ol>
-                  </ol>
-                  <li>Set the response <a href="#response-value">value</a> to <code>value</code>.</li>
-                </ol>
-                <li>Return the response.</li>
-              </ol>
-            </section>
-        </section>
-        <section>
-          <h2>Asynchronous Javascript Execution</h2>
-          <section>
-            <h3 id="async-js-execution">executeAsyncScript()</h3>
-
-              <dl class='parameters'>
-                <dt> DOMString script</dt>
-                <dd>The script to execute.</dd>
-                <dt>sequence&lt;Argument>? args</dt>
-                <dd>The script arguments.</dd>
-              </dl>
-              <p>
-                <table class="simple jsoncommand">
-                  <tr>
-                    <th>HTTP Method</th>
-                    <th>Path Template</th>
-                    <th>Notes</th>
-                  </tr>
-                  <tr>
-                    <td>POST</td>
-                    <td id='post-execute_async'>/session/{sessionId}/execute_async</td>
-                    <td></td>
-                  </tr>
-                </table>
-                <p>
-              <p>When executing asynchronous JavaScript, the WebDriver implementation MUST use the following algorithm:
-                <ol>
-                  <li>Let <code>timeout</code> be the value of the last "script" <a href="#timeouts">timeout command</a>, or 0 if no such commands have been received.</li>
-                  <li>Let <code>window</code> be the <a href="http://www.w3.org/TR/Window/">Window</a> object for WebDriver's current <a href="#where-commands-are-handled">command context</a>.</li>
-                  <li>Let <code>script</code> be the DOMString from the command's <code>script</code> parameter.</li>
-                  <li>Let <code>fn</code> be the Function object created by executing <code>new Function(script);</code></li>
-                  <li>Let <code>args</code> be the sequence created by the pre-processing algorithm defined <a href="#JS-args-preprocess">above</a>.</li>
-                  <li>Let <code>callback</code> be a Function object pushed to the end of <code>args</code>.</li>
-                  <li>Register a one-shot timer on <code>window</code> set to fire <code>timeout</code> milliseconds in the future.</li>
-                  <li>Invoke <code>fn.apply(window, args);</code></li>
-                  <li>If the previous step errors then:
-                    <ol>
-                      <li>Let <code>error</code> be the thrown value.</li>
-                      <li>Set the response <a href='#response-status'>status</a> to <code><a href="#status-javascript-error">javascript error</a></code>.</li>
-                      <li>Set the response <a href="#response-value">value</a> to a <code>object</code>, <code>dict</code>.</li>
-                      <li>If <code>error</code> is an Error, then set a "message" entry in <code>dict</code> whose value is the DOMString defined by <code>error.message</code>.</li>
-                      <li>Otherwise, set a "message" entry in <code>dict</code> whose value is the DOMString representation of <code>error</code>.</li>
-                    </ol>
-                  </li>
-                  <li>Otherwise, the WebDriver implementation MUST wait for one of the following to occur:
-                    <ol>
-                      <li>if the one-shot timer that was set on the <code>window</code> fires
-                        , the WebDriver implementation MUST immediately set the response <a href='#response-status'>status</a>
-                        to <code><a href='#status-timeout'>timeout</a></code> and return.</li>
-                        <li>if the <code>window</code> fires an <code>unload</code> event, the WebDriver implementation MUST immediately set the response <a href='#response-status'>status</a> to JavascriptError and return with the error message set to "Javascript execution context no longer exists.".</li>
-                        <li>if the <code>callback</code> function is invoked, then:
-                          <ol>
-                            <li>Let <code>result</code> be the first argument passed to <code>callback</code>.</li>
-                            <li>Set the command's response <a href='#response-status'>status</a> to Success.</li>
-                            <li>Let <code>value</code> be the result of the following algorithm:
-                              <ol>
-                                <li>If <code>result</code> is:
-                                  <ol>
-                                    <li><code>undefined</code> or <code>null</code>, return <code> null</code>.</li>
-                                    <li>a long, boolean, or DOMString, return <code>result</code>.</li>
-                                    <li>a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, then return the corresponding WebElement for that <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>.</li>
-                                    <!-- Should there be a recursion limit? -->
-                                    <li>a <code>Sequence &lt;Node> Nodes</code>, then return the result by recursively applying this algorithm to <code>result</code>. WebDriver implementations SHOULD limit the recursion depth.</li>
-                                    <!-- Should there be a limit? -->
-                                    <li>an object, then return the <code>object</code> created by recursively applying this algorithm to each property in <code>result</code>.</li>
-                                  </ol>
-                                </li>
-                              </ol>
-                            </li>
-                            <li>Set the command's response <a href="#response-value">value</a> to <code>value</code>.</li>
-                          </ol>
-                        </li>
-                        <li>Return the response.</li>
-                      </ol>
-                    </li>
-                  </ol>
-                </section>
-        </section>
-        <section>
-          <h2>Reporting Errors</h2>
-          <p></p>
-        </section>
-</section>
-<section>
-  <h2>Cookies</h2>
-
-  <p>This section describes the interaction with
-  <a href='http://www.w3.org/TR/html5/dom.html#dom-document-cookie'>cookies</a>
-  as described in the HTML Specification ([[!html51]]). When retrieving
-  and setting a cookie it MUST be in the format of a <code>Cookie</code>.</p>
-  <p class="note">Conformance tests for this section can be found in the <a href="https://github.com/w3c/web-platform-tests/tree/master/webdriver/">webdriver module</a> under the "cookies" folder.</p>
-  <section>
-    <h2>Cookie</h2>
-    <p>When returning Cookie objects, the server SHOULD include all optional fields it is capable of providing the information for.</p>
-    <section>
-      <!-- getCookie() -->
-      <h3>getCookie</h3>
-        <p>
-          <table class="simple jsoncommand">
-            <tr>
-              <th>HTTP Method</th>
-              <th>Path Template</th>
-              <th>Notes</th>
-            </tr>
-            <tr>
-              <th>HTTP Method</th>
-              <th>Path Template</th>
-              <th>Notes</th>
-            </tr>
-            <tr>
-              <td>GET</td>
-              <td id='GET-cookie-name'>/session/{sessionId}/cookie/{name}</td>
-              <td></td>
-            </tr>
-          </table>
-          <p>The <a>remote end steps</a> for the <dfn>Get Cookie</dfn> command are:</p>
-          <ol>
-            <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
-            <li><p>Let <var>name</var> be equal to "name" from <a>match a request</a>.</p></li>
-            <li><p>Let <var>result</var> be an empty JSON list.</p></li>
-            <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://html.spec.whatwg.org/#active-document">active document</a> <a href="https://dom.spec.whatwg.org/#concept-document-url">address</a>.</p></li>
-            <li><p>Let <var>length</var> be the length of <var>cookies</var>.</p></li>
-            <li><p>Let <var>k</var> be 0</p></li>
-            <li><p>While <var>k</var> &lt; <var>length</var>:</p>
-              <ol>
-                <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
-                <li><p>If <var>name</var> is undefined:</p>
-                  <ol>
-                    <li><p>Append a <a>serialized cookie</a> to <var>result</var>.</p></li>
-                  </ol>
-                </li>
-                <li><p>If <var>name</var> is defined and is equal to <var>cookie-name</var>:</p>
-                  <ol>
-                    <li><p>Append a <a>serialized cookie</a> to <var>result</var>.</p></li>
-                  </ol>
-                </li>
-                <li><p>Increase the value of <var>k</var> by 1.</p></li>
-              </ol>
-            </li>
-            <li><p>Return <a>success</a> with data <var>result.</var></p></li>
-          </ol>
-          <p>A <dfn>serialized cookie</dfn> is created with the following algorithm:</p>
-          <p>
-            <ol>
-              <li><p>Let <var>serialized cookie</var> be an empty map.</p></li>
-              <ul>
-                <li><p>Add an entry whose key is <var>name</var> and value is <var>cookie-name</var>  as defined in [[!RFC6265]]</p></li>
-                <li><p>Add an entry whose key is <var>value</var> and value is <var>cookie-value</var> as defined in [[!RFC6265]]</p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Path,
-                  let <var>path</var> be the attribute-value of the last attribute in the cookie-attribute-list
-                   with an attribute-name of "Path". Otherwise let <var>path</var> be null</p>
-                  <p>Add an entry to <var>serialized cookie</var> with key "path" and value <var>path</var></p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Domain,
-                  let <var>domain</var> be the attribute-value of the last attribute in the cookie-attribute-list
-                  with an attribute-name of "Domain". Otherwise let <var>domain</var> be null</p>
-                  <p>Add an entry to <var>serialized cookie</var> with key "domain" and value <var>domain</var></p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Secure,
-                  let <var>secure</var> be the attribute-value of the last attribute in the cookie-attribute-list
-                  with an attribute-name of "Secure". Otherwise let <var>secure</var> be null</p>
-                  <p>Add an entry to <var>serialized cookie</var> with key "secure" and value <var>secure</var></p></li>
-                <li><p>If cookie's attribute-list contains an attribute with attribute-name of Expires,
-                  let <var>expiry</var> be the attribute-value of the last attribute in the cookie-attribute-list
-                   with an attribute-name of "Expires" specified in milliseconds since midnight, January 1, 1970 UTC
-                    using the format described in [[!RFC1123]]. Otherwise let <var>expiry</var> be null</p>
-              </ul>
-              <li>Return <var>serialized cookie</var></li>
-            </ol>
-          </p>
-      </section>
-      <section>
-      <h3>addCookie</h3>
-        <p>
-          <table class="simple jsoncommand">
-            <tr>
-              <th>HTTP Method</th>
-              <th>Path Template</th>
-              <th>Notes</th>
-            </tr>
-            <tr>
-              <td>POST</td>
-              <td id='post-cookie'>/session/{sessionId}/cookie</td>
-              <td></td>
-            </tr>
-          </table>
-          <p>The <a>remote end steps</a> for the <dfn>Add Cookie</dfn> command are:</p>
-          <ol>
-            <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
-                return an error with code <a>no such window</a>.</p></li>
-            <li><p>Let <var>cookie</var> be the result of <a>getting a property</a>
-              named "cookie" from the <var>parameters</var> argument. If <var>cookie</var>
-              is not a map then return an error <a>unable to set cookie</a>.</p></li>
-            <li><p>If the <code>Document</code> is a <a href='http://www.w3.org/html/wg/drafts/html/master/single-page.html#cookie-averse-document-object'>
-              cookie-averse <code>Document</code> object</a> then return an error with code
-              <a>invalid cookie domain</a>.</p></li>
-            <li><p>Set the value is <var>cookie-name</var>, as defined in [[!RFC6265]], to the value of entry with key <var>name</var>.
-              If <var>name</var>is undefined return error <a>unable to set cookie</a></p></li>
-            <li><p>Set the value is <var>cookie-value</var>, as defined in [[!RFC6265]], to the value of entry with key <var>value</var>.
-                If <var>value</var>is undefined return error <a>unable to set cookie</a></p></li>
-            <li><p>If <var>cookie</var> has an entry with key <var>path</var> set attribute-value of the last attribute in the cookie-attribute-list
-             with an attribute-name of "Path".</p></li>
-            <li><p>If <var>cookie</var> has an entry with key <var>domain</var> set attribute-value of the last attribute in the cookie-attribute-list
-              with an attribute-name of "Domain".</p></li>
-            <li><p>If <var>cookie</var> has an entry with key <var>secure</var> set attribute-value of the last attribute in the cookie-attribute-list
-                with an attribute-name of "Secure".</p></li>
-            <li><p>If <var>cookie</var> has an entry with key <var>expiry</var> set attribute-value of the last attribute in the cookie-attribute-list
-                  with an attribute-name of "Expires".</p></li>
-            <li><p>Store the contents <var>cookie</var> in the user agent cookie manager
-              following the steps described in <a href='http://tools.ietf.org/html/rfc6265#section-5.3'>Storage Model</a>
-              in [[!RFC6265]]. If there is an error during this step return an error
-              with code <a>unable to set cookie</a>.</p></li>
-            <li><p>Return <a>success</a> with data null</p></li>
-          </ol>
-    </section>
-    <section>
-      <h3>deleteCookie</h3>
-      <p>
-        <table class="simple jsoncommand">
-          <tr>
-            <th>HTTP Method</th>
-            <th>Path Template</th>
-            <th>Notes</th>
-          </tr>
-          <tr>
-            <td>DELETE</td>
-            <td id='delete-cookie'>/session/{sessionId}/cookie/{name}</td>
-            <td></td>
-          </tr>
-        </table>
-      </p>
-      <p>The <a>remote end steps</a> for the <dfn>Delete Cookie</dfn> command are:</p>
-      <ol>
-        <li><p>If the <a>current browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
-        <li><p>Let <var>name</var> be equal to "name" from <a>match a request</a>.</p></li>
-        <li><p>Let <var>cookies</var> be a list of all cookies [[!RFC6265]] in the cookie store associated with <a href="https://html.spec.whatwg.org/#active-document">active document</a> <a href="https://dom.spec.whatwg.org/#concept-document-url">address</a>.</p></li>
-        <li><p>Let <var>length</var> be the length of <var>cookies</var>.</p></li>
-        <li><p>Let <var>k</var> be 0</p></li>
-        <li><p>While <var>k</var> &lt; <var>length</var>:</p>
-          <ol>
-            <li><p>Let <var>cookie</var> be the value in <var>cookies</var> at index <var>k</var>.</p></li>
-            <li><p>If <var>name</var> is undefined:</p>
-              <ol>
-                <li><p>Add an attribute to the attribute-list with attribute-name of Expires
-                  and set the value in the past.</p></li>
-              </ol>
-            <li><p>If <var>name</var> is defined and is equal to <var>cookie-name</var>:</p>
-              <ol>
-                <li><p>Add an attribute to the attribute-list with attribute-name of Expires
-                  and set the value in the past.</p></li>
-              </ol>
-          </ol>
-        <li><p>Return <a>success</a> with data null</p></li>
-      </ol>
-    </section>
-  </section>
-</section>
-<section>
-  <h2 id="timeouts">Timeouts</h2>
-  <p>This section describes how timeouts and implicit waits are handled within WebDriver</p>
-  <section>
-    <h2>Setting Timeouts</h2>
-    <p>The "timeouts" command is used to set the value of a timeout that a command can execute
-     for.</p>
-      <section>
-       <h3>setTimeouts()</h3>
-        <p>
-          <table class="simple jsoncommand">
-            <tr>
-              <th>HTTP Method</th>
-              <th>Path Template</th>
-              <th>Notes</th>
-            </tr>
-            <tr>
-              <td>POST</td>
-              <td id='post-timeouts'>/session/{sessionId}/timeouts</td>
-              <td></td>
-            </tr>
-          </table>
-        <p>
-        <ul>
-          <li>implicit - Set the amount of time the driver should wait when searching for elements. When searching for a single element, the driver should poll the page until an element is found or the timeout expires, whichever occurs first. When searching for multiple elements, the driver should poll the page until at least one element is found or the timeout expires, at which point it should return an empty list.<br>
-          If this command is never sent, the driver MUST default to an implicit wait of 0ms.</li>
-          <li>page load - Set the amount of time the driver should wait before returning when the <a href="#page-load-strategies-1">page load stratgey</a> is not "<code>none</code>". If this limit is exceeded, the <code>get()</code> command MUST return a "<code><a href="#status-timeout">timeout</a></code>" response status.</li>
-          <li>script - Set the amount of time the driver should wait after calling <a href='#widl-JavaScriptExecutor-executeAsyncScript-Argument-DOMString-script-sequence-Argument--args'><code>executeAsyncScript</code></a> for the callback to have executed before returning a <code><a href="#status-timeout">timeout</a></code> Response.</li>
-        </ul>
-        The parameters will have the following keys in the object:
-        <ul>
-          <li>Let <var>type</var> contain the type of timeout for specified operations. Valid values are: "implicit", "page load", "script". If invalid values are passed in:
-            <ul>
-              <li>Set the HTTP Response status code to 500</li>
-              <li>Let <var>status</var> be equal to <a href='#status-invalid-selector'>Invalid Selector</a></li>
-              <li>Let <var>value</var> to a stating that the strategy is invalid. It may return a list of valid search strategies.</li>
-            </ul>
-          </li>
-          <li>let <var>ms</var> contain the amount of time, in milliseconds, that time-limited commands are permitted to run.</li>
-        </ul>
-    </section>
   </section>
 </section>
 <section>
@@ -3500,6 +2312,571 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
     </section> <!-- high-level APIs -->
 </section>
 <section>
+  <h2>Navigation</h2>
+  <section>
+    <h3>Introduction</h3>
+    <p>Almost all usages of the WebDriver API begin by navigating to a particular URL. This section not only describes the commands used for navigation, but also describes when commands must be processed.</p>
+  </section>
+
+  <section>
+    <h3 id="page-load-strategies">The Page Load Strategy</h3>
+
+    <p><a>Local ends</a> may choose at what point during the page load cycle the remote end returns a response to navigation commands by requesting a particular <dfn>page load strategy</dfn> when creating a <a>new session</a>. The available page load strategies are:
+
+    <dl>
+      <dt><dfn>normal</dfn></dt>
+      <dd><p>The response is sent when the <code>document.readyState</code> of the frame currently handling commands equals <code>complete</code>.</p>
+
+      <dt><dfn>eager</dfn></dt>
+      <dd><p>The response is sent when the <code>document.readyState</code> of frame currently handling reaches <code>interactive</code> or <code>complete</code>.</p>
+
+      <dt><dfn>none</dfn></dd>
+      <dd><p>The response is sent immediately after initiating the navigation.</p>
+    </dl>
+
+    <!-- Todo: most of this should be elsewhere -->
+    <p>All WebDriver implementations MUST support the <a>normal</a> and <a>eager</a> modes and SHOULD support the <a>none</a> mode. If no page loading strategy is chosen, then <a>normal</a> MUST be the default.
+    In addition, implementors MAY add additional page loading strategies.</p>
+  </section>
+
+  <section>
+    <h3>get</h3>
+    <table class="simple jsoncommand">
+      <tr>
+        <th>HTTP Method</th>
+        <th>Path Template</th>
+        <th>Notes</th>
+      </tr>
+      <tr>
+        <td>POST</td>
+        <td id='post-url'>/session/{sessionId}/url</td>
+        <td></td>
+      </tr>
+    </table>
+    <p>The <dfn>get</dfn> command is used to cause the browser to navigate to a new location. From a user's point of view, it is as if they have entered the "url" into the URL bar.</p>
+
+    <aside class="example">
+        <p>To navigate the current top level browsing context of the session with id <code>1</code> to <code>http://example.com/</code>, the local end would send a <code>POST</code> to <code>/session/1/url</code> with body:</p>
+        <pre class="highlight">
+          {
+              "url": "http://example.com",
+          }
+        </pre>
+    </aside>
+
+    <p>The <a>remote end steps</a> for the <a>get</a> command are:</p>
+    <ol>
+      <li><p>If the <a>current top level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
+      <li><p>Let <var>url</var> be the result of <a>getting a property</a> named "url" from the <var>parameters</var> argument.</p></li>
+      <li><p>If <var>url</var> is undefined, return an <a>error</a> with code <a>invalid argument</a></p></li>
+      <li><p><a href="">Navigate</a> the <a>current top level browsing context</a>'s to <var>url</var>. If this navigation results in a HTTP 401 response, the <a>remote end</a> must proceed with the steps below, irrespective of how the authentication challenge is handled.</p></li>
+      <li><p>If the <a>current session</a>'s <a>page load strategy</a> is <a>none</a> jump to the next step in this overall set of steps. Otherwise:</p>
+        <ol>
+          <li><p>Let <var>readiness target</var> be <code>"interactive"</code> if the <a>current session</a>'s <a>page load strategy is <a>eager</a>, or <code>"complete"</code> if it is <a>normal</a>.</p></li>
+          <li><p>Wait for the <a href="">current document readiness</a> to reach <var>readiness target</var>, or for the <a>current session</a>'s <a>load timeout</a> milliseconds to pass, whichever occurs sooner.</p></li>
+          <li><p>If the previous step completed by the <a>load timeout</a> being reached, and the browser is not currently displaying an alert<!-- perhaps? Not sure if this is what the spec is trying to say -->, return an <a>error</a> with code <a>timeout</a>.</p></li>
+        </ol>
+      <li><p>Return <a>success</a> with data null</p></li>
+    </ol>
+        <!-- TODO: Figure out if next paragraph is actually required -->
+          <!--li>When a page contains a META tag with the "http-equiv" attribute set to "refresh", a response MUST be returned if the timeout is greater than 1 second and the other criteria for determining whether a page is loaded are met. When the refresh period is 1 second or less and the page loading strategy is "normal" or "conservative" implementations MUST wait for the refresh to complete before responding.</li-->
+
+      </section>
+      <!-- getCurrentUrl() -->
+      <section>
+        <h3>getCurrentUrl</h3>
+
+        <table class="simple jsoncommand">
+          <tr>
+            <th>HTTP Method</th>
+            <th>Path Template</th>
+            <th>Notes</th>
+          </tr>
+          <tr>
+            <td>GET</td>
+            <td id='get-url'>/session/{sessionId}/url</td>
+            <td></td>
+          </tr>
+        </table>
+        <p>The <dfn>getCurrentUrl</dfn> command returns the url of the <a>current top level browsing context</a>
+        <p>The <a>remote end steps</a> for the <a>getCurrentUrl</a> command are:</p>
+        <ol>
+          <li><p>If the <a>current top level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
+          <li><p>Let <var>url</var> be the <a href="https://url.spec.whatwg.org/#concept-url-serializer">serialization</a> of the <a>current top level browsing context</a>'s <a href="https://html.spec.whatwg.org/#active-document">active document</a>'s <a href="https://dom.spec.whatwg.org/#concept-document-url">url</a>.</p></li>
+          <li><p>Let <var>data</var> be a <a>new JSON Object</a>.</p>
+          <li><p><a>Set the properties</a> of <var>data</var> with values ("value", <var>url</var>)</p></li>
+          <li><p>Return <a>success</a> with data <var>data</var></p></li>
+      </section>
+      <!-- goBack() -->
+      <section>
+        <h3>goBack()</h3>
+
+        <table class="simple jsoncommand">
+          <tr>
+            <th>HTTP Method</th>
+            <th>Path Template</th>
+            <th>Notes</th>
+          </tr>
+          <tr>
+            <td>POST</td>
+            <td id='post-back'>/session/{sessionId}/back</td>
+            <td></td>
+          </tr>
+        </table>
+        <p>The "goBack" command is equivalent to a user hitting the "back" button in their browser, and MUST behave as a <a href="http://www.w3.org/TR/html/browsers.html#traverse-the-history-by-a-delta">traversal of the browser history by a delta of -1</a> (as defined in [[!html51]]). If a user calls "<code>goBack</code>" when there are no further pages in the browser's history stack, then this call MUST be a no-op.
+        </p>
+        <p> If the page takes too long <a href="#timeouts">as specified by the timeouts</a> a <code><a href="#status-timeout">timeout</a></code> error MUST be raised. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
+      </section>
+      <section>
+        <h3>goForward()</h3>
+
+        <table class="simple jsoncommand">
+          <tr>
+            <th>HTTP Method</th>
+            <th>Path Template</th>
+            <th>Notes</th>
+          </tr>
+          <tr>
+            <td>POST</td>
+            <td id='post-forward'>/session/{sessionId}/forward</td>
+            <td></td>
+          </tr>
+        </table>
+        <p>The "goForward" command is equivalent to a user hitting the "forward" button in their browser, and MUST behave as a <a href="http://www.w3.org/TR/html/browsers.html#traverse-the-history-by-a-delta">traversal of the browser history by a delta of +1</a> (as defined in [[!html51]]). If a user calls "<code>goForward</code>" when there are no further pages in the browser's history stack, then this call MUST be a no-op.
+        <p> If the page takes too long <a href="#timeouts">as specified by the timeouts</a> a <code><a href="#status-timeout">timeout</a></code> error MUST be raised. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
+      </section>
+      <section>
+       <!-- refresh() -->
+        <h3>refresh()</h3>
+
+        <table class="simple jsoncommand">
+          <tr>
+            <th>HTTP Method</th>
+            <th>Path Template</th>
+            <th>Notes</th>
+          </tr>
+          <tr>
+            <td>POST</td>
+            <td id='post-refresh'>/session/{sessionId}/refresh</td>
+            <td></td>
+          </tr>
+        </table>
+        <p>"refresh" emulates the user hitting the "refresh" or "reload" button in their browser, causing the current page to be reloaded.</p>
+        <p> If the page takes too long <a href="#timeouts">as specified by the timeouts</a> a <code><a href="#status-timeout">timeout</a></code> error MUST be raised. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
+      </section>
+      <section>
+        <!-- getTitle() -->
+        <h3>getTitle()</h3>
+
+        <table class="simple jsoncommand">
+          <tr>
+            <th>HTTP Method</th>
+            <th>Path Template</th>
+            <th>Notes</th>
+          </tr>
+          <tr>
+            <td>POST</td>
+            <td id='get-title'>/session/{sessionId}/title</td>
+            <td></td>
+          </tr>
+        </table>
+        <p>
+          The "getTitle" command MUST return the contents of the <code>&lt;title&gt;</code> element like it would for <code>document.title</code>. In the case of a <a href='http://www.w3.org/TR/html5/browsers.html#nested-browsing-context'>Nested Browsing Context</a> WebDriver MUST return the title of the [[html51]] <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsering context</a>.
+
+          <p> If the page takes too long <a href="#timeouts">as specified by the timeouts</a> a <code><a href="#status-timeout">timeout</a></code> error MUST be raised. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
+        </p>
+      </section>
+  </section>
+
+    <section>
+      <h2>Invalid SSL Certificates</h2>
+
+      <table class="simple">
+        <tr><td>Capability Name</td><td>Type</td></tr>
+        <tr><td><span id="capability-securessl">secureSsl</span></td><td>boolean</td></tr>
+      </table>
+
+      <p>WebDriver implementations MUST support users accessing sites served via HTTPS. Access to those sites using self-signed or invalid certificates, and where the certificate does not match the serving domain MUST be the same as if the HTTPS was configured properly.</p>
+
+      <p class="note">The reason for this is that implementations of this spec are often used for testing. It's a sorry fact that many QA engineers and testers are asked to verify that apps work on sites that have insecure HTTPS configurations</p>
+
+
+      <p>The exception to requirement is if the <a>Capabilities</a> used to initialize has the WebDriver session had the capability <code>secureSsl</code> set to true. In this case, implementations MAY choose to make accessing a site with bad HTTPS configurations cause a <code>WebDriverException</code> to be thrown. Remote end implementations MUST return an <code><a href="#status-unknown-error">unknown error</a></code> status in this case. If this is the case, the <a>Capabilities</a> describing the session MUST also set the <code>secureSsl</code> capability to "true".</p>
+    </section>
+    <section>
+      <h3>Detecting When to Handle Commands</h3>
+
+      <p>Commands MUST only be processed when the <span id="page-loading-strategies">page loading strategy</span> being used indicates that page loading is complete.</p>
+
+      <p>Commands SHOULD be handled in a synchronous fashion. Requests should be received and then a response sent when the Command has completed.</p>
+    </section>
+  </section>
+</section>
+<section>
+  <!-- TODO(simon): identify a better location for this -->
+  <h2>Running Without Window Focus</h2>
+  <p>All browsers must comply with the <a
+    href="http://www.w3.org/TR/html5/editing.html#focus">focus</a> section of
+  the [[!html51]] spec. In particular, the requirement that the active element within a top-level browsing
+  context be independent of whether or not the top-level browsing context itself
+  has system focus MUST be followed.</p>
+
+  <p class="note">This requirement is put in place to allow efficient machine
+  utilization when using the WebDriver API to control several browsers
+  independently on the same desktop</p>
+</section>
+<section>
+  <h2 id="timeouts">Timeouts</h2>
+  <p>This section describes how timeouts and implicit waits are handled within WebDriver</p>
+  <section>
+    <h2>Setting Timeouts</h2>
+    <p>The "timeouts" command is used to set the value of a timeout that a command can execute
+     for.</p>
+      <section>
+       <h3>setTimeouts()</h3>
+        <p>
+          <table class="simple jsoncommand">
+            <tr>
+              <th>HTTP Method</th>
+              <th>Path Template</th>
+              <th>Notes</th>
+            </tr>
+            <tr>
+              <td>POST</td>
+              <td id='post-timeouts'>/session/{sessionId}/timeouts</td>
+              <td></td>
+            </tr>
+          </table>
+        <p>
+        <ul>
+          <li>implicit - Set the amount of time the driver should wait when searching for elements. When searching for a single element, the driver should poll the page until an element is found or the timeout expires, whichever occurs first. When searching for multiple elements, the driver should poll the page until at least one element is found or the timeout expires, at which point it should return an empty list.<br>
+          If this command is never sent, the driver MUST default to an implicit wait of 0ms.</li>
+          <li>page load - Set the amount of time the driver should wait before returning when the <a href="#page-load-strategies-1">page load stratgey</a> is not "<code>none</code>". If this limit is exceeded, the <code>get()</code> command MUST return a "<code><a href="#status-timeout">timeout</a></code>" response status.</li>
+          <li>script - Set the amount of time the driver should wait after calling <a href='#widl-JavaScriptExecutor-executeAsyncScript-Argument-DOMString-script-sequence-Argument--args'><code>executeAsyncScript</code></a> for the callback to have executed before returning a <code><a href="#status-timeout">timeout</a></code> Response.</li>
+        </ul>
+        The parameters will have the following keys in the object:
+        <ul>
+          <li>Let <var>type</var> contain the type of timeout for specified operations. Valid values are: "implicit", "page load", "script". If invalid values are passed in:
+            <ul>
+              <li>Set the HTTP Response status code to 500</li>
+              <li>Let <var>status</var> be equal to <a href='#status-invalid-selector'>Invalid Selector</a></li>
+              <li>Let <var>value</var> to a stating that the strategy is invalid. It may return a list of valid search strategies.</li>
+            </ul>
+          </li>
+          <li>let <var>ms</var> contain the amount of time, in milliseconds, that time-limited commands are permitted to run.</li>
+        </ul>
+    </section>
+  </section>
+</section>
+<!-- Section removed as it was describing specific local end implementations --><section>
+  <h2>Executing Javascript</h2>
+  <div class="note">
+    <p>Open questions: What happens if a user's JS triggers a modal dialog?
+      Blocking seems like a reasonable idea, but there is an assumption that
+      WebDriver is not threadsafe.
+
+      What happens to unhandled JS errors? Caused by a user's JS? Caused by JS
+      on a page? How does a user of the API obtain the list of errors? Is that
+      list cleared upon read?
+    </div>
+    <p class="note">Conformance tests for this section can be found in the <a href="https://github.com/w3c/web-platform-tests/tree/master/webdriver/">webdriver module</a> under the "ecmascript" folder.</p>
+
+    <section>
+      <h2>Javascript Command Parameters</h2>
+
+      <p>When calling <a href="#sync-js-execution">Synchronous JavaScript Execution</a> or calling <a href="async-js-execution">Asynchronous JavaScript Execution</a> we need to extract
+        the following from <var><a href="#post-payload">payload body</a></var> into <dfn>JavaScript Command Parameters</dfn>:</p>
+
+        <ul>
+          <li>let <var>script</var> be the JavaScript to execute, in the form of a Function body.</li>
+          <li>let <var>args</var> be an array that are used as the parameters to the function defined by <var>script</var>.
+            The <var>args</var> can contain the numbers, booleans, a WebElement, objects or arrays</li>
+        </ul>
+    </section>
+
+    <p>When executing Javascript, it MUST be possible to reference the <code>args</code> parameter using the function's <code>arguments</code> object. The arguments MUST be in the same order as defined in <code>args</code>. Each WebDriver implementation MUST preprocess the values in <code>args</code> using the following algorithm:
+
+      <p id="JS-args-preprocess">For each index, <code>index</code> in <code>args</code>, if <code>args[index]</code> is...
+        <ol>
+          <li>a long, boolean, DOMString, or <code>null</code>, then let <code>args[index] = args[index]</code>.</li>
+          <li>a sequence, then recursively apply this algorithm to <code>args[index]</code> and assign the result to <code>args[index]</code>.</li>
+          <li>an object, then recursively apply this algorithm to each value in <code>args[index]</code> and assign the result to <code>args[index]</code>.</li>
+          <li>a <a href="#elements">WebElement</a>, then:
+            <ol>
+              <li>If <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's tree, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error.</li>
+              <li>Otherwise, let <code>args[index]</code> be the underlying <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>.</li>
+            </ol>
+          </li>
+          <li>Otherwise WebDriver implementations MAY throw an <code><a href="#status-unknown-error">unknown error</a></code> indicating the index of the unhandled parameter but SHOULD attempt to convert the value into a <code>object</code>.</li>
+        </ol>
+        <section>
+          <h2 id="sync-js-execution">Synchronous Javascript Execution</h2>
+          <section>
+            <!-- executeScript() -->
+            <h3>executeScript()</h3>
+            <dd>
+              <dl class='parameters'>
+                <dt> DOMString script</dt>
+                <dd>The script to execute.</dd>
+                <dt>sequence&lt;Argument>? args</dt>
+                <dd>The script arguments.</dd>
+              </dl>
+              <p>
+                <table class="simple jsoncommand">
+                  <tr>
+                    <th>HTTP Method</th>
+                    <th>Path Template</th>
+                    <th>Notes</th>
+                  </tr>
+                  <tr>
+                    <td>POST</td>
+                    <td id='post-execute_script'>/session/{sessionId}/execute</td>
+                    <td></td>
+                  </tr>
+                </table>
+                <p>
+              <p>When executing JavaScript, the WebDriver implementations MUST use the following algorithm:
+                <ol>
+                  <li>Let <code>window</code> be the <a href="http://www.w3.org/TR/Window/">Window</a> object for WebDriver's current <a href="#where-commands-are-handled">command context</a>.
+                  <li>Let <code>script</code> be the DOMString from the command's <code>script</code> parameter.
+                  <li>Let <code>fn</code> be the Function object created by executing <code>new Function(script);</code>
+                  <li>Let <code>args</code> be the sequence created by the pre-processing algorithm defined <a href="#JS-args-preprocess">above</a>.
+                  <li>Invoke <code>fn.apply(window, args);</code>
+                  <li>If the previous step errors then:
+                  <ol>
+                    <li>Let <code>error</code> be the thrown value.
+                    <li>Set the response <a href="href=#response-status">status</a> to <code><a href="#status-javascript-error">javascript error</a></code>.
+                    <li>Set the response <a href="#response-value">value</a> to a <code>object</code>, <code>dict</code>.
+                    <li>If <code>error</code> is an Error, then set a "message" entry in <code>dict</code> whose value is the DOMString defined by <code>error.message</code>.
+                    <li>Otherwise, set a "message" entry in <code>dict</code> whose value is the DOMString representation of <code>error</code>.
+                  </ol>
+                  <li>Otherwise:
+                  <ol>
+                    <li>Let <code>result</code> be the value returned by the function in step #5.
+                    <li>Set the command's response <a href='#response-status'>status</a> to <code><a href="#status-success">success</a></code>.
+                    <li>Let <code>value</code> be the result of the following algorithm:
+                  <ol>
+                    <li>If <code>result</code> is:
+                    <ol>
+                      <li><code>undefined</code> or <code>null</code>, return <code> null</code>.
+                      <li>a long, boolean, or DOMString, return <code>result</code>.
+                      <li>a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, then return the corresponding WebElement for that <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>.
+                      <!-- Should there be a recursion limit? -->
+                      <li>a <code>Sequence &lt;Node&gt; nodes</code>, then return the result of recursively applying this algorithm to <code>result</code>.
+                      <!-- Should there be a limit? -->
+                      <li>an object, then return the <code>object</code> created by recursively applying this algorithm to each property in <code>result</code>.
+                    </ol>
+                  </ol>
+                  <li>Set the response <a href="#response-value">value</a> to <code>value</code>.</li>
+                </ol>
+                <li>Return the response.</li>
+              </ol>
+            </section>
+        </section>
+        <section>
+          <h2>Asynchronous Javascript Execution</h2>
+          <section>
+            <h3 id="async-js-execution">executeAsyncScript()</h3>
+
+              <dl class='parameters'>
+                <dt> DOMString script</dt>
+                <dd>The script to execute.</dd>
+                <dt>sequence&lt;Argument>? args</dt>
+                <dd>The script arguments.</dd>
+              </dl>
+              <p>
+                <table class="simple jsoncommand">
+                  <tr>
+                    <th>HTTP Method</th>
+                    <th>Path Template</th>
+                    <th>Notes</th>
+                  </tr>
+                  <tr>
+                    <td>POST</td>
+                    <td id='post-execute_async'>/session/{sessionId}/execute_async</td>
+                    <td></td>
+                  </tr>
+                </table>
+                <p>
+              <p>When executing asynchronous JavaScript, the WebDriver implementation MUST use the following algorithm:
+                <ol>
+                  <li>Let <code>timeout</code> be the value of the last "script" <a href="#timeouts">timeout command</a>, or 0 if no such commands have been received.</li>
+                  <li>Let <code>window</code> be the <a href="http://www.w3.org/TR/Window/">Window</a> object for WebDriver's current <a href="#where-commands-are-handled">command context</a>.</li>
+                  <li>Let <code>script</code> be the DOMString from the command's <code>script</code> parameter.</li>
+                  <li>Let <code>fn</code> be the Function object created by executing <code>new Function(script);</code></li>
+                  <li>Let <code>args</code> be the sequence created by the pre-processing algorithm defined <a href="#JS-args-preprocess">above</a>.</li>
+                  <li>Let <code>callback</code> be a Function object pushed to the end of <code>args</code>.</li>
+                  <li>Register a one-shot timer on <code>window</code> set to fire <code>timeout</code> milliseconds in the future.</li>
+                  <li>Invoke <code>fn.apply(window, args);</code></li>
+                  <li>If the previous step errors then:
+                    <ol>
+                      <li>Let <code>error</code> be the thrown value.</li>
+                      <li>Set the response <a href='#response-status'>status</a> to <code><a href="#status-javascript-error">javascript error</a></code>.</li>
+                      <li>Set the response <a href="#response-value">value</a> to a <code>object</code>, <code>dict</code>.</li>
+                      <li>If <code>error</code> is an Error, then set a "message" entry in <code>dict</code> whose value is the DOMString defined by <code>error.message</code>.</li>
+                      <li>Otherwise, set a "message" entry in <code>dict</code> whose value is the DOMString representation of <code>error</code>.</li>
+                    </ol>
+                  </li>
+                  <li>Otherwise, the WebDriver implementation MUST wait for one of the following to occur:
+                    <ol>
+                      <li>if the one-shot timer that was set on the <code>window</code> fires
+                        , the WebDriver implementation MUST immediately set the response <a href='#response-status'>status</a>
+                        to <code><a href='#status-timeout'>timeout</a></code> and return.</li>
+                        <li>if the <code>window</code> fires an <code>unload</code> event, the WebDriver implementation MUST immediately set the response <a href='#response-status'>status</a> to JavascriptError and return with the error message set to "Javascript execution context no longer exists.".</li>
+                        <li>if the <code>callback</code> function is invoked, then:
+                          <ol>
+                            <li>Let <code>result</code> be the first argument passed to <code>callback</code>.</li>
+                            <li>Set the command's response <a href='#response-status'>status</a> to Success.</li>
+                            <li>Let <code>value</code> be the result of the following algorithm:
+                              <ol>
+                                <li>If <code>result</code> is:
+                                  <ol>
+                                    <li><code>undefined</code> or <code>null</code>, return <code> null</code>.</li>
+                                    <li>a long, boolean, or DOMString, return <code>result</code>.</li>
+                                    <li>a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, then return the corresponding WebElement for that <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>.</li>
+                                    <!-- Should there be a recursion limit? -->
+                                    <li>a <code>Sequence &lt;Node> Nodes</code>, then return the result by recursively applying this algorithm to <code>result</code>. WebDriver implementations SHOULD limit the recursion depth.</li>
+                                    <!-- Should there be a limit? -->
+                                    <li>an object, then return the <code>object</code> created by recursively applying this algorithm to each property in <code>result</code>.</li>
+                                  </ol>
+                                </li>
+                              </ol>
+                            </li>
+                            <li>Set the command's response <a href="#response-value">value</a> to <code>value</code>.</li>
+                          </ol>
+                        </li>
+                        <li>Return the response.</li>
+                      </ol>
+                    </li>
+                  </ol>
+                </section>
+        </section>
+        <section>
+          <h2>Reporting Errors</h2>
+          <p></p>
+        </section>
+</section>
+<section>
+  <h2>Introduction</h2>
+  <p>The WebDriver API aims to provide a synchronous API that can be used for a variety of use cases, though
+  it is primarily designed to support automated testing of web apps.</p>
+  <section>
+    <h3>Intended Audience</h3>
+    <p>This specification is intended for implementors of the WebDriver API. It is not intended as light bed
+    time reading.</p>
+  </section>
+  <section>
+    <h3>Relationship of WebDriver API and Existing Specifications</h3>
+    <p>Where possible and appropriate, the WebDriver API references existing specifications. For example, the
+    list of boolean attributes for elements is drawn from the
+    <a href="http://dev.w3.org/html5/spec/Overview.html">HTML specification</a>. When references are made, this
+    specification will link to the relevant sections.</p>
+  </section>
+
+  <section>
+    <h3>Naming the Two Sides of the API</h3>
+
+    <p>The WebDriver API can be thought of as a client/server process. However, implementation details can mean that this terminology becomes confusing. For this reason, the two sides of the API are called the "local" and the "remote" ends.</p>
+    <dl>
+      <dt><dfn id="local-end">Local</dfn></dt>
+      <dd>The user-facing API. <code><a href="#command-1">Command</a></code> objects are sent and <code><a href="#response">Response</a></code> objects are
+      consumed by the local end of the WebDriver API. It can be thought of as
+      being "local" to the user of the API.</dd>
+
+      <dt><dfn id="remote-end">Remote</dfn></dt>
+      <dd>The implementation of the user-facing API. <code><a href="#command-1">Command</a></code> objects are
+      consumed and <code><a href="#response">Response</a></code> objects are sent by the remote end of the WebDriver
+      API. The implementation of the remote end may be on a machine remote from
+      the user of the local end.</dd>
+
+    </dl>
+
+    <p>There is no requirement that the local and remote ends be in different processes. The IDLs given in this specification SHOULD be used as the basis for any conforming local end implementation.</p>
+  </section>
+
+  <section>
+    <h3>Conformance Requirements</h3>
+
+    <p>All diagrams, examples, and notes in this specification are non-normative, as are all sections explicitly marked non-normative. Everything else in this specification is normative.</p>
+
+    <p>The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative parts of this document are to be interpreted as described in [[!RFC2119]]. The key word "OPTIONALLY" in the normative parts of this document is to be interpreted with the same normative meaning as "MAY" and "OPTIONAL".</p>
+
+    <p>Conformance requirements phrased as algorithms or specific steps may be implemented in any manner, so long as the end result is equivalent.</p>
+  </section>
+
+  <section>
+    <h3>Conformance Classes</h3>
+
+    <p>This specification defines three broad conformance classes:</p>
+    <dl>
+      <dt><dfn>Local End</dfn>
+      <dd>This represents the client side of the protocol, which is usually in the form of language-specific libraries providing an API on top of the WebDriver protocol. This specification does not place any restrictions on the details of those libraries above the level of the wire protocol. <!-- TODO: define the requirements on the local end somewhere -->
+      <dt><dfn>Remote End</dfn>
+      <dd>This is the server side of the protocol, which is usually implemented by a web browser or similar user agent. Defining the behaviour of the remote end in response to the WebDriver protocol forms the largest part of this specification.
+      <dt><dfn>Intermediary Node</dfn>
+      <dd>Intermediary nodes are those that act as proxies, implementing both the client and server sides of the protocol. Intermediary nodes must be black-box indistinguishable from <a>remote ends</a> from the point of view of <a>local end</a> and so are bound by the requirements on <a>remote ends</a> in terms of the wire protocol. However they are not expected to implement <a>commands</a> directly.
+    </dl>
+  </section>
+
+  <section>
+   <h3>Terminology</h3>
+
+   <p>In equations, all numbers are integers,
+    subtraction is represented by “−”, and bitwise OR by “|”.
+    The characters “(” and “)” are used to provide logical grouping in these contexts.
+  </section>
+
+  <section>
+   <h3>Common Infrastructure</h3>
+
+   <h4>Style Pixel Values</h4>
+
+   <p>When asked to <dfn>normalize style pixel values to integer</dfn>
+    for a value <var>s</var>:
+
+   <ol>
+    <li>Let <var>trimmed string</var> be a substring of <var>s</var>
+     where the suffix "px" is removed.
+
+    <li>Let <var>pixels</var> be the result of parsing
+     <var>trimmed string</var> as an integer.
+
+    <li>If <var>pixels</var> is not a valid integer or the previous
+     operation did not succeed, return 0.
+
+    <li>Return <var>pixels</var>.
+   </ol>
+
+   <p>When asked to <dfn>normalize style pixel values to floating
+    point</dfn> for a value <var>s</var>:
+
+   <ol>
+    <li>Let <var>trimmed string</var> be a substring of <var>s</var>
+     where the suffix "px" is removed.
+
+    <li>Let <var>pixels</var> be the result of parsing
+     <var>trimmed string</var> as a float.
+
+    <li>If <var>pixels</var> is not a valid float
+     or the previous operation did not succeed, return 0.0.
+
+    <li>Round off <var>pixels</var> using <code>ceil</code>
+     so that it has no more than four decimals.
+
+    <li>Return <var>pixels</var>.
+   </ol>
+
+   <p class=note>These operations are almost equivalent to calling
+    <code><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.2>parseInt</a></code>
+    and <code><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.3>parseFloat</a></code>
+    from [[!ECMA-262]] with the exception that non-valid integer
+    or float return values are returned as 0 or 0.0.
+
+    <h4>Top Level Browsing Context no longer open</h4>
+    <p>A top level browsing context is <dfn>no longer open</dfn> if it has been <a href="https://html.spec.whatwg.org/#a-browsing-context-is-discarded">discarded</a>
+  </section>
+</section>
+<section>
   <h2>Modals</h2>
     This section describes how modal dialogs should be handled using the WebDriver API.
     <p class="note">Conformance tests for this section can be found in the <a href="https://github.com/w3c/web-platform-tests/tree/master/webdriver/">webdriver module</a> under the "modals" folder.</p>
@@ -3619,16 +2996,46 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
       future commands to the remote end</p>
     </section>
 </section>
+  <section>
+    <h2>Extending the Protocol</h2>
+    <p></p>
+    <section>
+      <h3>Vendor-specific Extensions</h3>
+      <p>The WebDriver protocol is designed to allow extension to meet vendor-specific needs, such as interacting with the chrome of a browser. Vendor-specific extensions are implemented by appending a prefix to the command name. This should be of the form:</p>
+      <pre>
+        '-' + vendor prefix + '-' + command name
+      </pre>
+      <p>For example: "<code>-o-open-bookmark</code>" or "<code>-moz-install-extension</code>".</p>
+      <p>It is guaranteed that no command name in this or future versions of the WebDriver specification will be prefixed with a leading dash.</p>
+
+      <div class="note">
+        It is suggested that vendors use the same vendor identifier as in [[!CSS21]] (notably, section <a href="http://www.w3.org/TR/CSS21/syndata.html#vendor-keywords">4.1.2.2</a>)
+      </div>
+    </section>
+    <section>
+      <h3>Extending the JSON/HTTP Protocol</h3>
+      <p>This section is non-normative.</p>
+      <p>The wire protocol (see <a href="#mapping-to-http-and-json">Appendix</a> below) makes use of URLs to distinguish command names. When extending the protocol by adding new URLs, vendors should use their vendor prefix without additional characters to prevent any potential clashes with other implementations. This leads to URLs of the form: <code>http://host:port/session/somekey/<b>moz</b>/extension</code>.
+    </section>
+  </section>
+
 <section>
-  <h2>Screenshots</h2>
-  <p>Screenshots are a powerful mechanism for providing information to users of WebDriver, particularly once a particular WebDriver instance has been disposed of. In different circumstances, users want different types of screenshot. Note that the WebDriver spec does not provide a mechanism for taking a screenshot of the entire screen.</p>
-
-  <p>In all cases, screenshots MUST be returned as lossless PNG images encoded using Base64. Local ends MUST provide the user with access to the PNG images without requiring the user to decode the Base64. This access MUST be via at least one of a binary blob or a file.</p>
-
-  <p>All commands within this section are implemented using the "TakesScreenshot" interface:</p>
+  <h2>Controlling Windows</h2>
 
   <section>
-    <h3>takeScreenshot()</h3>
+    <h2>Definitions</h2>
+
+    <p>Within this specification, a window equates to [[!html51]]'s <a href="http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">top level browsing context</a>. Put another way, within this spec browser tabs are counted as separate windows.</p>
+
+    <p><strong>TODO: define "frame"</strong></p>
+
+    <p>A <dfn id='window-handle'>Window Handow</dfn> is an opaque string that MUST uniquely identify the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> and MUST NOT be "current". This MAY be a UUID.
+  </section>
+
+  <section>
+    <h2>Window Handles</h2>
+    <section>
+      <h3>getWindowHandle()</h3>
       <p>
         <table class="simple jsoncommand">
           <tr>
@@ -3638,76 +3045,156 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
           </tr>
           <tr>
             <td>GET</td>
-            <td id='get-screenshot'>/session/{sessionId}/screenshot</td>
+            <td id='get-window_handle'>/session/{sessionId}/window_handle</td>
             <td></td>
           </tr>
         </table>
+        <p>Each <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> has a <a href='#window-handle'>window handle</a>. The "getWindowHandle" command can be used to obtain the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> handle for the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> that commands are currently acting upon.</p>
+
+    </section>
+  </section>
+
+  <section>
+    <h2 name="iterating-over-windows">Iterating Over <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a></h2>
+    <section>
+      <h3>getWindowHandles()</h3>
+
       <p>
-      Take a screenshot and return a lossless PNG encoded using Base64. If
-      <code>element</code> is not populated or is <code>null</code> then the User Agent MUST return the screenshot of the current state of the document at the top level browsing context.
-      <p>The possible errors for this command:
-      <ul>
-        <li><code><a href="#unknown-error">unknown error</a></code> if the if the screenshot cannot be taken.</li>
-      </ul>
-      <p>Leaving below until <a href='https://www.w3.org/Bugs/Public/show_bug.cgi?id=27920'>Bug 27920</a> has a consensus</p>
-      <dl class='parameters'>
-        <dt>optional WebElement? element</dt>
-        <dd>The <a>WebElement</a> on which to operate. If <code>element</code> is not populated or is <code>null</code>
-          then the User Agent MUST return the screenshot of the current state of the document at the top level browsing context.</dd>
-      </dl>
-    </dd>
+        <table class="simple jsoncommand">
+          <tr>
+            <th>HTTP Method</th>
+            <th>Path Template</th>
+            <th>Notes</th>
+          </tr>
+          <tr>
+            <td>GET</td>
+            <td id='get-window_handles'>/session/{sessionId}/window_handles</td>
+            <td></td>
+          </tr>
+        </table>
+        <p>This array of returned strings MUST contain a handle for every <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> associated with the browser session and no others. For each returned <a href='#window-handle'>window handle</a> the javascript expression "window.top.closed" (or equivalent) MUST evaluate to false at the time the command is being executed.</p>
+
+    <p>The ordering of the sequence is not defined, but MAY be determined by iterating over each OS Window and returning the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> items within that OS window before iterating over the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing contexts</a> of the next OS window. For example, in the diagram below, the <a href='#window-handle'>window handle</a> should be returned as the handles for: win1tab1, win1tab2, win2.</p>
+
+    <img src="example-windows.png" alt="Two top level windows. The first window has two tabs, lablled win1tab1 and win1tab2. The second window has only one tab labelled win2"/>
+
+    <p class="note">This implies that the correct way to determine whether or not a particular interaction with the browser opens a new window is done by obtaining the set of <a href='#window-handle'>window handle</a> before the interaction is performed and comparing with the set after the action is performed.</p>
+    </section>
   </section>
 
   <section>
-    <h2>Current Top Level Browsing Context</h2>
-    <table class="simple">
-      <tr><th>Capability Name</th><th>Type</th></tr>
-      <tr><td><span id="capability-takesScreenshot">takesScreenshot</span></td><td>boolean</td></tr>
-    </table>
+    <h2>Closing Windows</h2>
+    <section>
+      <h3>close()</h3>
+        <p>
+          <table class="simple jsoncommand">
+            <tr>
+              <th>HTTP Method</th>
+              <th>Path Template</th>
+              <th>Notes</th>
+            </tr>
+            <tr>
+              <td>DELETE</td>
+              <td id='delete-window_handle'>/session/{sessionId}/window_handle</td>
+              <td></td>
+            </tr>
+          </table>
 
-    <p>If this capability is supported, local end MUST add the <code>TakesScreenshot</code> interface to the <code>WebDriver</code> interface.</p>
+        <p>The close command closes the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> that Commands are currently being sent to. If this means that a call to get the list of <a href='#window-handle'>window handle</a>s would return an empty list, then this close command MUST  <a href='removing-a-session'>remove the session</a>.</p>
 
-    <p>This command will take a screenshot of the return the screenshot of the current state of the document at the top level browsing context. Implementations of the remote end SHOULD capture the entire document, even if this would require a user to scroll the browser window. That is, the returned PNG SHOULD have the same width and height as returned by a call to <code>getSize</code> of the BODY element and MUST contain all visible content on the page, and this SHOULD be done without resizing the browser window. If the remote end is unable to capture the entire Document, then the part of the Document currently displayed in UI of the browser MUST be captured without additional chrome such as scrollbars and browser chrome.</p>
+        <p>Once the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> has closed, future commands MUST return a status code of <code><a href="#status-no-such-window">no such window</a></code> until a new <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> is selected for receiving commands.</p>
 
-    <div class="note">
-      <p>One way to think of capturing the entire Document is that the user has an infinitely large monitor and has resized the window to allow all content to be visible. One of those monitors would be very cool.</p>
-    </div>
-
-    <p>Nested frames MUST be sized as if the user has resized the window to the dimensions of the PNG being returned. This often means that not all potentially visible content within the nested frames is captured.</p>
-
-    <p>Remote ends MUST NOT attempt to track changes in window size as the screenshot is being taken. In particular this means that in the case of a page that makes use of "infinite scrolling" (where an AJAX call is used to populate additional content as the user scrolls down) or in some other way resizes content as the window size is changed only the content that was originally contained in the Document when the command is executed will be captured.</p>
+    </section>
   </section>
-  <section>
-    <h2>Element</h2>
-      <table class="simple">
-        <tr><th>Capability Name</th><th>Type</th></tr>
-        <tr><td><span id="capability-takesElementScreenshot">takesElementScreenshot</span></td><td>boolean</td></tr>
-      </table>
 
-  	<p>If this capability is supported, local end MUST add the <code>TakesScreenshot</code> interface to the <code>WebElement</code> interface.</p>
-    <table class="simple jsoncommand">
-      <tr>
-        <th>HTTP Method</th>
-        <th>Path Template</th>
-        <th>Notes</th>
-      </tr>
-      <tr>
-        <td>GET</td>
-        <td id='get-screenshot'>/session/{sessionId}/screenshot/{ELEMENT}</td>
-        <td></td>
-      </tr>
-    </table>
-    <p>
-      <ul>
-        <li>Let <var>element</var> be the value from <var><a href="#uri-template-element">element</a></var> from the URI-Template</li>
-        <li>Let <var>screenshot</var> be a be a Base64 encoded, lossless PNG representation of area bounded by the clientBoundingRect of the DOMElement.
-          <ol>
-            <li>If the element is not in the current viewport, the DOMElement must be scrolled into view.</li>
-            <li><If the <code>WebElement</code> represents a FRAME or IFRAME element, this is equivalent of taking a screenshot of the frame's BODY elemen</li>
-          </ol>
-        </li>
-        <li>Return <var>screenshot</var> to the local end.</li>
-      </ul>
+  <section>
+    <h2>Resizing and Positioning Windows</h2>
+    <p>All commands MUST be handled by the OS window that ultimately owns the current context.</p>
+    <dl class='idl' title='dictionary WindowSize'>
+      <dt>double height</dt>
+      <dd>The height of the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a></dd>.
+      <dt>double width</dt>
+      <dd>The width of the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a></dd>.
+    </dl>
+    <section>
+      <!-- setWindowSize() -->
+      <h3>setWindowSize()</h3>
+        <p>
+          <table class="simple jsoncommand">
+            <tr>
+              <th>HTTP Method</th>
+              <th>Path Template</th>
+              <th>Notes</th>
+            </tr>
+            <tr>
+              <td>POST</td>
+              <td id='post-window_handle-size'>/session/{sessionId}/window/size</td>
+              <td></td>
+            </tr>
+          </table>
+        <p>
+        Resizes the OS window currently receiving commands to have the <code>height</code> and <code>width</code> passed in as parameters.
+        <p>If a request is made to resize a OS window to a size which cannot be performed (e.g. the browser has a minimum, or fixed OS window size, or the operating system does not support resizing windows at all as is the case in many phone OSs), an <code><a href="#status-unsupported-operation">unsupported operation</a></code> status code MUST be returned.</p>
+        <p>After <code>setWindowSize</code>, the browser window MUST NOT be in the maximised state.</p>
+        <dl class='parameters'>
+          <dt>unsigned double width</dt>
+          <dd>The "width" value refer to the javascript <code>window.outerwidth</code> property. If the User Agent does not support this property, it represents the width of the whole OS window including window chrome and window resizing borders/handles.</li></dd>
+          <dt>unsigned double height</dt>
+          <dd>The "height" value refer to the javascript <code>window.outerheight</code> property. If the User Agent does not support this property, it represents the width of the whole OS window including window chrome and window resizing borders/handles.</li></dd>
+
+      </section>
+      <section>
+      <!-- getWindowSize() -->
+      <h3>getWindowSize()</h3>
+        <p>
+          <table class="simple jsoncommand">
+            <tr>
+              <th>HTTP Method</th>
+              <th>Path Template</th>
+              <th>Notes</th>
+            </tr>
+            <tr>
+              <td>GET</td>
+              <td id='get-window_handle-size'>/session/{sessionId}/window/size</td>
+              <td></td>
+            </tr>
+          </table>
+        <p>
+          A command named "getWindowSize()":
+        <ol>
+          <li>Create a <a>WindowSize</a> dictionary containing the <code><a href='#widl-WindowSize-height'>height</a></code> and <code><a href='#widl-WindowSize-width'>width</a></code> keys.
+          <li>Populate <code><a href='#widl-WindowSize-width'>width</a></code> with the value of <code>window.outerwidth</code> property of the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a>. If the User Agent does not support this property, it represents the width of the whole OS window including window chrome and window resizing borders/handles.</li>
+          <li>Populate <code><a href='#widl-WindowSize-height'>height</a></code> with the value of <code>window.outerheight</code> property of the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a>. If the User Agent does not support this property, it represents the width of the whole OS window including window chrome and window resizing borders/handles.</li>
+          <li>Return <a>WindowSize</a></li>
+        </ol>
+      </section>
+
+      <section>
+      <!-- maximizeWindow() -->
+      <h3>maximizeWindow()</h3>
+        <p>
+          <table class="simple jsoncommand">
+            <tr>
+              <th>HTTP Method</th>
+              <th>Path Template</th>
+              <th>Notes</th>
+            </tr>
+            <tr>
+              <td>POST</td>
+              <td id='get-window_handle-maximize'>/session/{sessionId}/window/maximize</td>
+              <td></td>
+            </tr>
+          </table>
+        <p>After  <code>maximizeWindow</code>, the OS window currently receving commands MUST be left as if the maximise button had been pressed if, and only if, the window manager of the OS supports this concept; it is not sufficient to leave the window "restored", but with the full screen dimensions.</p>
+        <p>If a request is made to resize a window to a size which cannot be performed (e.g. the browser has a minimum, or fixed window size, or the operating system does not support resizing windows at all as is the case in many phone OSs), an <code><a href="#status-unsupported-operation">unsupported operation</a></code> status code MUST be returned.</p>
+      </section>
+      <section>
+      <!-- fullscreenWindow -->
+      <h3>fullscreenWindow()</h3>
+        <p>After <code>fullscreenWindow</code>, the OS window currently receiving commands MUST be in full-screen mode. For those operating systems that support the concept, this MUST be equivalent to if the user requested the OS window be full screen.</p>
+
+        <p>If the User Agent or OS does not support switching to full-screen mode, an <code><a href="#status-unsupported-operation">unsupported operation</a></code> status code MUST be returned.</p>
+    </section>
   </section>
 </section>
 <section>
@@ -3748,29 +3235,551 @@ an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor
     <p class="note">This is one way in which it might be possible to test mobile applications that marry a native wrapper around a series of HTML views.</p>
   </section>
 </section>
-  <section>
-    <h2>Extending the Protocol</h2>
-    <p></p>
+<section>
+  <h2>Element State</h2>
     <section>
-      <h3>Vendor-specific Extensions</h3>
-      <p>The WebDriver protocol is designed to allow extension to meet vendor-specific needs, such as interacting with the chrome of a browser. Vendor-specific extensions are implemented by appending a prefix to the command name. This should be of the form:</p>
-      <pre>
-        '-' + vendor prefix + '-' + command name
-      </pre>
-      <p>For example: "<code>-o-open-bookmark</code>" or "<code>-moz-install-extension</code>".</p>
-      <p>It is guaranteed that no command name in this or future versions of the WebDriver specification will be prefixed with a leading dash.</p>
+      <h2>Reading current element state from the document</h2>
+      <p class="note">Conformance tests for this section can be found in the <a href="https://github.com/w3c/web-platform-tests/tree/master/webdriver/">webdriver module</a> under the "element_state" folder.</p>
 
-      <div class="note">
-        It is suggested that vendors use the same vendor identifier as in [[!CSS21]] (notably, section <a href="http://www.w3.org/TR/CSS21/syndata.html#vendor-keywords">4.1.2.2</a>)
-      </div>
-    </section>
+          <p>When we are returning an <a>ElementRect</a> to the local end it will need to be serialised</p>
+          <dl class='idl' title='dictionary ElementRect'>
+            <dt>double x</dt>
+            <dd>The x coordinate for the top left of the element</dd>
+            <dt>double y</dt>
+            <dd>The y coordinate for the top left of the element</dd>
+            <dt>double height</dt>
+            <dd>Height of the element in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a></dd>
+            <dt>double width</dt>
+            <dd>Width of the element in <a href='http://www.w3.org/TR/css3-values/#absolute-lengths'>CSS reference pixels</a></dd>
+          </dl>
     <section>
-      <h3>Extending the JSON/HTTP Protocol</h3>
-      <p>This section is non-normative.</p>
-      <p>The wire protocol (see <a href="#mapping-to-http-and-json">Appendix</a> below) makes use of URLs to distinguish command names. When extending the protocol by adding new URLs, vendors should use their vendor prefix without additional characters to prevent any potential clashes with other implementations. This leads to URLs of the form: <code>http://host:port/session/somekey/<b>moz</b>/extension</code>.
+      <!-- isDisplayed() -->
+      <h3>isDisplayed()</h3>
+
+      <table class="simple jsoncommand">
+        <tr>
+          <th>HTTP Method</th>
+          <th>Path Template</th>
+          <th>Notes</th>
+        </tr>
+        <tr>
+          <td>GET</td>
+          <td id='get-id-displayed'>/session/{sessionId}/element/{element}/displayed</td>
+          <td></td>
+        </tr>
+      </table>
+
+      <p>The command is used to determine the
+       <a rel="element displayed">element displayedness</a> of
+       the <a href=http://w3c.github.io/dom/#element>Document element</a>
+       connected with the <a>web element</a> reference given by
+       the <code>element</code> fragment in the path.
+
+      <p>The response is composed using the following algorithm:
+
+      <ol>
+       <li>Let <var>response</var> be an initially empty
+        <a>response</a>.
+
+       <li>Let <var>visible</var> be a boolean initially set to
+        false.
+
+       <li>Let <var>element</var> be an initially undefined
+        <a href="http://w3c.github.io/dom/#element">Document element</a>.
+
+       <li>Let <var>element reference</var> be a string with the
+        value of the <code>element</code> fragment from the path.
+
+       <li>If <var>element reference</var> is null or has a
+        length equal to 0, set <var>response</var>'s
+        <a href=#response-status>status</a> to
+        the <a>invalid argument</a> status and return <var>response</var>.
+
+       <li>If the <a>default content</a>'s <a
+        href=http.//www.w3.org/TR/html5/browser.html#top-level-browsing-context>top
+        level browsing context</a> is no longer open, set
+        <var>response</var>'s <a href=#response-status>status</a>
+        to the <a>no such window</a> status</a> and return
+        <var>response</var>.
+
+       <li>Set <var>element</var> be the <a
+        href=http://w3c.github.io/dom/#element>Document element</a>
+        found after applying the <a>web element lookup</a> algorithm
+        to the <a>element reference map</a>.
+ 
+       <li>If <var>element</var> is null
+        or <var>element</var> does not represent a
+        <a href=http://w3c.github.io/dom/#element>Document element</a>,
+        set <var>response</var>'s <a href=#response-status>status</a>
+        to the <a>no such element</a> status
+        and return <var>response</var>.
+
+       <li>If <var>element</var> represents
+        <a href=http://w3c.github.io/dom/#element>Document element</a>
+        that is no longer attached to the document's node tree,
+        set <var>response</var>'s <a href=#response-status>status</a>
+        to the <a>stale element reference</a> status and return
+        <var>response</var>.
+
+       <li>Apply the <a>element displayed</a> algorithm to
+        <var>element</var> and set <var>visible</var> to its
+        return value.</li>
+
+       <li>Set <var>response</var>'s
+        <a href=#response-status>status</a> to <a>success</a>
+        and its <a href="#response-value">value</a> to <var>visible</var>.
+
+       <li>Return <var>response</var>.
+      </ol>
+    </section>
+
+      <section>
+        <!-- isSelected -->
+        <h3>isSelected()</h3>
+        <p>
+          <table class="simple jsoncommand">
+            <tr>
+              <th>HTTP Method</th>
+              <th>Path Template</th>
+              <th>Notes</th>
+            </tr>
+            <tr>
+              <td>GET</td>
+              <td id='get-id-selected'>/session/{sessionId}/element/{ELEMENT}/selected</td>
+              <td></td>
+            </tr>
+          </table>
+
+          <p>The remote end MUST determine whether a <code>WebElement</code> is selected using the following algorithm:
+          <ol>
+            <li id="is_selectable">If the item is not "<code title='selectable'>selectable</code>", the WebElement is not selected. A <dfn id="selectable" title="selectable">selectable</dfn> element is either an OPTION element or an INPUT element of type "<a href="http://www.w3.org/TR/html5/forms.html#checkbox-state-(type=checkbox)">checkbox</a>" or "<a href="http://www.w3.org/TR/html5/forms.html#radio-button-state-(type=radio)">radio</a>".</li>
+            <li>If the Document node represented by the WebElement is an OPTION element, the "<a href="http://www.w3.org/TR/html5/forms.html#concept-option-selectedness">selectedness</a>" of the element, as defined in [[!html51]] determines whether the element is selected.</li>
+            <li>Otherwise, the value of the Document node's "<a href="http://www.w3.org/TR/html5/forms.html#attr-input-checked">checked</a>" property determines whether the element is selected. This MUST reflect the element's "<a href="http://www.w3.org/TR/html5/forms.html#concept-fe-checked">checkedness</a>" as defined in [[!html51]].</li>
+          </ol>
+          <p>If <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
+      </section>
+      <section>
+        <!-- getElementAttribute() -->
+        <h3>getElementAttribute()</h3>
+        <p>
+          <table class="simple jsoncommand">
+            <tr>
+              <th>HTTP Method</th>
+              <th>Path Template</th>
+              <th>Notes</th>
+            </tr>
+            <tr>
+              <td>GET</td>
+              <td id='get-id-attribute'>/session/{sessionId}/element/{ELEMENT}/attribute/{name}</td>
+              <td></td>
+            </tr>
+          </table>
+          <div class="note">
+          <p>Although the [[!html51]] spec is very clear about the difference between the properties and attributes of a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, users are frequently confused between the two. Because of thisend point which covers the case of returning either of the value of a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> property or attribute. If a user wishes to refer specifically to an attribute or a property, they should evaluate Javascript in order to be unambiguous.</p>
+
+          <p>The end result of this algorithm are values that can be passed to other commands within this specification. Notably, this means that URLs that are returned can be passed to <a href="#widl-WebDriver-get-void-DOMString-url">get</a> and the expected URL will be navigated to.</p>
+          </div>
+
+          <p>To determine the <var>value</var> of the response, the following steps must be taken where <var>name</var> is the <code>name</code> property on the <code>parameters</code> dictionary in Command, and <var>element</var> is the <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> modeled by the <code>ELEMENT</code> parameter.:
+          <ol>
+            <li>Initially set <var>result</var> to null.
+            <li>Handle special-cases:
+              <ol>
+                <li>If "<var>name</var>" case insensitively matches "<code>style</code>", then store the value of the computed value of the <code>style</code> property of <var>element</var>, <a href="http://dev.w3.org/csswg/cssom/#serialize-a-css-rule">serialized as defined</a> in the [[!CSSOM-VIEW]] spec, as <var>result</var>. Notably, CSS property names must be cased as specified in in section 6.5.1 of the [[!CSSOM-VIEW]] spec. In addition, color property values must be standardized to <a href='http://www.w3.org/TR/css3-color/#rgba-color'>RGBA color format</a> as described in [[!css3-color]]. If a user agent does not support RGBA then it MUST return a value as 1 for opacity.</li>
+
+                <li>If "<var>name</var>" case insensitively matches "selected" or "checked", and the element is <a href="#is_selectable">selectable</a>:
+                  <ol>
+                    <li>If the element supports neither a <a href="http://www.w3.org/TR/html51/forms.html#concept-option-selectedness">selectedness</a> or <a href="http://www.w3.org/TR/html51/forms.html#concept-fe-checked">checkedness</a> check, then store null as <var>result</var>.</li>
+                    <li>For an <code>option</code> element, store the element's <a href="http://www.w3.org/TR/html51/forms.html#concept-option-selectedness">selectedness</a> as <var>result</var>.</li>
+                    <li>In all other cases, store the element's <a href="http://www.w3.org/TR/html51/forms.html#concept-fe-checked">checkedness</a> as <var>result</var>.</li>
+                  </ol>
+                </li>
+                <li>If any of the above steps have been executed, go to the <a href="#attribute-result-coercion">result coercion</a> step of this algorithm.
+              </ol>
+            </li>
+
+            <li>Obtain the property indexed by "<var>name</var>" from the element and store this as <var>result</var>. If <var>name</var> case insensitively matches "class" set <var>result</var> to be <var>element</var>'s <code>className</code> property. Similarly, if <var>name</var> case insensitively matches "readonly", set <var>result</var> to be the <var>element</var>'s <code>readOnly</code> property.</li>
+
+            <li>If <var>result</var> is null or undefined, or if it is an object, set the value of <var>result</var> to be the <code>value</code> of the Attr node obtained by calling <code>getAttributeNode</code> on <var>element</var> iff that Attr is <code>specified</code>. That is, <var>result</var> is the equivalent of executing the following Ecmascript: <code>var attr = element.getAttributeNode(name); var result = (attr &amp;&amp; attr.specified) ? attr.value : null;</code></li>
+
+            <li name="attribute-result-coercion">Coerce the return value to a DOMString:
+              <ol>
+                <li>If <var>result</var> is a boolean value, use the value "true" if <var>result</var> is true, or null otherwise.</li>
+                <li>if <var>result</var> is null or undefined, set <var>result</var> to be null.</li>
+                <li>In all other cases, coerce <var>result</var> to a DOMString.</li>
+              </ol>
+            </li>
+          </ol>
+          <dl class='parameters'>
+            <dt>DOMString name</dt>
+            <dd>The name of the property or attribute to return.</dd>
+          </dl>
+          <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
+      </section>
+      <section>
+        <!-- getCssValue() -->
+        <h3>getCssValue()</h3>
+        <p>
+          <table class="simple jsoncommand">
+            <tr>
+              <th>HTTP Method</th>
+              <th>Path Template</th>
+              <th>Notes</th>
+            </tr>
+            <tr>
+              <td>GET</td>
+              <td id='get-id-css-property'>/session/{sessionId}/element/{ELEMENT}/css/{propertyName}</td>
+              <td></td>
+            </tr>
+          </table>
+          <p>The "getCssValue" command will return a <code>DOMString</code> of the value of the property passed. It MUST return the value of <a href="http://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertyvalue"><code>getPropertyValue(propertyName)</code></a> returned from calling <a href='http://dev.w3.org/csswg/cssom/#dom-window-getcomputedstyle'><code>window.getComputedStyle(element)</code></a>. Color property values MUST be standardized to <a href='http://www.w3.org/TR/css3-color/#rgba-color'>RGBA color format</a> as described in [[!css3-color]]. If a user agent does not support RGBA then it MUST return a value as 1 for opacity. If the property is not present then return an empty string.
+          <dl class='parameters'>
+            <dt>DOMString propertyName</dt>
+            <dd>The name of the property whose value will be returned</dd>
+          </dl>
+          <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
+      </section>
+      <section>
+        <!-- getElementText() -->
+        <h3>getElementText()</h3>
+          <p>
+            <table class="simple jsoncommand">
+              <tr>
+                <th>HTTP Method</th>
+                <th>Path Template</th>
+                <th>Notes</th>
+              </tr>
+              <tr>
+                <td>GET</td>
+                <td id='get-id-text'>/session/{sessionId}/element/{ELEMENT}/text</td>
+                <td></td>
+              </tr>
+            </table>
+            <p>The following definitions are used in this section:
+          <dl>
+              <dt id="text.whitespace">Whitespace</dt>
+              <dd>Any text that matches the ECMAScript regular expression class <code>\s</code>.
+
+              <dt id="text.whitespace-nbsp">Whitespace excluding non-breaking spaces</dt>
+              <dd>Any text that matches the ECMAScript regular expression <code>[^\S\xa0]</code>
+
+              <dt id="text.blocklevel">Block level element</dt>
+              <dd>A block-level element is one which is not a table cell, and whose effective CSS display style is not in the set ['inline', 'inline-block', 'inline-table', 'none', 'table-cell', 'table-column', 'table-column-group']</dd>
+
+              <dt id="text.horizontal">Horizontal whitespace characters</dt>
+              <dd>Horizontal whitespace characters are defined by the ECMAScript regular expression <code>[\x20\t\u2028\u2029]</code>.</dd>
+             </dl>
+
+         <p>The expected return value is roughly what a text-only browser would display. The algorithm for determining this text is as follows:</p>
+
+         <p>Let <code>lines</code> equal an empty array. Then:
+         <ol>
+            <li>if the element is in the <code>head</code> element of the document, return an empty string otherwise carry on with the algorithm below.</li>
+             <li><span id="text.1">For</span> each descendent of node, at time of execution, in order:
+                 <ol>
+                     <li>Get whitespace, text-transform, and then, if descendent is:
+                         <ul>
+                             <li>a node which is not <a href="#determining-if-displayed">displayed</a>, do nothing</li>
+                             <li>a [[!DOM4]] <a href="http://www.w3.org/TR/2012/WD-dom-20120105/#interface-text">text node</a> let <code>text</code> equal the <code>nodeValue</code> property of descendent. Then:
+                                 <ol>
+                                     <li>Remove any zero-width spaces (\u200b, \u200e, \u200f), form feeds (\f) or vertical tab feeds (\v) from <code>text</code>.</li>
+                                     <li>Canonicalize any recognized single newline sequence in <code>text</code> to a single newline (greedily matching <code>(\r\n|\r|\n)</code> to a single \n)</li>
+                                     <li>If the parent's effective CSS whitespace style is 'normal' or 'nowrap' replace each newline (\n) in <code>text</code> with a single space character (\x20). If the parent's effective CSS whitespace style is 'pre' or 'pre-wrap' replace each <a href="#text.horizontal">horizontal whitespace character</a> with a non-breaking space character (\xa0). Otherwise replace each sequence of <a href="#text.horizontal">horizontal whitespace characters</a> except non-breaking spaces (\xa0) with a single space character</li>
+                                     <li>Apply the parent's effective CSS text-transform style as per the <a href="http://www.w3.org/TR/CSS21/text.html#propdef-text-transform">CSS 2.1 specification</a> ([[!CSS21]])</li>
+                                     <li>If <code>last(lines)</code> ends with a space character and <code>text</code> starts with a space character, trim the first character of <code>text</code>.</li>
+                                     <li>Append <code>text</code> to <code>last(lines)</code> in-place</li>
+                                 </ol>
+                             </li>
+                             <li>an element which is <a href="#determining-if-displayed">displayed</a>. If the element is a:
+                                 <ul>
+                                     <li>BR element: Push '' to <code>lines</code> and continue</li>
+                                     <li><a href="#text.blocklevel">Block-level</a> element and if <code>last(lines)</code> is not '', push '' to <code>lines</code>.</li>
+                                 </ul>
+                             And then recurse depth-first to <a href="#text.1">step 1</a> at the beginning of the algorithm with descendent set to the current element</li>
+                             <li>If element is a TD element, or the effective CSS display style is 'table-cell', and last(lines) is not '', and <code>last(lines)</code> does not end with whitespace append a single space character to <code>last(lines)</code> [Note: Most innerText implementations append a \t here]</li>
+                             <li>If element is a block-level element: push '' to <code>lines</code></li>
+                         </ul>
+                     </li>
+                 </ol>
+             </li>
+             <li>The string MUST then have the white space normalised as defined in the [[!XPATH]] <a href="http://www.w3.org/TR/xpath/#function-normalize-space">normalize-space function</a> which is then returned.</li>
+         </ol>
+         <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
+       </section>
+       <section>
+        <!-- getElementTagName() -->
+        <h3>getElementTagName()</h3>
+        <p>
+           <table class="simple jsoncommand">
+             <tr>
+               <th>HTTP Method</th>
+               <th>Path Template</th>
+               <th>Notes</th>
+             </tr>
+             <tr>
+               <td>GET</td>
+               <td id='get-id-displayed'>/session/{sessionId}/element/{ELEMENT}/name</td>
+               <td></td>
+             </tr>
+           </table>
+           <p>The "getElementTagName" command will return a <code>DOMString</code>
+            that is the <a href='http://www.w3.org/TR/DOM-Level-3-Core/glossary.html#dt-qualifiedname'>
+            qualified name</a> of the element.
+          <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document's <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
+       </section>
+       <section>
+        <h3>ElementRect getElementRect()</h3>
+        <p>
+         <table class="simple jsoncommand">
+           <tr>
+             <th>HTTP Method</th>
+             <th>Path Template</th>
+             <th>Notes</th>
+           </tr>
+           <tr>
+             <td>GET</td>
+             <td id='get-id-rect'>/session/{sessionId}/element/{ELEMENT}/rect</td>
+             <td></td>
+           </tr>
+         </table>
+
+        <p>The "getElementRect" command MUST return the <a>ElementRect</a> with:
+          <ul>
+            <li><code><a href='#widl-ElementRect-x'>x</a></code> and <code><a href='#widl-ElementRect-y'>y</a></code> represent the top left coordinates of the <a>WebElement</a> relative to top left corner of the document.
+            <li><code><a href='#widl-ElementRect-height'>height</a></code> and the <code><a href='#widl-ElementRect-width'>width</a></code> will contain the height and the width of the
+        <a href='http://dev.w3.org/fxtf/geometry/#dom-domrect'>DOMRect</a>
+        of the <a>WebElement</a>.
+          </ul>
+         <p>The point (0, 0) refers to the top left corner of the document.
+          <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
+      </section>
+      <section>
+        <h3>isEnabled()</h3>
+        <p>
+           <table class="simple jsoncommand">
+             <tr>
+               <th>HTTP Method</th>
+               <th>Path Template</th>
+               <th>Notes</th>
+             </tr>
+             <tr>
+               <td>GET</td>
+               <td id='get-id-enabled'>/session/{sessionId}/element/{ELEMENT}/enabled</td>
+               <td></td>
+             </tr>
+           </table>
+        <p>The "isEnabled" command MUST return false if all the following criteria are met otherwise return true:
+          <ul>
+            <li>A form control is <a href='http://www.w3.org/html/wg/drafts/html/master/forms.html#concept-fe-disabled'>disabled</a>
+            as described in [[!html51]].</li>
+            <li>A <a>WebElement</a> has a <code>disabled</code> <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#boolean-attribute">boolean attribute</a> as described in <a href='http://www.w3.org/html/wg/drafts/html/master/disabled-elements.html#disabled-elements'>disabled elements</a> of [[!html51]]</li>
+          </ul>
+
+        <p>If the <code><a href='widl-WebElement-ELEMENT'>ELEMENT</a></code> does not represent a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a>, or it represents a <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> that is no longer attached to the document <a href='http://w3c.github.io/dom/#concept-node-tree'>node tree</a>, then the WebDriver implementation MUST immediately abort the command and return a <code title="stale-element-reference"><a href="#status-stale-element-reference">stale element reference</a></code> error. If the <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> currently receiving commands is no longer open a <code><a href="#no-such-window">no such window</a></code> error MUST be raised.
+      </section>
+    </section>
+  </section>
+</section>
+<section>
+  <h2>Context of Commands</h2>
+
+  <p>Web applications can be composed of multiple <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> and/or frames. For a normal user, the context in which an operation is performed is obvious: it's the window or frame that currently has OS focus and which has just received user input. The WebDriver API does not follow this convention. There is an expectation that many browsers using the WebDriver API may be used at the same time on the same machine. This section describes how WebDriver tracks which window or frame is currently the context in which commands are being executed.</p>
+
+  <section>
+    <h2>Default Content</h2>
+
+    <p>WebDriver's <dfn id="default-content">default content</dfn> is [[!html51]]'s <a href="http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">top level browsing context</a> that is currently receiving WebDriver commands.</p>
+
+    <p>When a WebDriver instance is started and a single OS window is opened, the <a href="#default-content">default content</a> of that OS window is automatically selected for receiving further commands. If more than one OS window or multiple <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing contexts</a> are opened when the session starts, then the user MUST first select which <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> to act upon using the <code>switchToWindow</code> command. Until the user selects a <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a>, all commands must return a status code of <code><a href="#status-no-such-window">no such window</a></code>.</p>
+
+  </section>
+
+  <section>
+    <h2>Switching Windows</h2>
+
+    <section>
+      <h3>switchToWindow()</h3>
+        <dl class='parameters'>
+          <dt>DOMString handle</dt>
+          <dd>The identifier used for a <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a></dd>
+        </dl>
+        <p>
+          <table class="simple jsoncommand">
+            <tr>
+              <th>HTTP Method</th>
+              <th>Path Template</th>
+              <th>Notes</th>
+            </tr>
+            <tr>
+              <td>POST</td>
+              <td id='post-window'>/session/{sessionId}/window</td>
+              <td></td>
+            </tr>
+          </table>
+          <p>
+        <p>The "switchToWindow" command is used to select which <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> MUST be used as the context for processing commands. In order to determine which <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> should be used for accepting commands, the "switchToWindow" command MUST iterate over all <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> comparing the window handle.
+
+        <p>If no <a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing contexts</a> match, then a "<code><a href="#status-no-such-window">no such window</a></code>" status code MUST be returned, otherwise the "<a href="#default-content">default content</a>" of the first match will be selected for accepting commands.</p>
+
     </section>
   </section>
 
+  <section>
+    <h2>Switching Frames</h2>
+    <section>
+      <h3>switchToFrame()</h3>
+        <table class="simple jsoncommand">
+          <tr>
+            <th>HTTP Method</th>
+            <th>Path Template</th>
+            <th>Notes</th>
+          </tr>
+          <tr>
+            <td>POST</td>
+            <td id='post-frame'>/session/{sessionId}/frame</td>
+            <td></td>
+          </tr>
+        </table>
+        <dl class='parameters'>
+          <dt><a>WebElement</a> or unsigned short? id</dt>
+          <dd>The identifier used for a frame.</dd>
+        </dl>
+        <p>The "switchToFrame" command is used to select which frame which is a child of the<a href='http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context'>top level browsing context</a> MUST be used as the context for handling future commands. All frame switching is taken from the current context from which commands are currently being handled. The "<code>id</code>" parameter can be an unsigned short or a <a>WebElement</a>. WebDriver implementations MUST determine which frame to select using the following algorithm:
+
+        <ol>
+          <li>If the "id" is a unsigned short the current context is set to the equivalent of the JS expression "window.frames[id]" where "id" is the number and "window" is the Document window represented by the current context.</li>
+          <li>If the "id" is null, the current context is set to the <a href='#default-content'>default content</a>.</li>
+          <li>If the "id" represents a <a>WebElement</a>, and the corresponding <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> represents a FRAME or an IFRAME, and the <a>WebElement</a> is part of the current context, the "window" property of that <a href='http://w3c.github.io/dom/#element'>Document <code>element</code></a> becomes the current context.</li>
+        </ol>
+
+        <p>In all cases if no match is made a "<code><a href="#status-no-such-frame">no such frame</a></code>" status code MUST be returned.</p>
+
+        <p>If the indicated frame exists, frame switching MUST succeed even if doing so would violate the normal security constraints in place within the Javascript sandbox.</p>
+      </section>
+      <section>
+      <h3>switchToParentFrame()</h3>
+
+        <table class="simple jsoncommand">
+          <tr>
+            <th>HTTP Method</th>
+            <th>Path Template</th>
+            <th>Notes</th>
+          </tr>
+          <tr>
+            <td>POST</td>
+            <td id='post-frame-parent'>/session/{sessionId}/frame/parent</td>
+            <td></td>
+          </tr>
+        </table>
+        <p>The "switchToParentFrame" command MUST set the context of future commands to the <code>window.parent</code>. If the current context is the [[!html51]]'s <a href="http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">top level browsing context</a>, the context remains unchanged.</p>
+      </section>
+    </section>
+  </section>
+</section>
+<!DOCTYPE html>
+<html data-bug-blocked=20860
+      data-bug-product="Browser Test/Tools WG"
+      data-bug-component=WebDriver>
+  <head>
+    <title>WebDriver</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+
+    <style type="text/css">
+    /* --- WEB IDL --- */
+pre.IDL {
+    border-top: 1px solid #90b8de;
+    border-bottom: 1px solid #90b8de;
+    padding:    1em;
+    line-height:    120%;
+}
+
+pre.IDL::before {
+    content:    "WebIDL";
+    display:    block;
+    width:      150px;
+    background: #90b8de;
+    color:  #fff;
+    font-family:    initial;
+    padding:    3px;
+    font-weight:    bold;
+    margin: -1em 0 1em -1em;
+}
+
+code a:visited, code a:link {
+  color:  #ff4500;
+}
+
+     #respec-ui { top: 80px !important }
+    </style>
+
+    <!--
+      === NOTA BENE ===
+      For the three scripts below, if your spec resides on dev.w3 you can check them
+      out in the same tree and use relative links so that they'll work offline,
+     -->
+    <script src='respec-w3c-common.js' class='remove' async></script>
+    <script class='remove'>
+      var respecConfig = {
+          specStatus:           "ED",
+
+          shortName:            "webdriver",
+
+          // publishDate:  "2009-08-06",
+
+          // copyrightStart: "2005"
+
+          // previousPublishDate:  "1977-03-15",
+
+          // previousMaturity:  "WD",
+
+          edDraftURI:           "https://w3c.github.io/webdriver/webdriver-spec.html",
+
+          // lcEnd: "2009-08-05",
+
+          editors:  [
+              { name: "Simon Stewart", url: "http://www.rocketpoweredjetpants.com/",
+                company: "Facebook", companyURL: "http://www.facebook.com/"
+              },
+              { name: "David Burns", url: "http://www.theautomatedtester.co.uk/",
+                company: "Mozilla", companyURL: "http://www.mozilla.org/" },
+          ],
+
+          otherLinks: [{
+            key: "Raising issues with the specification",
+            data: [{
+                    value: "W3 Bug Tracker",
+                    href: "https://www.w3.org/Bugs/Public/enter_bug.cgi?comment=&blocked=20860&short_desc=[WebDriver%20Spec]%3A%20&product=Browser%20Test%2FTools%20WG&component=WebDriver"
+                  }]
+          }],
+
+          wg:           "Browser Testing and Tools Working Group",
+
+          wgURI:        "http://www.w3.org/testing/browser/",
+
+          wgPublicList: "public-browser-tools-testing",
+
+          wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/49799/status",
+
+          noIDLSorting: true,
+      };
+    </script>
+    <script src=bug-assist.js></script>
+  </head>
+  <body>
+
+<section id="abstract">
+<p>This specification defines the WebDriver API, a platform and language-neutral interface and associated wire protocol that allows programs or scripts to introspect into, and control the behaviour of, a web browser. The WebDriver API is primarily intended to allow developers to write tests that automate a browser from a separate controlling process, but may also be implemented in such a way as to allow in-browser scripts to control a &mdash; possibly separate &mdash; browser.</p>
+
+<p>The WebDriver API is defined by a wire protocol and a set of interfaces to discover and manipulate DOM elements on a page, and to control the behaviour of the containing browser.</p>
+
+<p>This specification also includes a normative reference serialisation (to JSON over HTTP) of the interface's invocations and responses that are to be used by browser vendors to ensure interoperability.</p>
+</section>
+
+<section id="sotd">
+<p>If you wish to make comments regarding this document, please email feedback to <a href="mailto:public-browser-tools-testing@w3.org">public-browser-tools-testing@w3.org</a>. All feedback is welcome, and the editors will read and consider all feedback.</p>
+
+<p>This specification is still under active development and may not be stable. Any implementors who are not actively participating in the preparation of this specification may find unexpected changes occurring. It is suggested that any implementors join the WG for this specification. Despite not being stable, it should be noted that this specification is strongly based on an existing Open Source project &mdash; <a href="http://selenium.googlecode.com/">Selenium WebDriver</a> &mdash; and the existing implementations of the API defined within that project.</p>
+</section>
 <section class='appendix'>
   <h2>Capabilities</h2>
 


### PR DESCRIPTION
* Adds Firefox OS to list of operating systems allowed in the `platformName` capability.
* Removes the suggestions to omit the `-` character when extending `platformName` with non-standardised OSes because how you choose to implement an enum in a programming language is no business of the specification and we should leave this as an exercise for the reader.

Let's keep it simple.