### PR TITLE
Screen Capture: drop issue about checking corner positions

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5796,17 +5796,17 @@ following must be <var>parameters</var> after the local end has made a request t
  given a <a>rectangle</a>:
 
 <ol>
- <li><p>If either the <a>initial viewport</a>’s width or height is 0 <a>CSS reference pixels</a>,
+ <li><p>If either the <a>initial viewport</a>’s width or height
+  is 0 <a>CSS reference pixels</a>,
   return <a>error</a> with <a>error code</a> <a>unable to capture screen</a>.
 
  <li><p>Let <var>paint width</var> be the <a>initial viewport</a>’s width –
-  min(<a>rectangle x coordinate</a>, <a>rectangle x coordinate</a> + <a>rectangle width dimension</a>).
+  min(<a>rectangle x coordinate</a>,
+  <a>rectangle x coordinate</a> + <a>rectangle width dimension</a>).
 
  <li><p>Let <var>paint height</var> be the <a>initial viewport</a>’s height –
-  min(<a>rectangle y coordinate</a>, <a>rectangle y coordinate</a> + <a>rectangle height dimension</a>).
-
- <li><p class=issue>Determine if all corners of <var>rect</var> is
-  inside the rectangle that is the viewport.
+  min(<a>rectangle y coordinate</a>,
+  <a>rectangle y coordinate</a> + <a>rectangle height dimension</a>).
 
  <li><p>Let <var>canvas</var> be a new <a><code>canvas</code> element</a>,
   and set its <a data-lt="canvas width attribute">width</a>


### PR DESCRIPTION
Testing that one or more of the corners are inside the viewport is
faulty logic, since the bounding box of the element can be greater
and also unatainable by scrolling the element into view.

Using hit testing to verify that some part of the element is visible
is bordering on element visibility checks and is not the intention
of this command.