### PR TITLE
Correct <a> active user prompt to match <dfn> 'user prompt'

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2628,7 +2628,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
    <li><p>If the previous step completed
     by the load timeout being reached
-    and the browser is does not have an <a>active user prompt</a>,
+    and the browser is does not have an active <a>user prompt</a>,
     return <a>error</a> with <a>error code</a> <a>timeout</a>.
   </ol>
 </ol>
@@ -3095,7 +3095,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If there is an <a>active user prompt</a>,
+ <li><p>If there is an active <a>user prompt</a>,
   that due to the uniqueness of the user agent
   prevents the focussing of another <a>top-level browsing context</a>,
   return <a>error</a> with <a>error code</a> <a>unsupported operation</a>.


### PR DESCRIPTION
Fix respec warning

Found linkless <a> element with text 'active user prompt' but no matching <dfn>.  respec-w3c-common:1:26900

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/491)
<!-- Reviewable:end -->
