### PR TITLE
Remove undefined properties <a> and reword accordingly

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5734,7 +5734,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
   the <a>active document</a>’s <a>address</a>
   using <a>cookie name</a> <var>name</var>,
   <a>cookie value</a> <var>value</var>,
-  and an attribute-value list of the following <a>properties</a>
+  and an attribute-value list of the following cookie concepts
+  listed in the <a>table for cookie conversion</a>
   from <var>data</var>:
 
   <dl>


### PR DESCRIPTION
The <a> 'properties' (that belong to <var>data</var>) is an undefined
concept. However, the 'Cookie concepts' of the 'table for cookie
conversion' are well defined and can be used instead, making the text
more consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/486)
<!-- Reviewable:end -->
