### PR TITLE
Match template variables to variable names used in algorithms

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -499,264 +499,264 @@ URL, and command for each WebDriver <a>command</a>.
 
  <tr>
   <td>DELETE</td>
-  <td>/session/{sessionId}</td>
+  <td>/session/{session id}</td>
   <td><a>Delete Session</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/url</td>
+  <td>/session/{session id}/url</td>
   <td><a>Get</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/url</td>
+  <td>/session/{session id}/url</td>
   <td><a>Get Current Url</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/back</td>
+  <td>/session/{session id}/back</td>
   <td><a>Back</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/forward</td>
+  <td>/session/{session id}/forward</td>
   <td><a>Forward</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/refresh</td>
+  <td>/session/{session id}/refresh</td>
   <td><a>Refresh</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/title</td>
+  <td>/session/{session id}/title</td>
   <td><a>Get Title</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/window/handle</td>
+  <td>/session/{session id}/window/handle</td>
   <td><a>Get Window Handle</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/window/handles</td>
+  <td>/session/{session id}/window/handles</td>
   <td><a>Get Window Handles</a></td>
  </tr>
 
  <tr>
   <td>DELETE</td>
-  <td>/session/{sessionId}/window</td>
+  <td>/session/{session id}/window</td>
   <td><a>Close Window</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/window/size</td>
+  <td>/session/{session id}/window/size</td>
   <td><a>Set Window Size</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/window/size</td>
+  <td>/session/{session id}/window/size</td>
   <td><a>Get Window Size</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/window/maximize</td>
+  <td>/session/{session id}/window/maximize</td>
   <td><a>Maximize Window</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/window/fullscreen</td>
+  <td>/session/{session id}/window/fullscreen</td>
   <td><a>Fullscreen Window</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/window</td>
+  <td>/session/{session id}/window</td>
   <td><a>Switch To Window</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/frame</td>
+  <td>/session/{session id}/frame</td>
   <td><a>Switch To Frame</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/frame/parent</td>
+  <td>/session/{session id}/frame/parent</td>
   <td><a>Switch To Parent Frame</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/element</td>
+  <td>/session/{session id}/element</td>
   <td><a>Find Element</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/elements</td>
+  <td>/session/{session id}/elements</td>
   <td><a>Find Elements</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/displayed</td>
+  <td>/session/{session id}/element/{element id}/displayed</td>
   <td><a>Is Element Displayed</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/selected</td>
+  <td>/session/{session id}/element/{element id}/selected</td>
   <td><a>Is Element Selected</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/attribute/{name}</td>
+  <td>/session/{session id}/element/{element id}/attribute/{name}</td>
   <td><a>Get Element Attribute</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/css/{propertyName}</td>
+  <td>/session/{session id}/element/{element id}/css/{property name}</td>
   <td><a>Get Element CSS Value</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/text</td>
+  <td>/session/{session id}/element/{element id}/text</td>
   <td><a>Get Element Text</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/name</td>
+  <td>/session/{session id}/element/{element id}/name</td>
   <td><a>Get Element Tag Name</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/rect</td>
+  <td>/session/{session id}/element/{element id}/rect</td>
   <td><a>Get Element Rect</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/enabled</td>
+  <td>/session/{session id}/element/{element id}/enabled</td>
   <td><a>Is Element Enabled</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/execute</td>
+  <td>/session/{session id}/execute</td>
   <td><a>Execute Script</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/execute_async</td>
+  <td>/session/{session id}/execute_async</td>
   <td><a>Execute Async Script</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/cookie/{name}</td>
+  <td>/session/{session id}/cookie/{name}</td>
   <td><a>Get Cookie</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/cookie</td>
+  <td>/session/{session id}/cookie</td>
   <td><a>Add Cookie</a></td>
  </tr>
 
  <tr>
   <td>DELETE</td>
-  <td>/session/{sessionId}/cookie/{name}</td>
+  <td>/session/{session id}/cookie/{name}</td>
   <td><a>Delete Cookie</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/timeouts</td>
+  <td>/session/{session id}/timeouts</td>
   <td><a>Set Timeout</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/actions</td>
+  <td>/session/{session id}/actions</td>
   <td><a>Actions</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/element/{elementId}/click</td>
+  <td>/session/{session id}/element/{element id}/click</td>
   <td><a>Element Click</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/element/{elementId}/tap</td>
+  <td>/session/{session id}/element/{element id}/tap</td>
   <td><a>Element Tap</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/element/{elementId}/clear</td>
+  <td>/session/{session id}/element/{element id}/clear</td>
   <td><a>Element Clear</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/element/{elementId}/sendKeys</td>
