### PR TITLE
Rename section title and reference 'Releasing Actions' to 'Release Actions'

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1152,7 +1152,7 @@ var respecConfig = {
  <tr>
   <td>DELETE</td>
   <td>/session/{<var>session id</var>}/actions</td>
-  <td><a>Releasing Actions</a></td>
+  <td><a>Release Actions</a></td>
  </tr>
 
  <tr>
@@ -7593,8 +7593,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
       </section> <!-- Remote End Steps -->
   </section> <!-- Perform Actions -->
 
-  <section><!-- Releasing Actions -->
-  <h2>Releasing Actions</h2>
+  <section><!-- Release Actions -->
+  <h2>Release Actions</h2>
   <table class="simple jsoncommand">
     <tr>
       <th>HTTP Method</th>


### PR DESCRIPTION
Currently, no other command in 'table of endpoints' uses the -ing form of
the command verbs. Corrected to make the text more uniform.

Fix respec warning

Found linkless <a> element with text 'releasing actions' but no matching <dfn>.  respec-w3c-common:1:26900

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/493)
<!-- Reviewable:end -->
