### PR TITLE
Remove 'valid' before capability name. Fixes #461

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2059,7 +2059,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
       <dt>"<code>timeouts</code>"
       <dd>
-        <p>If <var>capability value</var> is not a valid
+        <p>If <var>capability value</var> is not a
         <a>Session Timeouts Configuration</a> object,
         return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 


### PR DESCRIPTION
Removing valid from before Session Timeouts Configuration since the
object keys are linked in that sentence. The configuration will either have
the keys, making it valid, or it won't meaning it is invalid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/516)
<!-- Reviewable:end -->