+  <td>/session/{session id}/element/{element id}/sendKeys</td>
   <td><a>Element Send Keys</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/dismiss_alert</td>
+  <td>/session/{session id}/dismiss_alert</td>
   <td><a>Dismiss Alert</a></td>
  </tr>
 
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/alert/accept</td>
+  <td>/session/{session id}/alert/accept</td>
   <td><a>Accept Alert</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/alert/text</td>
+  <td>/session/{session id}/alert/text</td>
   <td><a>Get Alert Text</a></td>
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/alert/text</td>
+  <td>/session/{session id}/alert/text</td>
   <td><a>Send Alert Text</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/screenshot</td>
+  <td>/session/{session id}/screenshot</td>
   <td><a>Take Screenshot</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/screenshot</td>
+  <td>/session/{session id}/element/{element id}/screenshot</td>
   <td><a>Take Element Screenshot</a></td>
  </tr>
 </table>
@@ -1345,7 +1345,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>DELETE</td>
-  <td>/session/{sessionId}</td>
+  <td>/session/{session id}</td>
  </tr>
 </table>
 
@@ -1374,7 +1374,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/timeouts</td>
+  <td>/session/{session id}/timeouts</td>
  </tr>
 </table>
 
@@ -1471,7 +1471,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>POST</td>
-  <td id=post-url>/session/{sessionId}/url</td>
+  <td id=post-url>/session/{session id}/url</td>
  </tr>
 </table>
 
@@ -1557,7 +1557,7 @@ URL, and command for each WebDriver <a>command</a>.
           </tr>
           <tr>
             <td>GET</td>
-            <td>/session/{sessionId}/url</td>
+            <td>/session/{session id}/url</td>
           </tr>
         </table>
         <p>The <dfn>Get Current Url</dfn> command returns the url of
@@ -1593,7 +1593,7 @@ URL, and command for each WebDriver <a>command</a>.
           </tr>
           <tr>
             <td>POST</td>
-            <td>/session/{sessionId}/back</td>
+            <td>/session/{session id}/back</td>
           </tr>
         </table>
 
@@ -1646,7 +1646,7 @@ URL, and command for each WebDriver <a>command</a>.
           </tr>
           <tr>
             <td>POST</td>
-            <td>/session/{sessionId}/forward</td>
+            <td>/session/{session id}/forward</td>
           </tr>
         </table>
         <p>The <dfn>Forward</dfn> command causes the browser to traverse
@@ -1697,7 +1697,7 @@ URL, and command for each WebDriver <a>command</a>.
           </tr>
           <tr>
             <td>POST</td>
-            <td>/session/{sessionId}/refresh</td>
+            <td>/session/{session id}/refresh</td>
           </tr>
         </table>
 
@@ -1756,7 +1756,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/title</td>
+  <td>/session/{session id}/title</td>
  </tr>
 </table>
 
@@ -1835,7 +1835,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/window_handle</td>
+  <td>/session/{session id}/window_handle</td>
  </tr>
 </table>
 
@@ -1870,7 +1870,7 @@ URL, and command for each WebDriver <a>command</a>.
          </tr>
          <tr>
            <td>GET</td>
-           <td>/session/{sessionId}/window_handles</td>
+           <td>/session/{session id}/window_handles</td>
          </tr>
        </table>
 
@@ -1910,7 +1910,7 @@ URL, and command for each WebDriver <a>command</a>.
   </tr>
   <tr>
     <td>POST</td>
-    <td>/session/{sessionId}/window</td>
+    <td>/session/{session id}/window</td>
   </tr>
 </table>
 
@@ -1947,7 +1947,7 @@ URL, and command for each WebDriver <a>command</a>.
          </tr>
          <tr>
            <td>DELETE</td>
-           <td>/session/{sessionId}/window</td>
+           <td>/session/{session id}/window</td>
          </tr>
        </table>
 
@@ -1977,7 +1977,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/frame</td>
+  <td>/session/{session id}/frame</td>
  </tr>
 </table>
 
@@ -2074,7 +2074,7 @@ URL, and command for each WebDriver <a>command</a>.
        </tr>
        <tr>
          <td>POST</td>
-         <td>/session/{sessionId}/frame/parent</td>
+         <td>/session/{session id}/frame/parent</td>
        </tr>
      </table>
      <p>The <a>Switch to Parent Frame</a> command sets the <a>current
@@ -2117,7 +2117,7 @@ URL, and command for each WebDriver <a>command</a>.
             </tr>
             <tr>
               <td>GET</td>
