### PR TITLE
Fix typo in <a> to match its dfn

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -7573,7 +7573,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
         <ol>
           <li><p>If the <a>current top-level browsing context</a>
               is <a>no longer open</a>, return <a>error</a>
-              with <a>error code</a> <a>no such window.</a></li>
+              with <a>error code</a> <a>no such window</a>.</li>
 
           <li><p><a>Handle any user prompts</a>. If this results in
               an <a>error</a>, return that error.</li>


### PR DESCRIPTION
Fix respec warning

Found linkless <a> element with text 'no such window.' but no matching <dfn>.  respec-w3c-common:1:26900

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/476)
<!-- Reviewable:end -->
