### PR TITLE
Get Window Handle: change endpoint to GET /session/{session id}/window

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -535,14 +535,14 @@ URL, and command for each WebDriver <a>command</a>.
 
  <tr>
   <td>GET</td>
-  <td>/session/{session id}/window/handle</td>
-  <td><a>Get Window Handle</a></td>
+  <td>/session/{session id}/window/handles</td>
+  <td><a>Get Window Handles</a></td>
  </tr>
 
  <tr>
   <td>GET</td>
-  <td>/session/{session id}/window/handles</td>
-  <td><a>Get Window Handles</a></td>
+  <td>/session/{session id}/window</td>
+  <td><a>Get Window Handle</a></td>
  </tr>
 
  <tr>
@@ -1974,7 +1974,7 @@ URL, and command for each WebDriver <a>command</a>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{session id}/window/handle</td>
+  <td>/session/{session id}/window</td>
  </tr>
 </table>
 


### PR DESCRIPTION
The endpoint for getting a window’s handle is not RESTful as many of
the other commands are.

Thanks to Jim Evans for suggesting.