### PR TITLE
User Prompts: rename to Set Alert Text and expect string input

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1006,7 +1006,7 @@ var respecConfig = {
  <tr>
   <td>POST</td>
   <td>/session/{<var>session id</var>}/alert/text</td>
-  <td><a>Send Alert Text</a></td>
+  <td><a>Set Alert Text</a></td>
  </tr>
 
  <tr>
@@ -5608,7 +5608,7 @@ following must be <var>parameters</var> after the local end has made a request t
    <a>Dismiss Alert</a><br />
    <a>Accept Alert</a><br />
    <a>Get Alert Text</a><br />
-   <a>Send Alert Text</a>
+   <a>Set Alert Text</a>
  </tr>
 </table>
 
@@ -5788,7 +5788,7 @@ following must be <var>parameters</var> after the local end has made a request t
 </section>
 
 <section>
-<h3>Send Alert Text</h3>
+<h3>Set Alert Text</h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5801,7 +5801,7 @@ following must be <var>parameters</var> after the local end has made a request t
  </tr>
 </table>
 
-<p>The <dfn>Send Alert Text</dfn> <a>command</a>
+<p>The <dfn>Set Alert Text</dfn> <a>command</a>
  sets the text field prompt to a given value,
  and only makes sense on <a>window.<code>prompt</code></a>.
 
@@ -5830,19 +5830,16 @@ following must be <var>parameters</var> after the local end has made a request t
     <a>error code</a> <a>unsupported operation</a>.
   </dl>
 
- <li><p>Let <var>character array</var> be the result of
+ <li><p>Let <var>text</var> be the result of
   <a>getting a property</a> <code>message</code>
   from the <var>parameters</var> argument.
 
- <li><p>Let <var>message</var> be the result of
-  joining together each element in <var>character array</var> to a string.
-
  <li><p>Set the <a>current user prompt</a>’s text field value
-  to the value of <var>message</var>.
+  to the value of <var>text</var>.
 
  <li><p>Return <a>success</a> with data null.
 </ol>
-</section> <!-- /Send Alert Text -->
+</section> <!-- /Set Alert Text -->
 </section> <!-- /User Prompts -->
 
 <section>


### PR DESCRIPTION
There is no added value to simulating key presses to user prompt
dialogues since there are no generated key events from it.