### PR TITLE
Add missing checks for valid top-level browsing context

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4129,6 +4129,9 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <a>remote end steps</a> are:
 
 <ol>
+ <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+  return <a>error</a> with <a>error code</a> <a>no such window</a>.
+
  <li><p>Let <var>start node</var> be
   the <a>current browsing context</a>’s <a>document element</a>.
 
@@ -4172,7 +4175,12 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  is used to find an elements in the <a>current browsing context</a>
  that can be used for future <a>commands</a>.
 
+<p>The <a>remote end steps</a> are:
+
 <ol>
+ <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+  return <a>error</a> with <a>error code</a> <a>no such window</a>.
+
  <li><p>Let <var>start node</var> be
   the <a>current browsing context</a>’s <a>document element</a>.
 
@@ -4213,7 +4221,12 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  in the <a>current browsing context</a>
  that can be used for future <a>commands</a>.
 
+<p>The <a>remote end steps</a> are:
+
 <ol>
+ <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+  return <a>error</a> with <a>error code</a> <a>no such window</a>.
+
  <li><p>Let <var>start node</var> be the result of
   <a>getting a known element</a> by <a>UUID</a> <var>reference</var>.
 
@@ -4258,7 +4271,12 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  in the <a>current browsing context</a>
  that can be used for future <a>commands</a>.
 
+<p>The <a>remote end steps</a> are:
+
 <ol>
+ <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+  return <a>error</a> with <a>error code</a> <a>no such window</a>.
+
  <li><p>Let <var>start node</var> be the result
   of <a>getting a known element</a> by <a>UUID</a> <var>reference</var>.
 
@@ -7654,13 +7672,15 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
     <p>The <a>remote end steps</a> are:
       <ol>
+        <li><p>If the <a>current top-level browsing context</a> is <a>no longer
+            open</a>, return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
         <li><p>Let <var>undo actions</var> be equal to the <a>current
-              session</a>'s <a>input cancel list</a> in reverse
-              order.</li>
+            session</a>'s <a>input cancel list</a> in reverse
+            order.</li>
 
         <li><p><a>Dispatch tick actions</a> with arguments <var>undo
-              actions</var> and duration 0.</li>
+            actions</var> and duration 0.</li>
 
         <li><p>Let the <a>current session</a>'s <a>input cancel actions</a> be
             an empty <a>List</a>.</li>
@@ -8125,6 +8145,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  If given a parameter argument <code>scroll</code>
  that evaluates to false,
  the <a>element</a> will not be <a>scrolled into view</a>.
+
+<p>The <a>remote end steps</a> are:
 
 <ol>
  <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,


### PR DESCRIPTION
This adds the missing remote step for checking for a valid top-level browsing context. In some cases we also missed the leading paragraph.

It fixes issue #508.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/579)
<!-- Reviewable:end -->
