### PR TITLE
Input state object is a table for clarity

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6234,21 +6234,18 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
       <!-- todo: define generating DOM events from an input somewhere -->
   </section> <!-- /Terminology -->
 
-  <!-- TODO: define input source -->
-  <section><!-- Input State -->
-    <h2>Input State</h2>
+<section>
+<h2>Input State</h2>
 
-    <aside class="note">
-      <p>The objects and properties defined in this section are
-      spec-internal constructs and do not correspond to Javascript
-      objects. For convenience the same terminology is used for their
-      manipulation.
-    </aside>
+<p class=note>The objects and properties defined in this section
+ are spec-internal constructs
+ and do not correspond to ECMAScript objects.
+ For convenience the same terminology is used for their manipulation.
 
-    <p>Each <a>session</a> has an associated <dfn>input state</dfn>
-    object. This is a map between <a>input id</a> and the device
-    state for that <a>input source</a>, with one entry for each
-    active <a>input source</a>.
+<p>Each <a>session</a> has an associated <dfn>input state</dfn> table.
+ This is a map between <a>input id</a>
+ and the <a data-lt="input state">device state</a> for that <a>input source</a>,
+ with one entry for each active <a>input source</a>.
 
     <p>Each <a>session</a> also has an associated <dfn>input cancel
     list</dfn>, which is a list of actions. This list is used to


### PR DESCRIPTION
We currently refer to the input state object, but I think it’s clearer to call it an input state table, or possibly map.

This also fixes the reference to JavaScript, which should be ECMAScript.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/600)
<!-- Reviewable:end -->
