### PR TITLE
Use in-view centre point reference when getting x and y for pointer a…

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -7328,13 +7328,9 @@ entries:
                   of <a>trying</a> to <var>get a known element</var> with
                   argument <var>element</var>.</li>
 
-              <li><p>If <var>x</var> is undefined, let <var>x</var>
-                  equal <var>element</var>'s <a>horizontal
-                  midpoint</a>.</li>
-
-              <li><p>If <var>y</var> is undefined, let <var>y</var>
-                  equal <var>element</var>'s <a>vertical
-                  midpoint</a>.</li>
+              <li><p>If <var>x</var> and <var>y</var> are <a>undefined</a>,
+                let <var>x</var> and <var>y</var> be the result of calculating the
+                <a>in-view centre point</a> of <var>element</var>.
             </ol>
         </li>
 


### PR DESCRIPTION
…ctions

This removes 2 links that are not defined and better defines how to calculate x and y.