### PR TITLE
Avoid redefinition of "script timeout"

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -941,16 +941,16 @@ code a:visited, code a:link {
 <p>Each top-level browsing context has an associated <dfn>window handle</dfn>, which is a string uniquely identifying that browsing context. This string is implementation defined but must not be "current".</p>
 
 <!-- TODO(ato): https://www.w3.org/Bugs/Public/show_bug.cgi?id=28005 -->
-<p>A <a>session</a> has an associated <dfn>script timeout</dfn>
+<p>A <a>session</a> has an associated <dfn>script timeout duration</dfn>
  that specifies a time to wait for scripts to run.
  Unless stated otherwise it is 30,000 milliseconds.
 
 <!-- TODO(ato): https://www.w3.org/Bugs/Public/show_bug.cgi?id=28004 -->
-<p>A <a>session</a> has an associated <dfn>page load timeout</dfn>
+<p>A <a>session</a> has an associated <dfn>page load timeout duration</dfn>
  that specifies a time to wait for the page loading to complete.
  Unless stated otherwise it is 300,000 milliseconds.
 
-<p>A <a>session</a> has an associated <dfn>implicit wait timeout</dfn>
+<p>A <a>session</a> has an associated <dfn>implicit wait timeout duration</dfn>
  that specifies a time to wait for the <a>implicit element location strategy</a>
  when locating elements using <a href=#findelement>find element</a>
  and <a href=#findelements>find elements</a>.
@@ -1055,17 +1055,17 @@ associated browser process to be killed</p>.
           <ul>
             <li>
               <p>
-                Set <a>script timeout<a> equal to 30000 milliseconds.
+                Set <a>script timeout duration<a> equal to 30,000 milliseconds.
               </p>
             </li>
             <li>
               <p>
-                Set <a>page load timeout</a> equal to 300000 milliseconds.
+                Set <a>page load timeout duration</a> equal to 300,000 milliseconds.
               </p>
             </li>
             <li>
               <p>
-                Set <a>implicit wait timeout</a> equal to 0 (zero) milliseconds.
+                Set <a>implicit wait timeout duration</a> equal to 0 (zero) milliseconds.
               </p>
             </li>
             <li>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -941,16 +941,16 @@ code a:visited, code a:link {
 <p>Each top-level browsing context has an associated <dfn>window handle</dfn>, which is a string uniquely identifying that browsing context. This string is implementation defined but must not be "current".</p>
 
 <!-- TODO(ato): https://www.w3.org/Bugs/Public/show_bug.cgi?id=28005 -->
-<p>A <a>session</a> has an associated <dfn>script timeout duration</dfn>
+<p>A <a>session</a> has an associated <dfn>session script timeout</dfn>
  that specifies a time to wait for scripts to run.
  Unless stated otherwise it is 30,000 milliseconds.
 
 <!-- TODO(ato): https://www.w3.org/Bugs/Public/show_bug.cgi?id=28004 -->
-<p>A <a>session</a> has an associated <dfn>page load timeout duration</dfn>
+<p>A <a>session</a> has an associated <dfn>session page load timeout</dfn>
  that specifies a time to wait for the page loading to complete.
  Unless stated otherwise it is 300,000 milliseconds.
 
-<p>A <a>session</a> has an associated <dfn>implicit wait timeout duration</dfn>
+<p>A <a>session</a> has an associated <dfn>session implicit wait timeout</dfn>
  that specifies a time to wait for the <a>implicit element location strategy</a>
  when locating elements using <a href=#findelement>find element</a>
  and <a href=#findelements>find elements</a>.
@@ -1055,17 +1055,17 @@ associated browser process to be killed</p>.
           <ul>
             <li>
               <p>
-                Set <a>script timeout duration<a> equal to 30,000 milliseconds.
+                Set <a>session script timeout<a> equal to 30,000 milliseconds.
               </p>
             </li>
             <li>
               <p>
-                Set <a>page load timeout duration</a> equal to 300,000 milliseconds.
+                Set <a>session page load timeout</a> equal to 300,000 milliseconds.
               </p>
             </li>
             <li>
               <p>
-                Set <a>implicit wait timeout duration</a> equal to 0 (zero) milliseconds.
+                Set <a>session implicit wait timeout</a> equal to 0 (zero) milliseconds.
               </p>
             </li>
             <li>


### PR DESCRIPTION
"script timeout" was defined twice, as both an error and an associated
state to a session.