### PR TITLE
Harmonise titles for commands on elements

### DIFF
--- a/02_commands.html
+++ b/02_commands.html
@@ -144,10 +144,11 @@
   </section>
 
   <section>
-    <h3>List of endpoints</h3>
-    <p>The following <dfn>table of endpoints</dfn> lists the method, URL and command for each WebDriver command.</p>
+    <h3>List of Endpoints</h3>
+    <p>The following <dfn>table of endpoints</dfn> lists the method,
+     URL, and command for each WebDriver command.
 
-    <table class="simple">
+    <table class=simple>
       <tr>
         <th>Method</th>
         <th>URL</th>
@@ -251,12 +252,12 @@
       <tr>
         <td>GET</td>
         <td>/session/{sessionId}/element/{elementId}/displayed</td>
-        <td><a>Is Displayed</a></td>
+        <td><a>Is Element Displayed</a></td>
       </tr>
       <tr>
         <td>GET</td>
         <td>/session/{sessionId}/element/{elementId}/selected</td>
-        <td><a>Is Selected</a></td>
+        <td><a>Is Element Selected</a></td>
       </tr>
       <tr>
         <td>GET</td>
@@ -266,7 +267,7 @@
       <tr>
         <td>GET</td>
         <td>/session/{sessionId}/element/{elementId}/css/{propertyName}</td>
-        <td><a>Get CSS Value</a></td>
+        <td><a>Get Element CSS Value</a></td>
       </tr>
       <tr>
         <td>GET</td>
@@ -286,7 +287,7 @@
       <tr>
         <td>GET</td>
         <td>/session/{sessionId}/element/{elementId}/enabled</td>
-        <td><a>Is Enabled</a></td>
+        <td><a>Is Element Enabled</a></td>
       </tr>
       <tr>
         <td>POST</td>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -324,10 +324,11 @@ code a:visited, code a:link {
   </section>
 
   <section>
-    <h3>List of endpoints</h3>
-    <p>The following <dfn>table of endpoints</dfn> lists the method, URL and command for each WebDriver command.</p>
+    <h3>List of Endpoints</h3>
+    <p>The following <dfn>table of endpoints</dfn> lists the method,
+     URL, and command for each WebDriver command.
 
-    <table class="simple">
+    <table class=simple>
       <tr>
         <th>Method</th>
         <th>URL</th>
@@ -431,12 +432,12 @@ code a:visited, code a:link {
       <tr>
         <td>GET</td>
         <td>/session/{sessionId}/element/{elementId}/displayed</td>
-        <td><a>Is Displayed</a></td>
+        <td><a>Is Element Displayed</a></td>
       </tr>
       <tr>
         <td>GET</td>
         <td>/session/{sessionId}/element/{elementId}/selected</td>
-        <td><a>Is Selected</a></td>
+        <td><a>Is Element Selected</a></td>
       </tr>
       <tr>
         <td>GET</td>
@@ -446,7 +447,7 @@ code a:visited, code a:link {
       <tr>
         <td>GET</td>
         <td>/session/{sessionId}/element/{elementId}/css/{propertyName}</td>
-        <td><a>Get CSS Value</a></td>
+        <td><a>Get Element CSS Value</a></td>
       </tr>
       <tr>
         <td>GET</td>
@@ -466,7 +467,7 @@ code a:visited, code a:link {
       <tr>
         <td>GET</td>
         <td>/session/{sessionId}/element/{elementId}/enabled</td>
-        <td><a>Is Enabled</a></td>
+        <td><a>Is Element Enabled</a></td>
       </tr>
       <tr>
         <td>POST</td>


### PR DESCRIPTION
Most commands related to elements use the word “element” in the title
to indicate that the operation they perform happen on the element.

This patch updates the following command titles:

Is Displayed -> Is Element Displayed
Is Selected -> Is Element Selected
Get CSS Value -> Get Element CSS Value
Is Enabled -> Is Element Enabled