### PR TITLE
Remove custom Status of This Document

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -118,22 +118,8 @@ var respecConfig = {
  by browser vendors to ensure interoperability.
 </section>
 
-<section id=sotd>
-<p>If you wish to make comments regarding this document,
- please email feedback to <a href=mailto:public-browser-tools-testing@w3.org>public-browser-tools-testing@w3.org</a>.
- All feedback is welcome, and the editors will read and consider all feedback.
-
-<p>This specification is intended for implementors of the WebDriver API.
- It is not intended as light bed time reading.
- This specification is still under active development and may not be stable.
- Any implementors who are not actively participating in the preparation of this specification
- may find unexpected changes occurring.
- It is suggested that any implementors join the WG for this specification.
- Despite not being stable,
- it should be noted that this specification is strongly based on an existing open source project &mdash;
- <a href=https://github.com/SeleniumHQ/selenium>Selenium WebDriver</a> &mdash;
- and the existing implementations of the API defined within that project.
-</section>
+<!-- ReSpec complains if removed completely -->
+<section id=sotd></section>
 
 <section>
 <h3>Conformance</h3>


### PR DESCRIPTION
The status is auto-generated by ReSpec, which has the same information
listed here.