### PR TITLE
Add non-normative description of 'browser chrome'

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -562,6 +562,14 @@ var respecConfig = {
   defined by the platform for that property i.e. the value it would
   have in the absence of any shadowing by content script.
 
+<p class=note>The <dfn>browser chrome</dfn> is a non-normative term
+  to describe the user interface of the user agent. Examples of
+  <dfn data-lt="browser chrome element">browser chrome elements</dfn>
+  include but are not limited to: toolbars (such as a bookmark
+  toolbar), menus (such as the file menu), buttons (such as the
+  back button) and decorations (such as security and
+  certificate indicators).
+
 </section> <!-- /Terminology -->
 
 <section>


### PR DESCRIPTION
Fixes https://github.com/w3c/webdriver/issues/565

Attempt to describe (not define) 'browser chrome' and 'browser chrome elements' in chapter [2. Terminology](https://w3c.github.io/webdriver/webdriver-spec.html#terminology#h-terminology)

Once this is settled I'll link text to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/604)
<!-- Reviewable:end -->
