### PR TITLE
Fix current top-level browsing context

### DIFF
--- a/04_sessions.html
+++ b/04_sessions.html
@@ -60,11 +60,12 @@
  will run.</p>
 
 <p>A <a>session</a> has an associated
- <dfn>current top level browsing context</dfn>,
+ <dfn>current top-level browsing context</dfn>,
  which is the <a>current browsing context</a> if it itself is a
  <a href=http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context>top-level browsing context</a>,
  or the top-level browsing context for which
- the <a>current browsing context</a> is an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor browsing context</a>.
+ the <a>current browsing context</a>
+ is an <a href=https://html.spec.whatwg.org/#ancestor-browsing-context>ancestor browsing context</a>.
 
 <p>The top-level browsing context is said to be <dfn>no longer open</dfn>
  if it has been <a href=https://html.spec.whatwg.org/#a-browsing-context-is-discarded>discarded</a>.

--- a/05_navigation.html
+++ b/05_navigation.html
@@ -53,10 +53,10 @@
 
     <p>The <a>remote end steps</a> for the <a>get</a> command are:</p>
     <ol>
-      <li><p>If the <a>current top level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
+      <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
       <li><p>Let <var>url</var> be the result of <a>getting a property</a> named "url" from the <var>parameters</var> argument.</p></li>
       <li><p>If <var>url</var> is undefined, return an <a>error</a> with code <a>invalid argument</a></p></li>
-      <li><p><a href="">Navigate</a> the <a>current top level browsing context</a>'s to <var>url</var>. If this navigation results in a HTTP 401 response, the <a>remote end</a> must proceed with the steps below, irrespective of how the authentication challenge is handled.</p></li>
+      <li><p><a href="">Navigate</a> the <a>current top-level browsing context</a>'s to <var>url</var>. If this navigation results in a HTTP 401 response, the <a>remote end</a> must proceed with the steps below, irrespective of how the authentication challenge is handled.</p></li>
       <li><p>If the <a>current session</a>'s <a>page load strategy</a> is <a>none</a> jump to the next step in this overall set of steps. Otherwise:</p>
         <ol>
           <li><p>Let <var>readiness target</var> be <code>"interactive"</code> if the <a>current session</a>'s <a>page load strategy is <a>eager</a>, or <code>"complete"</code> if it is <a>normal</a>.</p></li>
@@ -85,11 +85,11 @@
             <td></td>
           </tr>
         </table>
-        <p>The <dfn>getCurrentUrl</dfn> command returns the url of the <a>current top level browsing context</a>
+        <p>The <dfn>getCurrentUrl</dfn> command returns the url of the <a>current top-level browsing context</a>
         <p>The <a>remote end steps</a> for the <a>getCurrentUrl</a> command are:</p>
         <ol>
-          <li><p>If the <a>current top level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
-          <li><p>Let <var>url</var> be the <a href="https://url.spec.whatwg.org/#concept-url-serializer">serialization</a> of the <a>current top level browsing context</a>'s <a href="https://html.spec.whatwg.org/#active-document">active document</a>'s <a href="https://dom.spec.whatwg.org/#concept-document-url">url</a>.</p></li>
+          <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
+          <li><p>Let <var>url</var> be the <a href="https://url.spec.whatwg.org/#concept-url-serializer">serialization</a> of the <a>current top-level browsing context</a>'s <a href="https://html.spec.whatwg.org/#active-document">active document</a>'s <a href="https://dom.spec.whatwg.org/#concept-document-url">url</a>.</p></li>
           <li><p>Let <var>data</var> be a <a>new JSON Object</a>.</p>
           <li><p><a>Set the properties</a> of <var>data</var> with values ("value", <var>url</var>)</p></li>
           <li><p>Return <a>success</a> with data <var>data</var></p></li>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -802,11 +802,12 @@ code a:visited, code a:link {
  will run.</p>
 
 <p>A <a>session</a> has an associated
- <dfn>current top level browsing context</dfn>,
+ <dfn>current top-level browsing context</dfn>,
  which is the <a>current browsing context</a> if it itself is a
  <a href=http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context>top-level browsing context</a>,
  or the top-level browsing context for which
- the <a>current browsing context</a> is an <a href="https://html.spec.whatwg.org/#ancestor-browsing-context">ancestor browsing context</a>.
+ the <a>current browsing context</a>
+ is an <a href=https://html.spec.whatwg.org/#ancestor-browsing-context>ancestor browsing context</a>.
 
 <p>The top-level browsing context is said to be <dfn>no longer open</dfn>
  if it has been <a href=https://html.spec.whatwg.org/#a-browsing-context-is-discarded>discarded</a>.
@@ -1027,10 +1028,10 @@ code a:visited, code a:link {
 
     <p>The <a>remote end steps</a> for the <a>get</a> command are:</p>
     <ol>
-      <li><p>If the <a>current top level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
+      <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
       <li><p>Let <var>url</var> be the result of <a>getting a property</a> named "url" from the <var>parameters</var> argument.</p></li>
       <li><p>If <var>url</var> is undefined, return an <a>error</a> with code <a>invalid argument</a></p></li>
-      <li><p><a href="">Navigate</a> the <a>current top level browsing context</a>'s to <var>url</var>. If this navigation results in a HTTP 401 response, the <a>remote end</a> must proceed with the steps below, irrespective of how the authentication challenge is handled.</p></li>
+      <li><p><a href="">Navigate</a> the <a>current top-level browsing context</a>'s to <var>url</var>. If this navigation results in a HTTP 401 response, the <a>remote end</a> must proceed with the steps below, irrespective of how the authentication challenge is handled.</p></li>
       <li><p>If the <a>current session</a>'s <a>page load strategy</a> is <a>none</a> jump to the next step in this overall set of steps. Otherwise:</p>
         <ol>
           <li><p>Let <var>readiness target</var> be <code>"interactive"</code> if the <a>current session</a>'s <a>page load strategy is <a>eager</a>, or <code>"complete"</code> if it is <a>normal</a>.</p></li>
@@ -1059,11 +1060,11 @@ code a:visited, code a:link {
             <td></td>
           </tr>
         </table>
-        <p>The <dfn>getCurrentUrl</dfn> command returns the url of the <a>current top level browsing context</a>
+        <p>The <dfn>getCurrentUrl</dfn> command returns the url of the <a>current top-level browsing context</a>
         <p>The <a>remote end steps</a> for the <a>getCurrentUrl</a> command are:</p>
         <ol>
-          <li><p>If the <a>current top level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
-          <li><p>Let <var>url</var> be the <a href="https://url.spec.whatwg.org/#concept-url-serializer">serialization</a> of the <a>current top level browsing context</a>'s <a href="https://html.spec.whatwg.org/#active-document">active document</a>'s <a href="https://dom.spec.whatwg.org/#concept-document-url">url</a>.</p></li>
+          <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>, return an error with code <a>no such window</a>.</p></li>
+          <li><p>Let <var>url</var> be the <a href="https://url.spec.whatwg.org/#concept-url-serializer">serialization</a> of the <a>current top-level browsing context</a>'s <a href="https://html.spec.whatwg.org/#active-document">active document</a>'s <a href="https://dom.spec.whatwg.org/#concept-document-url">url</a>.</p></li>
           <li><p>Let <var>data</var> be a <a>new JSON Object</a>.</p>
           <li><p><a>Set the properties</a> of <var>data</var> with values ("value", <var>url</var>)</p></li>
           <li><p>Return <a>success</a> with data <var>data</var></p></li>


### PR DESCRIPTION
When HTML refers to “top-level browsing context” (with hyphen) we
should too.