-              <td>/session/{sessionId}/window/size</td>
+              <td>/session/{session id}/window/size</td>
             </tr>
           </table>
         <p>The Get Window Size command returns the size of the
@@ -2168,7 +2168,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/window/size</td>
+  <td>/session/{session id}/window/size</td>
  </tr>
 </table>
 
@@ -2237,7 +2237,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/window/maximize</td>
+  <td>/session/{session id}/window/maximize</td>
  </tr>
 </table>
 
@@ -2277,7 +2277,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/window/fullscreen</td>
+  <td>/session/{session id}/window/fullscreen</td>
  </tr>
 </table>
 
@@ -2475,7 +2475,7 @@ URL, and command for each WebDriver <a>command</a>.
           </tr>
           <tr>
             <td>POST</td>
-            <td>/session/{sessionId}/elements</td>
+            <td>/session/{session id}/elements</td>
           </tr>
         </table>
         <ol>
@@ -2504,7 +2504,7 @@ URL, and command for each WebDriver <a>command</a>.
           </tr>
           <tr>
             <td>POST</td>
-            <td>/session/{sessionId}/element/{elementId}/elements</td>
+            <td>/session/{session id}/element/{element id}/elements</td>
           </tr>
         </table>
         <ol>
@@ -2535,7 +2535,7 @@ URL, and command for each WebDriver <a>command</a>.
           </tr>
           <tr>
             <td>POST</td>
-            <td>/session/{sessionId}/element</td>
+            <td>/session/{session id}/element</td>
           </tr>
         </table>
         <ol>
@@ -2572,7 +2572,7 @@ URL, and command for each WebDriver <a>command</a>.
           </tr>
           <tr>
             <td>POST</td>
-            <td>/session/{sessionId}/element/{elementId}/element</td>
+            <td>/session/{session id}/element/{element id}/element</td>
           </tr>
         </table>
         <ol>
@@ -2613,7 +2613,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/active</td>
+  <td>/session/{session id}/element/active</td>
  </tr>
 </table>
 
@@ -2974,7 +2974,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/displayed</td>
+  <td>/session/{session id}/element/{element id}/displayed</td>
  </tr>
 </table>
 
@@ -3023,7 +3023,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/selected</td>
+  <td>/session/{session id}/element/{element id}/selected</td>
  </tr>
 </table>
 
@@ -3091,7 +3091,7 @@ URL, and command for each WebDriver <a>command</a>.
             </tr>
             <tr>
               <td>GET</td>
-              <td>/session/{sessionId}/element/{elementId}/attribute/{name}</td>
+              <td>/session/{session id}/element/{element id}/attribute/{name}</td>
             </tr>
           </table>
           <div class="note">
@@ -3147,7 +3147,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/css/{propertyName}</td>
+  <td>/session/{session id}/element/{element id}/css/{property name}</td>
  </tr>
 </table>
 
@@ -3195,7 +3195,7 @@ URL, and command for each WebDriver <a>command</a>.
               </tr>
               <tr>
                 <td>GET</td>
-                <td>/session/{sessionId}/element/{elementId}/text</td>
+                <td>/session/{session id}/element/{element id}/text</td>
               </tr>
             </table>
             <p>The following definitions are used in this section:
@@ -3260,7 +3260,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/name</td>
+  <td>/session/{session id}/element/{element id}/name</td>
  </tr>
 </table>
 
@@ -3306,7 +3306,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/rect</td>
+  <td>/session/{session id}/element/{element id}/rect</td>
  </tr>
 </table>
 
@@ -3393,7 +3393,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/enabled</td>
+  <td>/session/{session id}/element/{element id}/enabled</td>
  </tr>
 </table>
 
@@ -3704,7 +3704,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/execute</td>
+  <td>/session/{session id}/execute</td>
  </tr>
 </table>
 
@@ -3751,7 +3751,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{sessionId}/execute_async</td>
+  <td>/session/{session id}/execute_async</td>
  </tr>
 </table>
 
@@ -3864,7 +3864,7 @@ URL, and command for each WebDriver <a>command</a>.
             </tr>
             <tr>
               <td>GET</td>
-              <td>/session/{sessionId}/cookie/{name}</td>
+              <td>/session/{session id}/cookie/{name}</td>
             </tr>
           </table>
           <p>The <a>remote end steps</a> for the <dfn>Get Cookie</dfn> command are:</p>
@@ -3932,7 +3932,7 @@ URL, and command for each WebDriver <a>command</a>.
             </tr>
             <tr>
               <td>POST</td>
