### PR TITLE
Replace 'HTTP status code' with 'HTTP status'

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2649,7 +2649,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
   <p>Otherwise return <a>error</a> with <a>error code</a> <a>insecure certificate</a>.
 
- <dt><a>response</a>’s <a>HTTP status code</a> is 401
+ <dt><a>response</a>’s <a>HTTP status</a> is 401
  <dt>Otherwise
  <dd><p>Irrespective of how a possible authentication challenge is handled,
   return <a>success</a> with data null.


### PR DESCRIPTION
FETCH defines 'HTTP status' that is code not 'HTTP status code'.

Fix respec warning:
Found linkless <a> element with text 'http status code' but no matching <dfn>.  respec-w3c-common:1:26900

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/473)
<!-- Reviewable:end -->
