### PR TITLE
dfn for 'table of standard capabilities'

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1558,7 +1558,7 @@ to define which features it requires the <a>remote end</a> to satisfy when
 creating a <a>new session</a>. Likewise, the <a>remote end</a> uses capabilities
 to describe the full feature set for a session.
 
-<p>The following table provides an overview of the standard capabilities that
+<p>The following <dfn>table of standard capabilities</dfn> enumerates the capabilities
 each implementation <em>MUST</em> support. An implementation <em>MAY</em> define
 additional capabilities, although it is <em>RECOMMENDED</em> that custom
 capabilities prepend the capability key with a vendor prefix, as outlined in

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1513,7 +1513,7 @@ var respecConfig = {
 <aside class=example>
  <p><a>Extension capabilities</a> are typically used
   to provide UA or <a>intermediary node</a> specific configuration
-  that is not handled by the <a>table of capabilities</a>.
+  that is not handled by the <a>table of standard capabilities</a>.
 
  <p>An example <a>new session</a> request body
   might look like this:


### PR DESCRIPTION
The dfn for the table was missing. Also, updated an occurrence of a related <a>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/479)
<!-- Reviewable:end -->
