### PR TITLE
Add dfn for plural of tick

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6030,7 +6030,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
         </tr>
       </table>
 
-    <p>A <dfn data-lt="tick|ticks">tick</dfn> is the basic unit of time over which actions
+    <p>A <dfn data-lt="ticks">tick</dfn> is the basic unit of time over which actions
       can be performed. During a tick, each input source has an assigned
       action — possibly a noop <a>pause</a> action — which may
       result in changes to the user agent internal state and eventually

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6030,7 +6030,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
         </tr>
       </table>
 
-    <p>A <dfn>tick</dfn> is the basic unit of time over which actions
+    <p>A <dfn data-lt="tick|ticks">tick</dfn> is the basic unit of time over which actions
       can be performed. During a tick, each input source has an assigned
       action — possibly a noop <a>pause</a> action — which may
       result in changes to the user agent internal state and eventually


### PR DESCRIPTION
Fix respec warning.

Found linkless <a> element with text 'ticks' but no matching <dfn>.   respec-w3c-common:1:26900

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/475)
<!-- Reviewable:end -->
