### PR TITLE
Fix a variable name. At some point in the past, this was renamed from…

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1743,7 +1743,7 @@ var respecConfig = {
    <dd>The value of <var>session id</var>.
 
    <dt>"<code>capabilities</code>"
-   <dd>The value of <var>resultant capabilities</var>.
+   <dd>The value of <var>capabilities result</var>.
   </dl>
 
  <li><p>Initialise the following if not set while <a>processing capabilities</a>:


### PR DESCRIPTION
… "resultant capabilities" to "capabilities result", but this instance was missed.