### PR TITLE
Ensure the correct browsing context is checked per-command.

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3009,7 +3009,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  by its associated <a>window handle</a>.
  A <a>top-level browsing context</a> is selected
  using the <a>Switch To Window</a> command.
- Once this is done, a specific browsing context can be selected
+ Once this is done, a specific <a>browsing context</a> can be selected
  using the <a>Switch to Frame</a> command.
 
 <p class=note>The use of the term “window” to
@@ -3018,8 +3018,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  the operating system notion of a “window”
  or the DOM <a><code>Window</code></a> object.
 
-<p>The <a>top-level browsing context</a> is said
- to be <dfn>no longer open</dfn> if it has been <a>discarded</a>.
+<p>A <a>browsing context</a> is said to be <dfn>no longer open</dfn>
+ if it has been <a>discarded</a>.
 
 <p>Each <a>browsing context</a> has an associated
  <dfn data-lt="window handles">window handle</dfn> (string)
@@ -3944,8 +3944,9 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
-  return <a>error</a> with <a>error code</a> <a>no such window</a>.
+ <li><p>If the <a>current browsing context</a> is <a>no longer
+  open</a>, return <a>error</a> with <a>error code</a> <a>no such
+  window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
 
@@ -4188,6 +4189,10 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
+ <li><p>If the <a>current browsing context</a> is <a>no longer
+  open</a>, return <a>error</a> with <a>error code</a> <a>no such
+  window</a>.
+
  <li><p>Let <var>start node</var> be
   the <a>current browsing context</a>’s <a>document element</a>.
 
@@ -4232,6 +4237,10 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  that can be used for future <a>commands</a>.
 
 <ol>
+ <li><p>If the <a>current browsing context</a> is <a>no longer
+  open</a>, return <a>error</a> with <a>error code</a> <a>no such
+  window</a>.
+
  <li><p>Let <var>start node</var> be
   the <a>current browsing context</a>’s <a>document element</a>.
 
@@ -4273,6 +4282,10 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  that can be used for future <a>commands</a>.
 
 <ol>
+ <li><p>If the <a>current browsing context</a> is <a>no longer
+  open</a>, return <a>error</a> with <a>error code</a> <a>no such
+  window</a>.
+
  <li><p>Let <var>start node</var> be the result of
   <a>getting a known element</a> by <a>UUID</a> <var>reference</var>.
 
@@ -4318,6 +4331,10 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  that can be used for future <a>commands</a>.
 
 <ol>
+ <li><p>If the <a>current browsing context</a> is <a>no longer
+  open</a>, return <a>error</a> with <a>error code</a> <a>no such
+  window</a>.
+
  <li><p>Let <var>start node</var> be the result
   of <a>getting a known element</a> by <a>UUID</a> <var>reference</var>.
 
@@ -4421,7 +4438,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
@@ -4479,7 +4496,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
@@ -4544,7 +4561,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
@@ -4593,7 +4610,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
@@ -4656,7 +4673,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
@@ -4701,7 +4718,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
@@ -4766,7 +4783,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
@@ -4830,7 +4847,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
@@ -4894,7 +4911,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p>Let <var>element result</var> be the result of <a>getting a known element</a>
@@ -4989,7 +5006,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p>Let <var>element result</var> be the result of <a>getting a known element</a>
@@ -5081,7 +5098,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
@@ -5220,7 +5237,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
@@ -5518,7 +5535,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
@@ -5575,7 +5592,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
@@ -5819,7 +5836,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
@@ -5856,7 +5873,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
@@ -5892,7 +5909,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
@@ -6010,7 +6027,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
@@ -7799,7 +7816,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
         <p>The <a>remote end steps</a> are:</p>
 
         <ol>
-          <li><p>If the <a>current top-level browsing context</a>
+          <li><p>If the <a>current browsing context</a>
               is <a>no longer open</a>, return <a>error</a>
               with <a>error code</a> <a>no such window</a>.</li>
 
@@ -8049,7 +8066,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current top-leval browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p>If there is no <a>current user prompt</a>,
@@ -8315,7 +8332,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  the <a>element</a> will not be <a>scrolled into view</a>.
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p>Let <var>scroll</var> be true if it is <a>undefined</a>.


### PR DESCRIPTION
Most commands were checking the top-level browsing context
rather than the current browser context. Review each command
and ensure that the correct browser context is checked for
whether it's open.

Closes #397

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/574)
<!-- Reviewable:end -->
