### PR TITLE
Make pause duration optional

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6460,9 +6460,9 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
           property named <code>duration</code> from <var>action
             item</var>.</li>
 
-      <li><p>If <var>duration</var> is not an <a>Integer</a> greater
-          than or equal to 0 return <a>error</a> with <a>error
-          code</a> <a>invalid argument</a>.</li>
+      <li><p>If <var>duration</var> is not <a>undefined</a>
+       and <var>duration</var> is not an <a>Integer</a> greater than or equal to 0,
+       return <a>error</a> with <a>error code</a> <a>invalid argument</a>.</li>
 
       <li><p>Set the <code>duration</code> property
           of <var>action</var> to <var>duration</var>.</li>


### PR DESCRIPTION
duration is optional for pointerMove but required for pause. If we let it be optional for pause then "compute tick duration" would default to duration 0.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/436)

<!-- Reviewable:end -->
