### PR TITLE
Do no duplicate content of <dfn> in its data-lt attribute

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -279,7 +279,7 @@ var respecConfig = {
    <!-- Origin-clean --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-canvas-origin-clean>Origin-clean</a></dfn>
    <!-- Parent browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#parent-browsing-context>Parent browsing context</a></dfn>
    <!-- Pause --> <li><dfn data-lt=unpaused><a href=https://html.spec.whatwg.org/#pause>HTML Pause</a></dfn>
-   <!-- Prompt to unload a document --> <li><dfn data-lt="prompt to unload a document|prompting to unload"><a href=https://html.spec.whatwg.org/#prompt-to-unload-a-document>Prompt to unload a document</a></dfn>
+   <!-- Prompt to unload a document --> <li><dfn data-lt="prompting to unload"><a href=https://html.spec.whatwg.org/#prompt-to-unload-a-document>Prompt to unload a document</a></dfn>
    <!-- Radio button --> <li><dfn><a href="https://html.spec.whatwg.org/#radio-button-state-%28type=radio%29">Radio Button</a></dfn> state
    <!-- Replacement enabled --> <li><dfn><a href=https://html.spec.whatwg.org/#replacement-enabled>Replacement enabled</a></dfn>
    <!-- Reset Button --> <li><dfn><a href="https://html.spec.whatwg.org/#reset-button-state-%28type=reset%29">Reset Button</a></dfn> state
@@ -292,9 +292,9 @@ var respecConfig = {
    <!-- Strip leading and trailing white space --><li><dfn data-lt="stripping leading and trailing whitespace"><a href="https://html.spec.whatwg.org/#strip-leading-and-trailing-whitespace">Strip leading and trailing whitespace</a></dfn>
    <!-- Submit Button --> <li><dfn><a href="https://html.spec.whatwg.org/#submit-button-state-%28type=submit%29">Submit Button</a></dfn> state
    <!-- Submittable elements --> <li><dfn data-lt="submittable element"><a href=https://html.spec.whatwg.org/#category-submit>Submittable elements</a></dfn>
-   <!-- Top-level browsing context --> <li><dfn data-lt="top-level browsing context|top-level browsing contexts"><a href=https://html.spec.whatwg.org/#top-level-browsing-context>Top-level browsing context</a></dfn>
+   <!-- Top-level browsing context --> <li><dfn data-lt="top-level browsing contexts"><a href=https://html.spec.whatwg.org/#top-level-browsing-context>Top-level browsing context</a></dfn>
    <!-- Traverse the history by a delta --> <li><dfn><a href=https://html.spec.whatwg.org/#traverse-the-history-by-a-delta>Traverse the history by a delta</a></dfn>
-   <!-- Traverse the history --> <li><dfn data-lt="traverse the history|traversing the history"><a href=https://html.spec.whatwg.org/#traverse-the-history>Traverse the history</a></dfn>
+   <!-- Traverse the history --> <li><dfn data-lt="traversing the history"><a href=https://html.spec.whatwg.org/#traverse-the-history>Traverse the history</a></dfn>
    <!-- Tree order --> <li><dfn><a href=https://html.spec.whatwg.org/#tree-order>Tree order</a></dfn>
    <!-- Unfocusing steps --><li><dfn><a href=https://html.spec.whatwg.org/#unfocusing-steps>unfocusing steps</a></dfn>
    <!-- User prompt --> <li><dfn data-lt="user prompts"><a href=https://html.spec.whatwg.org/#user-prompts>User prompt</a></dfn>
@@ -378,7 +378,7 @@ var respecConfig = {
   </ul>
 
   <dd><p>The specification uses
-   <dfn data-lt="uri templates|uri template">URI Templates</dfn>. [[!URI-TEMPLATE]]
+   <dfn data-lt="uri template">URI Templates</dfn>. [[!URI-TEMPLATE]]
 
  <dt>Styling
  <dd>The following terms are defined in
@@ -548,7 +548,7 @@ var respecConfig = {
  known as <dfn data-lt="node type">node types</dfn>:
 
 <dl>
- <dt><dfn data-lt="local end|local ends|local">Local End</dfn>
+ <dt><dfn data-lt="local ends|local">Local End</dfn>
  <dd><p>The local end represents the client side of the protocol,
   which is usually in the form of language-specific libraries
   providing an API on top of the WebDriver <a href=#protocol>protocol</a>.
@@ -557,12 +557,12 @@ var respecConfig = {
 
   <p class=issue>Define the requirements on the local end somewhere.
 
- <dt><dfn data-lt="remote end|remote ends|remote">Remote End</dfn>
+ <dt><dfn data-lt="remote ends|remote">Remote End</dfn>
  <dd>The remote end hosts the server side of the <a href=#protocol>protocol</a>.
   Defining the behaviour of a remote end in response to the WebDriver protocol
   forms the largest part of this specification.
 
- <dt><dfn data-lt="intermediary node|intermediary nodes">Intermediary Node</dfn>
+ <dt><dfn data-lt="intermediary nodes">Intermediary Node</dfn>
  <dd>Intermediary nodes are those that act as proxies,
   implementing both the client and server sides of the <a href=#protocol>protocol</a>.
   Intermediary nodes must be black-box indistinguishable from a <a>remote end</a>
@@ -654,7 +654,7 @@ var respecConfig = {
 
 <p>The WebDriver protocol is organised into <a>commands</a>.
  Each HTTP request with a method and template defined in this specification
- represents a single <dfn data-lt="command|commands">command</dfn>
+ represents a single <dfn data-lt="commands">command</dfn>
  and therefore each command produces a single HTTP response.
  In response to a <a>command</a>,
  a <a>remote end</a> will run a series of actions against the remote browser.
@@ -1462,7 +1462,7 @@ var respecConfig = {
 
 <p>The protocol is designed to allow extension to meet vendor-specific needs.
  Commands that are specific to a user agent
- are called <dfn data-lt="extension commands|extension command">extension commands</dfn>
+ are called <dfn data-lt="extension command">extension commands</dfn>
  and behave no differently than other <a>commands</a>;
  each has a dedicated HTTP endpoint and a set of <a>remote end steps</a>.
 
@@ -2118,7 +2118,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  Maintaining session continuity between requests to
  the <a>remote end</a> requires passing a <a>session ID</a>.
 
-<p>A WebDriver <dfn data-lt="session|sessions">session</dfn> represents
+<p>A WebDriver <dfn data-lt="sessions">session</dfn> represents
  the connection between a <a>local end</a> and a specific <a>remote end</a>.
  A <a>remote end</a> that is not an <a>intermediary node</a>
  has at most one <a>active session</a> at a given time.
@@ -2130,7 +2130,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  at the last remaining <a>top-level browsing context</a>.
 
 <p>A <a>remote end</a> has an associated list of
- <dfn data-lt="active sessions|active session">active sessions</dfn>,
+ <dfn data-lt="active session">active sessions</dfn>,
  which is a list of all <a>sessions</a> that are currently started.
 
 <p>Requests, except <a>New Session</a> requests,
@@ -2988,7 +2988,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  to be <dfn>no longer open</dfn> if it has been <a>discarded</a>.
 
 <p>Each <a>browsing context</a> has an associated
- <dfn data-lt="window handle|window handles">window handle</dfn> (string)
+ <dfn data-lt="window handles">window handle</dfn> (string)
  uniquely identifying it.
  It must not be "<code>current</code>".
 
@@ -3642,18 +3642,18 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  holding a <a>UUID</a> value.
 
 <p>Each <a>browsing context</a> has an associated list of
- <dfn data-lt="known elements|known element">known elements</dfn>.
+ <dfn data-lt="known element">known elements</dfn>.
  When the <a>browsing context</a> is <a>discarded</a>,
  the list of <a>known elements</a> is discarded along with it.
 
-<p>To <dfn data-lt="get a known element|getting a known element">get a known element</dfn>
+<p>To <dfn data-lt="getting a known element">get a known element</dfn>
  by a <a>UUID</a> <var>reference</var>,
  return <a>success</a> with the <a>known element</a>
  which <a>web element reference</a> matches <var>reference</var>.
  If there are none, return <a>error</a>
  with <a>error code</a> <a>no such element</a>.
 
-<p>To <dfn data-lt="create a web element reference|create an element">create a web element reference</dfn>
+<p>To <dfn data-lt="create an element">create a web element reference</dfn>
  for an <a><var>element</var></a>:
 
 <ol>
@@ -3707,7 +3707,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
 <p>A <a>stale element</a> is a reference to a <a>node</a>
  that has been disconnected from the <a>current browsing context</a>’s DOM.
- To determine if an <var>element</var> <dfn data-lt="is stale|stale element">is stale</dfn>,
+ To determine if an <var>element</var> <dfn data-lt="stale element">is stale</dfn>,
  run the following substeps:
 
 <ol>
@@ -7806,7 +7806,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  or a dialog spawned by <a><code>showModalDialog()</code></a>
  should this be supported by the user agent.
 
-<p>To <dfn data-lt="dismiss|dismissed|dismisses">dismiss</dfn>
+<p>To <dfn data-lt="dismissed|dismisses">dismiss</dfn>
  the <a>current user prompt</a>,
  do so as if the user would click the <b>Cancel</b> or <b>OK</b> button,
  whichever is present, in that order.
@@ -8304,7 +8304,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  if any part of it is drawn on the canvas within the bounderies of the viewport.
 
 <p>When asked to
- <dfn data-lt="normalize style pixel values to floating point|normalized style pixel float value">normalize style pixel values to floating point</dfn>
+ <dfn data-lt="normalized style pixel float value">normalize style pixel values to floating point</dfn>
  for a value <var>s</var> of the type string:
 
 <ol>
@@ -8334,7 +8334,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  we should change it to be an accurate description
  of what Selenium does.
 
-<p>The <dfn data-lt="element displayed|element displayedness|not displayed">element displayed</dfn> algorithm
+<p>The <dfn data-lt="element displayedness|not displayed">element displayed</dfn> algorithm
  is a boolean state where true signifies that the element is displayed
  and false signifies that the element is not displayed.
  To compute the state on <var>element</var>:


### PR DESCRIPTION
Newer versions of respec identify the content of <dfn> as if it was
in the data-lt attribute. Everything works fine without this minor
cleanup change, it merely makes the HTML a bit more simple.

Fixes https://github.com/w3c/webdriver/issues/477

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/526)
<!-- Reviewable:end -->
