### PR TITLE
Correct link to location strategy in "session implicit wait timeout"

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2164,7 +2164,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  Unless stated otherwise it is 300,000 milliseconds.
 
 <p>A <a>session</a> has an associated <dfn>session implicit wait timeout</dfn>
- that specifies a time to wait for the <a>implicit element location strategy</a>
+ that specifies a time to wait for the <a>element location strategy</a>
  when <a href=#element-retrieval>retreiving elements</a>.
  Unless stated otherwise it is zero milliseconds.
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/499)
<!-- Reviewable:end -->
