### PR TITLE
Unify format of all 'JSON Object' occurrences to 'JSON <a>Object</a>'

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1641,7 +1641,7 @@ with a "-moz-" prefix:
   <tr>
   <td><dfn>Session Timeouts Configuration</dfn>
   <td>"<code>timeouts</code>"
-  <td>JSON Object
+  <td>JSON <a>Object</a>
   <td>Describes the <a>timeouts</a> imposed on certain session operations.
   </tr>
 </tbody>
@@ -3715,7 +3715,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  is mapped to the <a>element</a>’s <a>web element reference</a>.
 
 <p>When required to <dfn>deserialise a web element</dfn>
- by a JSON Object <var>object</var> that <a>represents a web element</a>:
+ by a JSON <a>Object</a> <var>object</var> that <a>represents a web element</a>:
 
 <ol>
  <li><p>If <var>object</var> has no <a>own property</a> <a>web element identifier</a>,
@@ -6151,7 +6151,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
     <p>The algorithm for <a data-lt="extract an action
     chain">extracting an action chain from a request</a> takes the
-    JSON object representing an action chain, validates the input, and
+    JSON <a>Object</a> representing an action chain, validates the input, and
     returns a data structure that is the transpose of the input JSON,
     such that the actions to be performed in a single tick are grouped
     together.


### PR DESCRIPTION
Most "JSON Object" occurrences are `JSON <a>Object</a>` whereas a few are `JSON Object`. It looks the format could be unified (to `JSON <a>Object</a>`) without altering the text meaning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/469)
<!-- Reviewable:end -->
