### PR TITLE
Correct start nodes for element retrieval and error on missing args

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4090,9 +4090,17 @@ entries:
  <li><p>Let <var>start node</var> be
   the <a>current browsing context</a>’s <a>document element</a>.
 
- <li><p>Let <var>location strategy</var> be the result of <a>getting a property</a> called "<code>using</code>".
+ <li><p>Let <var>location strategy</var> be the result
+  of <a>getting a property</a> called "<code>using</code>".
 
- <li><p>Let <var>selector</var> be the result of <a>getting a property</a> called "<code>value</code>".
+ <li><p>If <var>location strategy</var> is <a>undefined</a>,
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Let <var>selector</var> be the result
+  of <a>getting a property</a> called "<code>value</code>".
+
+ <li><p>If <var>selector</var> is <a>undefined</a>,
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li>Return the result of <a>Find</a> with <var>all</var>, <var>start node</var>,
    <var>location strategy</var>, and <var>selector</var>.
@@ -4126,8 +4134,14 @@ entries:
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".
 
+ <li><p>If <var>location strategy</var> is <a>undefined</a>,
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
  <li><p>Let <var>selector</var> be the result
   of <a>getting a property</a> called "<code>value</code>".
+
+ <li><p>If <var>selector</var> is <a>undefined</a>,
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li>Return the result of <a>Find</a> with
   <var>all</var>, <var>start node</var>,
@@ -4163,8 +4177,14 @@ entries:
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".
 
+ <li><p>If <var>location strategy</var> is <a>undefined</a>,
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
  <li><p>Let <var>selector</var> be the result
   of <a>getting a property</a> called "<code>value</code>".
+
+ <li><p>If <var>selector</var> is <a>undefined</a>,
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li>Return the result of <a>Find</a> with
   <var>all</var>, <var>start node</var>,
@@ -4200,8 +4220,14 @@ entries:
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".
 
+ <li><p>If <var>location strategy</var> is <a>undefined</a>,
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
  <li><p>Let <var>selector</var> be the result
   of <a>getting a property</a> called "<code>value</code>".
+
+ <li><p>If <var>selector</var> is <a>undefined</a>,
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li>Return the result of <a>Find</a> with
   <var>all</var>, <var>start node</var>,

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4078,16 +4078,17 @@ entries:
  </tr>
 </table>
 
-<p>The <dfn>Find Element</dfn> <a>command</a> is used
-  to find an element in the <a>current browsing context</a> that can be used for
-  future <a>commands</a>.
+<p>The <dfn>Find Element</dfn> <a>command</a>
+ is used to find an <a>element</a> in the <a>current browsing context</a>
+ that can be used for future <a>commands</a>.
 
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>Let <var>all</var> be equal to false.
+ <li><p>Let <var>all</var> be false.
 
- <li><p>Let <var>start node </var> be <a><code>html</code> element</a>.
+ <li><p>Let <var>start node</var> be
+  the <a>current browsing context</a>’s <a>document element</a>.
 
  <li><p>Let <var>location strategy</var> be the result of <a>getting a property</a> called "<code>using</code>".
 
@@ -4117,9 +4118,10 @@ entries:
  that can be used for future <a>commands</a>.
 
 <ol>
- <li><p>Let <var>all</var> be equal to true.
+ <li><p>Let <var>all</var> be true.
 
- <li><p>Let <var>start node </var> be <a><code>html</code> element</a>.
+ <li><p>Let <var>start node</var> be
+  the <a>current browsing context</a>’s <a>document element</a>.
 
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".
@@ -4155,7 +4157,7 @@ entries:
 <ol>
  <li><p>Let <var>all</var> be equal to false.
 
- <li><p>Let <var>start node </var> be the result of
+ <li><p>Let <var>start node</var> be the result of
   <a>getting a known element</a> by <a>UUID</a> <var>reference</var>.
 
  <li><p>Let <var>location strategy</var> be the result
@@ -4192,7 +4194,7 @@ entries:
 <ol>
  <li><p>Let <var>all</var> be equal to true.
 
- <li><p>Let <var>start node </var> be the result
+ <li><p>Let <var>start node</var> be the result
   of <a>getting a known element</a> by <a>UUID</a> <var>reference</var>.
 
  <li><p>Let <var>location strategy</var> be the result
@@ -4206,9 +4208,7 @@ entries:
   <var>location strategy</var>, and <var>selector</var>.
 </ol>
 </section> <!-- /Find Elements From Element -->
-
 </section> <!-- /Element Retrieval -->
-
 
 <section>
 <h2>Element State</h2>


### PR DESCRIPTION
These two patches corrects the start nodes for element retrieval so that they don’t use the `<html>` element directly but instead the current document’s document element, and return the appropriate errors if the `value` and `using` fields are missing from the request bodies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/434)
<!-- Reviewable:end -->
