### PR TITLE
Simplify text by removing 'structure' from 'JSON Object structure'

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5485,7 +5485,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
 <p>For informational purposes,
  the table includes a legend of whether the field is optional
- in the <a>serialised cookie</a> structure provided to <a>Add Cookie</a>,
+ in the <a>serialised cookie</a> provided to <a>Add Cookie</a>,
  and a brief non-normative description of the field
  and the expected input type of its associated value.
 
@@ -5573,7 +5573,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  </tr>
 </table>
 
-<p>A <dfn>serialised cookie</dfn> is a JSON <a>Object</a> structure
+<p>A <dfn>serialised cookie</dfn> is a JSON <a>Object</a>
  where a <a>cookie</a>’s [[!RFC6265]] fields
  listed in the <a>table for cookie conversion</a>
  is mapped using the <i>JSON Key</i>


### PR DESCRIPTION
Pull request for  https://github.com/w3c/webdriver/issues/467

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/468)
<!-- Reviewable:end -->
