### PR TITLE
Set up automatic publication with Travis & Echidna

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,13 @@
 language: c
 script: ./validate
 sudo: false
+branches:
+  only:
+    - gh-pages
+env:
+  global:
+    - URL="https://w3c.github.io/webdriver/echidna-manifest.txt"
+    - DECISION="[TO-DO]"
+    - secure: "[TO-DO run: 'gem install travis; travis encrypt TOKEN=<the-token>']"
+after_success:
+  - curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"

--- a/echidna-manifest.txt
+++ b/echidna-manifest.txt
@@ -1,0 +1,3 @@
+# Manifest file for Echidna (automatic publication).
+# [TO-DO: add all necessary files here if there are more -- one per line after the main one.]
+webdriver-spec.html?specStatus=WD;shortName=webdriver respec

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -73,10 +73,13 @@ code a:visited, code a:link {
 
           editors:  [
               { name: "Simon Stewart", url: "http://www.rocketpoweredjetpants.com/",
-                company: "Facebook", companyURL: "http://www.facebook.com/"
+                company: "Facebook", companyURL: "http://www.facebook.com/",
+                w3cid: "50228"
               },
               { name: "David Burns", url: "http://www.theautomatedtester.co.uk/",
-                company: "Mozilla", companyURL: "http://www.mozilla.org/" },
+                company: "Mozilla", companyURL: "http://www.mozilla.org/",
+                w3cid: "50184"
+              }
           ],
 
           otherLinks: [{


### PR DESCRIPTION
Only 3 things left (find 3 instances of `TO-DO` in my changes):

1. Enter the URL to the group's decision to publish.
2. Encrypt the token with Travis and paste the resulting string in `.travis.yml` ([instructions](https://github.com/w3c/echidna/wiki/Setting-up-Echidna-as-a-GitHub-hook)).
3. (Only if the spec is made up of more files than the index HTML) list all those files in `echidna-manifest.txt`.