### PR TITLE
Is Element Displayed: correct retrieval of element

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2967,7 +2967,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
 </table>
 
-<p>The <dfn>Is Element Displayed</dfn> command
+<p>The <dfn>Is Element Displayed</dfn> <a>command</a>
  is used to determine the <a title="element displayed">element displayedness</a>
  of a <a>web element</a>.
 
@@ -2977,30 +2977,26 @@ URL, and command for each WebDriver <a>command</a>.
  <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
- <li><p>Let <var>visible</var> be a boolean initially set to
-  false.
+ <li><p>Let <var>visible</var> be a boolean initially set to false.
 
- <li><p><a>Deserialise the web element</a> from <var>parameters</var>,
-  and let it be known as <var>web element result</var>.
+ <li><p>Let <var>element result</var> be the result of
+  <a>getting a known element</a> by parameter <var>element id</var>.
 
- <li><p>If <var>web element result</var> is an <a>error</a>,
-  return it with its error code.
+ <li><p>If <var>element result</var> is a <a>success</a>,
+  let <var>element</var> be <var>element result</var>’s data.
 
- <li><p>Let <var>web element</var> be <var>web element result</var>’s data.
+  <p>Otherwise, return <var>element result</var>.
 
- <li><p>If <var>web element</var> <a>is stale</a>,
+ <li><p>If <var>element</var> <a>is stale</a>,
   return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
 
  <li><p>Apply the <a>element displayed</a> algorithm to
   <var>element</var> and set <var>visible</var> to its
   return value.
 
- <li><p>Let <var>body</var> be a new JSON Object initialised with:
-
-  <dl>
-   <dt>"<code>value</code>"
-   <dd>The value of <var>visible</var>.
-  </dl>
+ <li><p>Let <var>body</var> be a new JSON Object
+  with the "<code>value</code>" member
+  set to <var>element displayed</var>.
 
  <li><p>Return <a>success</a> with data <var>body</var>.
 </ol>


### PR DESCRIPTION
The command is being passed an element reference, not a web element
object.  Thus it needs to use the `getting a known element` algorithm
rather than the deserialisation algorithm it was using prior to this
patch.