### PR TITLE
Describe what happens when a selector is equal to "". Fixes #420

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3884,6 +3884,16 @@ entries:
 
  <li><p>Let <var>selector</var> be equal to <var>value</var>.
 
+ <li><p>If <var>selector</var> is equal to <code>""</code> or <a>null</a>, match on <var>all</var>:
+
+   <dl class=switch>
+    <dt>true
+    <dd>Return <a>success</a> with empty JSON List.
+
+    <dt>false
+    <dd>Return <a>error</a> <a>no such element</a>.
+   </dl>
+
  <li><p>Let <var>result</var> be an empty JSON List.
 
  <li><p>Let <var>elements returned</var> be the result


### PR DESCRIPTION
With findElements we return an empty list e.g. []
With findElement we return elementNotFoundError

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/432)
<!-- Reviewable:end -->
