### PR TITLE
Remove superfluous use of null in capabilities checks. Fixes #454

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1867,7 +1867,7 @@ named "<code>capabilities</code>" from <var>parameters</var>.
 named "<code>alwaysMatch</code>" from <var>capabilities request</var>.
 
   <ol>
-  <li><p>If <var>required capabilities</var> is <a>null</a> or <a>undefined</a>,
+  <li><p>If <var>required capabilities</var> is <a>undefined</a>,
   set the value to an empty JSON <a>Object</a>.
 
   <li><p>If <var>required capabilities</var> is not a JSON <a>Object</a>,
@@ -1878,7 +1878,7 @@ named "<code>alwaysMatch</code>" from <var>capabilities request</var>.
 named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
   <ol>
-  <li><p>If <var>desired capabilities</var> is <a>null</a> or <a>undefined</a>,
+  <li><p>If <var>desired capabilities</var> is <a>undefined</a>,
   set the value to a JSON <a>List</a> with a single entry of an empty JSON <a>Object</a>.
 
   <li><p>If <var>desired capabilities</var> is not a JSON <a>List</a>,
@@ -1926,7 +1926,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <li><p>Let <var>result</var> be a JSON <a>Object</a> with the same entries as
 <var>primary</var>.
 
-<li><p>If <var>secondary</var> is <a>null</a> or <a>undefined</a>, return
+<li><p>If <var>secondary</var> is <a>undefined</a>, return
 <var>result</var>.
 
 <li><p>Let <var>k</var> be 0.


### PR DESCRIPTION
Null and undefined are discrete types so we only need to check for
one of them when discussing JSON Objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/531)
<!-- Reviewable:end -->
