### PR TITLE
Unify wording for CSS class `.switch`

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2008,7 +2008,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
   <li><p>Let <var>capability value</var> be the value of the entry at index
   <var>k</var> in <var>capabilities</var>.
 
-  <li><p>Switch on <var>capability name</var>:
+  <li><p>Run the substeps of the first matching <var>capability name</var>:
 
     <dl class=switch>
       <dt>"<code>browserName</code>"
@@ -4827,7 +4827,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
   if it is a <a>success</a>.
   Otherwise return <var>element result</var>.
 
- <li><p>Match case-insensitively on the <var>element</var>'s tag name:
+ <li><p>Run the substeps of the first step that case-insensitively
+  matches the <var>element</var>'s tag name:
 
   <dl class=switch>
    <dt><code>"input"</code>
@@ -4864,7 +4865,9 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
    is not equal to <var>container</var> return <a>error</a> with
    <a>error code</a> <a>element click intercepted</a>.
 
- <li><p>Match case-insensively on <var>element</var>'s tag name:
+ <li><p>Run the substeps of the first step that case-insensitively
+  matches the <var>element</var>'s tag name:
+
   <dl>
    <dt><code>option</code>
    <dd><p>If <var>container</var> <code><a>hasAttribute</a>
@@ -7508,7 +7511,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
             the <code>origin</code> property of <var>action
             object</var>.</li>
 
-        <li><p>Match on the value of <var>origin</var>:
+        <li><p>Run the substeps of the first matching
+            value of <var>origin</var>:
             <dl>
               <dt><code>"viewport"</code></dt>
               <dd><p>Let <var>x</var> equal <var>x offset</var> and
@@ -7890,7 +7894,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  <li><p>If there is no <a>current user prompt</a>,
   abort these steps and return <a>success</a>.
 
- <li><p>Match on the <a>user prompt handler</a>:
+ <li><p>Run the substeps of the first matching
+  <a>user prompt handler</a>:
 
   <dl class=switch>
    <dt><a>dismiss state</a>
@@ -8039,7 +8044,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  <li><p>If there is no <a>current user prompt</a>,
   return <a>error</a> with <a>error code</a> <a>no such alert</a>.
 
- <li><p>Match on <a>current user prompt</a>:
+ <li><p>Run the substeps of the first matching
+  <a>current user prompt</a>:
 
   <dl class=switch>
    <dt><a>alert</a>


### PR DESCRIPTION
Fixes part of https://github.com/w3c/webdriver/issues/529

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/548)
<!-- Reviewable:end -->
