### PR TITLE
Remove string quote marks in validated file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: validate
 validate: webdriver-spec.html
-	curl -s -F laxtype=yes -F parser=html5 -F level=error -F out=gnu -F doc=@$< https://validator.nu
+	curl -s -F laxtype=yes -F parser=html5 -F level=error -F out=gnu -F doc=@$< https://validator.nu | sed -e 's/"//g'


### PR DESCRIPTION
The string message from validator.nu that follows uses “ and ” so this should be fine.  Unfortunately BSD sed does not support the 2g flag that GNU sed does to specify the number of instances to replace.