### PR TITLE
Unify session id variable placeholder in endpoint URL

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3345,7 +3345,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  </tr>
  <tr>
   <td>GET</td>
-  <td>/session/{sessionId}/window/size</td>
+  <td>/session/{session id}/window/size</td>
  </tr>
 </table>
 


### PR DESCRIPTION
This is the only place where `sessionId` is used in the endpoint URL, all other occurrences are `session id`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/470)
<!-- Reviewable:end -->
