### PR TITLE
Rename command Close to Close Window

### DIFF
--- a/02_commands.html
+++ b/02_commands.html
@@ -206,7 +206,7 @@
       <tr>
         <td>DELETE</td>
         <td>/session/{sessionId}/window_handle</td>
-        <td><a>Close</a></td>
+        <td><a>Close Window</a></td>
       </tr>
       <tr>
         <td>POST</td>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -386,7 +386,7 @@ code a:visited, code a:link {
       <tr>
         <td>DELETE</td>
         <td>/session/{sessionId}/window_handle</td>
-        <td><a>Close</a></td>
+        <td><a>Close Window</a></td>
       </tr>
       <tr>
         <td>POST</td>


### PR DESCRIPTION
Gives a nicer consistency because it's not obvious what “Close” by itself means.  This matches the other window control command names.