### PR TITLE
Rename acceptSslCerts to acceptInsecureCerts

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1615,12 +1615,12 @@ with a "-moz-" prefix:
   </tr>
 
   <tr>
-  <td><dfn>Accept SSL certificates</dfn>
-  <td>"<code>acceptSslCerts</code>"
+  <td><dfn>Accept insecure TLS certificates</dfn>
+  <td>"<code>acceptInsecureCerts</code>"
   <td>boolean
-  <td>Indicates whether untrusted and self-signed SSL certificates are
-  implicitly trusted on <a data-lt=go>navigation</a> for the duration of the
-  session.
+  <td>Indicates whether untrusted and self-signed TLS certificates
+   are implicitly trusted on <a data-lt=go>navigation</a>
+   for the duration of the <a>session</a>.
   </tr>
 
   <tr>
@@ -1951,18 +1951,20 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
   <dt>"<code>platformVersion</code>"
   <dd>The platform version, as a string.
 
-  <dt>"<code>acceptSslCerts</code>"
-  <dd>Boolean initially set to false, indicating the session <em>will not</em> implicitly trust
-  untrusted or self-signed SSL certificates on <a data-lt=go>navigation</a>.
+  <dt>"<code>acceptInsecureCerts</code>"
+  <dd>Boolean initially set to false,
+   indicating the session will not implicitly trust untrusted
+   or self-signed TLS certificates on <a data-lt=go>navigation</a>.
   </dl>
 
-<li><p>Let <var>capabilities length</var> be the number of entries in <var>capabilities</var>.
+<li><p>Let <var>capabilities length</var> be
+ the number of entries in <var>capabilities</var>.
 
 <li><p>Let <var>k</var> be 0.
 
 <li><p>While <var>k</var> &lt; <var>capabilities length</var>:
 
-  <ol>
+ <ol>
   <li><p>Let <var>capability name</var> be the name of the entry at index
   <var>k</var> in <var>capabilities</var>.
 
@@ -2023,16 +2025,15 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
         the "<code>platformVersion</code>" entry in
         <var>matched capabilities</var>, return null.
 
-      <dt>"<code>acceptSslCerts</code>"
-      <dd>
-        <p>If <var>capability value</var> is not a boolean,
-        return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+      <dt>"<code>acceptInsecureCerts</code>"
+      <dd><p>If <var>capability value</var> is not a boolean,
+       return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
-        <p>If <var>capability value</var> is <code>true</code> and the
-        <a>endpoint node</a> <em>does not</em> support insecure
-        SSL certificates, return null.
+       <p>If <var>capability value</var> is <code>true</code>
+        and the <a>endpoint node</a> does not support insecure TLS certificates,
+        return null.
 
-        <p>Otherwise, set the "<code>acceptSslCerts</code>" entry in
+       <p>Otherwise, set the "<code>acceptInsecureCerts</code>" entry in
         <var>matched capabilities</var> to <var>capability value</var>.
 
       <dt>"<code>pageLoadStrategy</code>"
@@ -2167,7 +2168,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  If it is unset, this indicates that certificate- or SSL errors
  that occur upon <a data-lt=go>navigation</a> should be suppressed.
  The state can be unset by providing
- an "<code>acceptSslCerts</code>" <a>capability</a> with the value true.
+ an "<code>acceptInsecureCerts</code>" <a>capability</a> with the value true.
  Unless stated otherwise, it is set.
 
 <p>A <a>session</a> has an associated <a>user prompt handler</a>.

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1720,7 +1720,7 @@ of the following: "<code>pac</code>", "<code>noproxy</code>",
 <tr>
 <td>"<code>sslProxy</code>"
 <td>string
-<td>Defines the proxy <em>hostname</em> for encrypted SSL traffic. If a hostname and port
+<td>Defines the proxy <em>hostname</em> for encrypted TLS traffic. If a hostname and port
   is passed through this property, set "<code>sslProxy</code>" to the hostname
   and "<code>sslProxyPort</code>" to the port.
   This property <em>SHOULD</em> only be set when the "<code>proxyType</code>" is
@@ -2162,10 +2162,10 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  which is one of <a>none</a>, <a>normal</a>, and <a>eager</a>.
  Unless stated otherwise, it is <a>normal</a>.
 
-<p>A <a>session</a> has an associated <dfn>secure SSL</dfn> state
- that indicates whether untrusted or self-signed SSL certificates
+<p>A <a>session</a> has an associated <dfn>secure TLS</dfn> state
+ that indicates whether untrusted or self-signed TLS certificates
  should be trusted for the duration of the WebDriver session.
- If it is unset, this indicates that certificate- or SSL errors
+ If it is unset, this indicates that certificate- or TLS errors
  that occur upon <a data-lt=go>navigation</a> should be suppressed.
  The state can be unset by providing
  an "<code>acceptInsecureCerts</code>" <a>capability</a> with the value true.
@@ -2639,7 +2639,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  <dd><p>Return <a>error</a> with <a>error code</a> <a>unknown error</a>.
 
  <dt><a>response</a> be <a>blocked by content security policy</a>
- <dd><p>If the <a>current session</a>’s <a>secure SSL</a> state is disabled,
+ <dd><p>If the <a>current session</a>’s <a>secure TLS</a> state is disabled,
   take implementation specific steps to ensure
   the navigation is not aborted
   and that the untrusted- or invalid TLS certificate error
@@ -2672,7 +2672,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  to cause the user agent to <a>navigate</a>
  the <a>current top-level browsing context</a> a new location.
 
-<p>If the <a>session</a> is not in a <a>secure SSL</a> state,
+<p>If the <a>session</a> is not in a <a>secure TLS</a> state,
  no certificate errors that would normally
  cause the user agent to abort and show a security warning
  are to be hinder navigation to the requested address.


### PR DESCRIPTION
Fulfils resolution from F2F in Lisbon: https://www.w3.org/2016/09/19-webdriver-minutes.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/437)
<!-- Reviewable:end -->
