### PR TITLE
Make normative reference to HTTP

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -361,6 +361,10 @@ var respecConfig = {
   </ul>
 
  <dt>HTTP and related specifications
+ <dd><p>To be <dfn>HTTP compliant</dfn>,
+  it is supposed that the implementation supports the relevant subsets of
+  [[!RFC7230]], [[!RFC7231]], [[!RFC7232]], [[!RFC7234]], and [[!RFC7235]].
+
  <dd><p>The following terms are defined in the Cookie specification: [[!RFC6265]]
   <ul>
    <!-- Compute cookie-string --> <li><dfn><a href=https://tools.ietf.org/html/rfc6265#section-5.4>Compute <code>cookie-string</code></a></dfn>
@@ -528,7 +532,7 @@ var respecConfig = {
 <h2>Protocol</h2>
 
 <p>WebDriver <a>remote ends</a> must provide
- an HTTP-based wire protocol
+ an <a>HTTP compliant</a> wire protocol
  where the <a>endpoints</a> map to different <a>commands</a>.
 
 <p>As this standard only defines the <a>remote end</a> protocol,


### PR DESCRIPTION
Resolves an action from the WebDriver F2F WG meeting in July 2016.

Define what it means to provide an HTTP frontend for the protocol.