### PR TITLE
It is possible for end nodes to have multiple active sessions.

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1761,8 +1761,6 @@ session := new_session(capabilities)</code></pre>
  <dfn>maximum active sessions</dfn> (an integer)
  that defines the number of <a>active sessions</a>
  that are supported.
- This may be “unlimited” for <a>intermediary nodes</a>,
- but must be exactly one for a <a>remote end</a> that is an <a>endpoint node</a>.
 
 <p>A <a>session</a> has an associated <dfn>session ID</dfn>
  (a <a>UUID</a>) used to uniquely identify this session.  Unless
@@ -1844,7 +1842,6 @@ session := new_session(capabilities)</code></pre>
 <p>The <dfn>New Session</dfn> <a>command</a>
  creates a new WebDriver <a>session</a> with the <a>endpoint node</a>.
  If the <a>maximum active sessions</a> has been reached,
- that is if the <a>endpoint node</a> already has a <a>current session</a>,
  there is a problem processing the given <a>capabilities</a>,
  or the provisioning of a <a>remote end</a> is impossible,
  a <a>session not created</a> <a>error</a> is returned.


### PR DESCRIPTION
It is up to implementors of the spec to define their own
value for "maximum active sessions"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/325)
<!-- Reviewable:end -->
