### PR TITLE
validate: use https://validator.w3.org/nu/ as our validator

### DIFF
--- a/validate
+++ b/validate
@@ -10,7 +10,7 @@ errs=$(curl -s -F laxtype=yes \
 		-F level=error \
 		-F out=gnu \
 		-F doc=@$file \
-		"https://validator.nu" \
+		"https://validator.w3.org/nu/" \
 	| sed -e 's/"//g')
 echo $errs
 test -z "$errs"


### PR DESCRIPTION
According to Michael[tm] Smith this validator is more frequently updated
and also has better stability.