### PR TITLE
protocol: prevent response result error fallthrough

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -661,7 +661,8 @@ var respecConfig = {
 
  <li><p>If <var>response result</var> is an <a>error</a>,
   <a>send an error</a> with <a>error code</a>
-  equal to <var>response result</var>’s <a>error code</a>.
+  equal to <var>response result</var>’s <a>error code</a>
+  and jump back to step 1 in this overall algorithm.
 
   <p>Otherwise, if <var>response result</var> is a <a>success</a>,
    let <var>response data</var> be <var>response result</var>’s data.


### PR DESCRIPTION
The current wording lets it send two responses when the response result
fails: First the error, and then directly afterwards a success with the
same data.

This change prevents the algorithm from doing this by jumping back to
step 1 direclty afterwards sending the error, as above.