### PR TITLE
horizontal ~ width, vertical ~ height

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3477,10 +3477,10 @@ session := new_session(capabilities)</code></pre>
  <li><p>Let <var>visible height</var> be the <var>rectangle</var>’s
   (<a>max</a>(<a>y coordinate</a>, <a>y coordinate</a> + <a>height dimension</a>)).
 
- <li>Let <var>vertical centre offset</var> be
+ <li>Let <var>horizontal centre offset</var> be
   (<var>visible width</var> / 2.0).
 
- <li>Let <var>horizontal centre offset</var> be
+ <li>Let <var>vertical centre offset</var> be
   (<var>visible height</var> / 2.0).
 
  <li>Let <var>centre point</var> be a pair


### PR DESCRIPTION
mismatched terms, horizontal center relates to width (not height)
vertical center relates to height (not width)

Fixes #424

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/426)
<!-- Reviewable:end -->
