### PR TITLE
Convert an <a> to <var> and change wording to match success definition

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -618,7 +618,7 @@ var respecConfig = {
   call <var>algorithm</var>" is equivalent to "Let <var>temp</var> be
   the result of calling <var>algorithm</var>. If <var>temp</var> is
   an <a>error</a> return <var>temp</var>, otherwise
-  let <var>result</var> be <var>temp</var>'s <a>data</a>.
+  let <var>result</var> be <var>temp</var>'s <var>data</var> field.
 
 <p>The result of <dfn data-lt="getting properties">getting a property</dfn>
  with <var>name</var> from an <a>Object</a> is defined as


### PR DESCRIPTION
Fix warning

Found linkless <a> element with text 'data' but no matching <dfn>.  respec-w3c-common:1:26900

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/485)
<!-- Reviewable:end -->
