### PR TITLE
Check if element is obscured before testing pointer interactability

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4898,20 +4898,18 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  <li><p><a>Scroll into view</a>
   the <var><a>element</a></var>’s <a>container</a> <a>element</a>.
 
- <li><p>Wait in an implementation-specific way up to the <a>session
-  implicit wait timeout</a> for the <a>container</a> to
-  become <a>pointer-interactable</a>.
+ <li><p>Wait in an implementation-specific way
+  up to the <a>session implicit wait timeout</a>
+  for the <a>container</a> to become <a>pointer-interactable</a>.
 
- <li><p>If <var><a>element</a></var>’s <a>container</a>
+ <li><p>If <a>element from point</a> for
+  the <a>in-view centrepoint</a> of <var>element</var>
+  is not equal to the <var>element</var>’s <a>container</a>,
+  return <a>error</a> with <a>error code</a> <a>element click intercepted</a>.
+
+ <li><p>If <var>element</var>’s <a>container</a>
   is not <a>pointer-interactable</a>,
   return <a>error</a> with <a>error code</a> <a>element not interactable</a>.
-
- <li><p>Let <var>coordinates</var> be the
-  <a>in-view centre point</a> of <a>element</a>.
-
- <li><p>If <a>element from point</a> for <var>coordinates</var>
-   is not equal to the <var>element</var>’s <a>container</a>,
-   return <a>error</a> with <a>error code</a> <a>element click intercepted</a>.
 
  <li><p>Run the substeps of the first step that case-insensitively
   matches the <var>element</var>'s tag name:


### PR DESCRIPTION
The pointer-interactability test will always fail if the element is
obscured, but the intercepted element test will only fail if there is
another overlaying element.

To give the intercepted click test a chance to run, we need to run it
before testing for pointer-interactability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/613)
<!-- Reviewable:end -->
