### PR TITLE
Unify the return values for window related commands

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3591,18 +3591,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
   containing the <a>current top-level browsing context</a>
   to the maximum available size allowed by the window manager.
 
- <li><p>Return <a>success</a>
-  with the a new JSON <a>Object</a>:
-
-  <dl>
-   <dt><code>width</code>
-   <dd><a>Current top-level browsing context</a>’s
-    <a>window dimension</a> width.
-
-   <dt><code>height</code>
-   <dd><a>Current top-level browsing context</a>’s
-    <a>window dimension</a> height.
-  </dl>
+ <li><p>Return <a>success</a> with the <a>JSON serialisation</a>
+  of the <a>current top-level browsing context</a>’s <a>window size</a>.
 </ol>
 </section> <!-- /Maximize Window -->
 
@@ -3645,18 +3635,9 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
    as close as possible to the dimensions of the display containing the window,
    and may hide browser-provided UI such as toolbars.
 
- <li><p>Return <a>success</a>
-  with a new JSON <a>Object</a>:
+ <li><p>Return <a>success</a> with the <a>JSON serialisation</a>
+  of the <a>current top-level browsing context</a>’s <a>window size</a>.
 
-  <dl>
-   <dt><code>width</code>
-   <dd><a>Current top-level browsing context</a>’s
-    <a>window dimension</a> width.
-
-   <dt><code>height</code>
-   <dd><a>Current top-level browsing context</a>’s
-    <a>window dimension</a> height.
-  </dl>
 </ol>
 </section> <!-- /Fullscreen Window -->
 


### PR DESCRIPTION
Commands "Get Window Size" and "Set Window Size" at their last success step return

> Return success with the JSON serialisation of the current top-level browsing context’s window size.

Whereas "Maximize Window" and "Fullscreen Window" at their last success step return

> Return success with the a new JSON Object:
>
> width
>    Current top-level browsing context’s window dimension width.
> height
>    Current top-level browsing context’s window dimension height.

which is effectively the same as the first one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/503)
<!-- Reviewable:end -->
