### PR TITLE
Remove status code handling on the local end

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -734,18 +734,6 @@ code a:visited, code a:link {
       </tr>
     </table>
   </section>
-
-  <section>
-    <h2>Handling of Status Codes at the Local End</h2>
-
-    <p>Status codes are returned from the <a href="#remote-end">remote end</a> to the <a href="#local-end">local end</a>. The <a href="#local-end">local end</a> SHOULD convert these into a form appropriate for the implementation language. For example, in C the status codes might be converted to constant integer values, whereas in Java various exceptions could be thrown.</p>
-
-    <p>Implementations of the <a href="#local-end">local end</a> written in languages that support exceptions SHOULD make use of an exception hierarchy rooted on a <code>WebDriverException</code> (or similarly named base exception class). Where references to <code>WebDriverException</code> are made in this specification, we are referring to this local end conversion of status codes to local end exceptions.</p>
-
-    <p class="note">The reason for this is to allow users of the local end to easily handle the all expected failure modes of a local WebDriver implementation by catching the <code>WebDriverException</code>.</p>
-
-     <p class="note">It is strongly recommended that the <code>WebDriverException</code> contain as much diagnostic information as possible, including version numbers and details about the remote end. This is because experience suggests that when reporting errors from tests using WebDriver, users will simply cut-and-paste a stack trace of an exception. Adding this information to the exception makes the task of debugging problems considerably easier.</p>
-  </section>
 </section>
 
 <section>


### PR DESCRIPTION
We decided not to talk so much about what the local end’s responsibilities are, as this is out of scope of the WebDriver implementations.  How the local ends choose to implement errors are entirely up to them.