-              <td>/session/{sessionId}/cookie</td>
+              <td>/session/{session id}/cookie</td>
             </tr>
           </table>
           <p>The <a>remote end steps</a> for the <dfn>Add Cookie</dfn> command are:</p>
@@ -3977,7 +3977,7 @@ URL, and command for each WebDriver <a>command</a>.
         </tr>
         <tr>
           <td>DELETE</td>
-          <td>/session/{sessionId}/cookie/{name}</td>
+          <td>/session/{session id}/cookie/{name}</td>
         </tr>
       </table>
 
@@ -4085,7 +4085,7 @@ URL, and command for each WebDriver <a>command</a>.
             </tr>
             <tr>
               <td>POST</td>
-              <td>/session/{sessionId}/actions</td>
+              <td>/session/{session id}/actions</td>
             </tr>
           </table>
           <br>
@@ -4139,7 +4139,7 @@ URL, and command for each WebDriver <a>command</a>.
             </tr>
             <tr>
               <td>DELETE</td>
-              <td>/session/{sessionId}/actions</td>
+              <td>/session/{session id}/actions</td>
             </tr>
           </table>
           <br>
@@ -4406,7 +4406,7 @@ URL, and command for each WebDriver <a>command</a>.
               </tr>
               <tr>
                 <td>POST</td>
-                <td>/session/{sessionId}/element/{elementId}/click</td>
+                <td>/session/{session id}/element/{element id}/click</td>
               </tr>
             </table>
             <p>Click in the middle of the WebElement instance. The middle of the element is defined as the middle of the box returned by
@@ -4476,7 +4476,7 @@ URL, and command for each WebDriver <a>command</a>.
               </tr>
               <tr>
                 <td>POST</td>
-                <td>/session/{sessionId}/element/{elementId}/tap</td>
+                <td>/session/{session id}/element/{element id}/tap</td>
               </tr>
             </table>
             <p>Tap in the middle of the WebElement. The middle of the element is defined as the middle of the box returned by
@@ -4540,7 +4540,7 @@ URL, and command for each WebDriver <a>command</a>.
               </tr>
               <tr>
                 <td>POST</td>
-                <td>/session/{sessionId}/element/{elementId}/clear</td>
+                <td>/session/{session id}/element/{element id}/clear</td>
               </tr>
             </table>
         </section>
@@ -4555,7 +4555,7 @@ URL, and command for each WebDriver <a>command</a>.
               </tr>
               <tr>
                 <td>POST</td>
-                <td>/session/{sessionId}/element/{elementId}/value</td>
+                <td>/session/{session id}/element/{element id}/value</td>
               </tr>
             </table>
             <p> Let <var>value</var> be an array of characters that will be typed into a WebElement.
@@ -4797,7 +4797,7 @@ URL, and command for each WebDriver <a>command</a>.
               </tr>
               <tr>
                 <td>POST</td>
-                <td>/session/{sessionId}/dismiss_alert</td>
+                <td>/session/{session id}/dismiss_alert</td>
               </tr>
             </table>
           <p>
@@ -4817,7 +4817,7 @@ URL, and command for each WebDriver <a>command</a>.
               </tr>
               <tr>
                 <td>POST</td>
-                <td>/session/{sessionId}/accept_alert</td>
+                <td>/session/{session id}/accept_alert</td>
               </tr>
             </table>
           <p>
@@ -4837,7 +4837,7 @@ URL, and command for each WebDriver <a>command</a>.
               </tr>
               <tr>
                 <td>GET</td>
-                <td>/session/{sessionId}/alert_text</td>
+                <td>/session/{session id}/alert_text</td>
               </tr>
             </table>
           <p>
@@ -4855,7 +4855,7 @@ URL, and command for each WebDriver <a>command</a>.
               </tr>
               <tr>
                 <td>POST</td>
-                <td>/session/{sessionId}/alert_text</td>
+                <td>/session/{session id}/alert_text</td>
               </tr>
             </table>
           <p>
@@ -4907,7 +4907,7 @@ URL, and command for each WebDriver <a>command</a>.
   </tr>
   <tr>
     <td>GET</td>
-    <td>/session/{sessionId}/screenshot</td>
+    <td>/session/{session id}/screenshot</td>
   </tr>
 </table>
 
@@ -4959,7 +4959,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/element/{elementId}/screenshot</td>
+  <td>/session/{session id}/element/{element id}/screenshot</td>
   <td></td>
  </tr>
 </table>


### PR DESCRIPTION
If algorithms we typically refer to the "session id", "element id", and
"property name" (the three template variables used).  These variables
are passed along to the remote end steps from the routing requests steps,
and it would make sense to use the same variable name whenever referencing
the same underlying data.