### PR TITLE
Add definition for Navigator.webdriver attribute

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -518,7 +518,7 @@ var respecConfig = {
   readonly attribute boolean webdriver;
 };</pre>
 
-<p>The <code>webdriver</code> IDL attribute
+<p data-dfn-for="Navigator">The <dfn><code>webdriver</code></dfn> IDL attribute
  of the <code><a>Navigator</a></code> interface must return
  the value of the <dfn>webdriver-active flag</dfn>, which is initially false.
 


### PR DESCRIPTION
Fix respec warning

No <dfn> for webdriver in Navigator

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/509)
<!-- Reviewable:end -->
