### PR TITLE
Limit extension commands to lower ASCII alphabet code points

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -384,6 +384,13 @@ var respecConfig = {
   <dd><p>The specification uses
    <dfn data-lt="uri template">URI Templates</dfn>. [[!URI-TEMPLATE]]
 
+ <dt>Infra
+ <dd>The following terms are defined
+  in the Infra standard: [[!INFRA]]
+   <ul>
+    <!-- ASCII lower alpha --> <li><dfn><a href=https://infra.spec.whatwg.org/#ascii-lower-alpha>ASCII lower alpha</a></dfn>
+   </ul>
+
  <dt>Styling
  <dd>The following terms are defined in
   the CSS Values and Units Module Level 3 specification: [[!CSS3-VALUES]]
@@ -504,9 +511,6 @@ var respecConfig = {
  Conversely, the shorthand
  <dfn>max</dfn>(<var>value</var>, <var>value</var>[, <var>value</var>])
  returns the largest item of two or more values.
-
-<p>An <dfn>ASCII string</dfn> is a string
- in the range U+0000 to U+007F, inclusive.
 
 <p>A <dfn data-lt=uuid>Universally Unique IDentifier (UUID)</dfn> is
  a 128 bits long URN that requires no central registration process. [[!RFC4122]].
@@ -1499,7 +1503,7 @@ var respecConfig = {
 
 <p>Each <a>extension command</a> has an associated
  <dfn>extension command name</dfn>
- that is a lowercased <a>ASCII string</a>,
+ that is an <a>ASCII lower alpha</a> string,
  and which should bear some resemblance to what the command performs.
  The name is used to form an <a>extension command</a>’s
  <a data-lt="extension command URL">URL</a>.
@@ -1527,7 +1531,7 @@ var respecConfig = {
 </aside>
 
 <p>An <dfn>extension command prefix</dfn>
- is a lowercased <a>ASCII string</a> that forms a <a>URL</a> path element,
+ is an <a>ASCII lower alpha</a> string that forms a <a>URL</a> path element,
  separating <a>extension commands</a> from other <a>commands</a>
  in order to avoid potential resource conflicts with other implementations.
  It is suggested that vendors use their vendor prefixes


### PR DESCRIPTION
This effectively excludes the default- and user encode sets which
contains unwanted characters to include in the concatenated URL that
makes up the extension command URL.

Fixes: https://github.com/w3c/webdriver/issues/566

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/567)
<!-- Reviewable:end -->
