### PR TITLE
Reference DOM instead of DOM4

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3135,7 +3135,7 @@ URL, and command for each WebDriver <a>command</a>.
    </ol>
   </ol>
 
- <li><p>If <var>element</var> is a [[!DOM4]] <a>text node</a>,
+ <li><p>If <var>element</var> is a [[!DOM]] <a>text node</a>,
   return true.
 
  <li><p>If it has equal to or more than one direct descendant elements:
@@ -3577,7 +3577,7 @@ URL, and command for each WebDriver <a>command</a>.
                      <li>Get whitespace, text-transform, and then, if descendent is:
                          <ul>
                              <li>a node which is not <a href="#determining-if-displayed">displayed</a>, do nothing</li>
-                             <li>a [[!DOM4]] <a href="http://www.w3.org/TR/2012/WD-dom-20120105/#interface-text">text node</a> let <code>text</code> equal the <code>nodeValue</code> property of descendent. Then:
+                             <li>a [[!DOM]] <a href="http://www.w3.org/TR/2012/WD-dom-20120105/#interface-text">text node</a> let <code>text</code> equal the <code>nodeValue</code> property of descendent. Then:
                                  <ol>
                                      <li>Remove any zero-width spaces (\u200b, \u200e, \u200f), form feeds (\f) or vertical tab feeds (\v) from <code>text</code>.</li>
                                      <li>Canonicalize any recognized single newline sequence in <code>text</code> to a single newline (greedily matching <code>(\r\n|\r|\n)</code> to a single \n)</li>


### PR DESCRIPTION
DOM4 is an alias for DOM.