### PR TITLE
Keyup for "Alt" sets `alt` property to false

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6612,7 +6612,7 @@ session := new_session(capabilities)</code></pre>
 
         <li><p>If <var>key</var> is <code>"Alt"</code>,
             let <var>device state's</var> <code>alt</code> property
-            be true.</li>
+            be false.</li>
 
         <li><p>If <var>key</var> is <code>"Shift"</code>,
             let <var>device state's</var> <code>shift</code> property


### PR DESCRIPTION
Unless I am missing something.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/344)
<!-- Reviewable:end -->
