### PR TITLE
Set the current browsing context when switching windows.

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2609,7 +2609,7 @@ session := new_session(capabilities)</code></pre>
 
  <li><p>If <var>handle</var> is equal to the associated <a>window handle</a>
   for some <a>top-level browsing context</a> in the <a>current session</a>,
-  set the <a>session</a>’s <a>current top-level browsing context</a>
+  set the <a>session</a>’s <a>current browsing context</a>
   to that browsing context, and return <a>success</a> with data null.
 
   <p>Otherwise, return <a>error</a> with <a>error code</a> <a>no such window</a>.

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -259,7 +259,6 @@ var respecConfig = {
    <!-- A browsing context is discarded --> <li><dfn data-lt=discarded><a href=https://html.spec.whatwg.org/#a-browsing-context-is-discarded>A browsing context is discarded</a></dfn>
    <!-- Active document --> <li><dfn><a href=https://html.spec.whatwg.org/#active-document>Active document</a></dfn>
    <!-- Active element --> <li><dfn>Active element</dfn> being the <a href=https://html.spec.whatwg.org/#dom-document-activeelement><code>activeElement</code></a> attribute on <a href=https://html.spec.whatwg.org/#document><code>Document</code></a>
-   <!-- Ancestor browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#ancestor-browsing-context>Ancestor browsing context</a></dfn>
    <!-- A serialization of the bitmap as a file --> <li><dfn data-lt="a serialisation of the canvas element’s bitmap as a file"><a href=https://html.spec.whatwg.org/#a-serialisation-of-the-bitmap-as-a-file>A serialisation of the bitmap as a file</a></dfn>
    <!-- Associated window --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-document-window>Associated window</a></dfn>
    <!-- Boolean attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#boolean-attribute>Boolean attribute</a></dfn>
@@ -1780,10 +1779,10 @@ session := new_session(capabilities)</code></pre>
  which is the <a>browsing context</a> against which <a>commands</a> will run.
 
 <p>A <a>session</a> has an associated
- <dfn>current top-level browsing context</dfn>,
- which is the <a>current browsing context</a> if it itself is a <a>top-level browsing context</a>,
- or the <a>top-level browsing context</a> for which
- the <a>current browsing context</a> is an <a>ancestor browsing context</a>.
+ <dfn>current top-level browsing context</dfn>, which is the <a>current browsing
+ context</a> if it itself is a <a>top-level browsing context</a>, and otherwise
+ is the <a>top-level browsing context</a> of the <a>current browsing
+ context</a>.
 
 <p>A <a>session</a> has an associated <dfn>session script timeout</dfn>
  that specifies a time to wait for scripts to run.


### PR DESCRIPTION
The current top-level browsing context is changed implicitly by doing this.

Fixes #338.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/339)
<!-- Reviewable:end -->
