### PR TITLE
Error on serialising window of discarded browsing context

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4446,10 +4446,15 @@ session := new_session(capabilities)</code></pre>
   the <a data-lt="JSON serialisation of an element">JSON serialisation</a>
   of the <a>web element</a> <var>value</var>.
 
- <dt>a <a><code>WindowProxy</code> object</a>
- <dd><p><a>Success</a> with
-  the <a data-lt="JSON serialisation of the WindowProxy object">JSON serialisation</a>
-  of <var>value</var>.
+ <dt>a <a><code>WindowProxy</code></a> object
+ <dd><p>If the associated <a>browsing context</a>
+  of the <a><code>WindowProxy</code></a> object
+  in <var>value</var> has been <a>discarded</a>,
+  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
+
+  <p>Otherwise return <a>success</a>
+   with the <a data-lt="JSON serialisation of the WindowProxy object">JSON serialisation</a>
+   of <var>value</var>.
 
  <dt>instance of <a>NodeList</a>
  <dt>instance of <a>HTMLCollection</a>


### PR DESCRIPTION
This patch resolves an action from the WG F2F in July 2016.

When attempting to serialise a WindowProxy exotic object which associated
browsing context has been discarded, we return an error instead.