### PR TITLE
Convert attribute id to data-lt for dnf 'perform actions'

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6054,8 +6054,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
     end up in implementation-specific territory. However there are
     certain content observable effects that must be consistent across
     implementations. To accomodate this, the specification requires
-    that <a>remote ends</a> <dfn id="perform-actions">perform
-    implementation-specific action dispatch steps</dfn>, along with a
+    that <a>remote ends</a> <dfn data-lt="perform-actions|perform actions">
+    perform implementation-specific action dispatch steps</dfn>, along with a
     list of events and their properties. This list is not
     comprehensive; in particular the default action of the input
     source may cause additional events to be generated depending on


### PR DESCRIPTION
Fix respec warning

Found linkless <a> element with text 'perform actions' but no matching <dfn>.  respec-w3c-common:1:26900

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/492)
<!-- Reviewable:end -->
