### PR TITLE
`Element Send Keys`: Only focus element if necessary

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5092,12 +5092,18 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
  <li><p><a>Scroll into view</a> the <var>element</var>.
 
- <li><p>Let <var>current text length</var> be the <a>Node Length</a>.
+ <li><p>If <var>element</var> is not the <a>active element</a>:
 
- <li><p>Set the text insertion caret using <a>set selection range</a>
-   with using <var>current text length</var> as the 2 parameters passed in.
+  <ol>
+   <li><p>Run the <a>focusing steps</a> for the <var>element</var>.
 
- <li><p>Run the <a>focusing steps</a> for the <var>element</var>.
+   <li><p>Let <var>current text length</var> be
+    the <var><a>element</a></var>’s <a data-lt="node
+    length">length</a>.
+
+   <li><p>Set the text insertion caret using <a>set selection range</a>
+    with using <var>current text length</var> as the 2 parameters passed in.
+  </ol>
 
  <li><p>Let <var>character array</var> be the result of <a>getting a property</a>
     <code>text</code> from the <var>parameters</var> argument.


### PR DESCRIPTION
This allows users to do something like:

```
element.sendKeys("Hello Worlt!");
element.sendKeys(Keys.LEFT);
element.sendKeys(Keys.BACKSPACE);
element.sendKeys("d!");
```

and have that be equivalent to:

```
element.sendKeys("Hello Worlt!" + Keys.LEFT + Keys.BACKSPACE + "d!");
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/575)
<!-- Reviewable:end -->
