### PR TITLE
Correct <a> 'input cancel actions'

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -7663,7 +7663,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
         <li><p><a>Dispatch tick actions</a> with arguments <var>undo
               actions</var> and duration 0.</li>
 
-        <li><p>Let the <a>current session</a>'s <a>input cancel actions</a> be
+        <li><p>Let the <a>current session</a>'s <a>input cancel list</a> be
             an empty <a>List</a>.</li>
 
         <li><p>Let the <a>current session</a>'s <a>input state</a> be


### PR DESCRIPTION
The concept "input cancel actions" is undefined and from reading the
algorthm it looks this step should be emptying the well defined
"input cancel list".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/511)
<!-- Reviewable:end -->
