### PR TITLE
Fix element click

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4963,12 +4963,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
- <li><p>Let <var>element result</var> be the result of <a>getting a known element</a>
-  by <a>UUID</a> reference <var>element id</var>.
-
- <lI><p>Let <var>element</var> be <var>element result</var>’s data
-  if it is a <a>success</a>.
-  Otherwise return <var>element result</var>.
+ <li><p>Let <var>element</var> be the result of <a>trying</a>
+  to <a>get a known element</a> by <a>UUID</a> reference <var>element id</var>.
 
  <li><p>If the <var>element</var> is
   an <a><code>input</code> element</a> in the <a>file upload state</a>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -469,7 +469,7 @@ var respecConfig = {
   the CSSOM View Module: [[!CSSOM-VIEW]]:
   <ul>
    <!-- elementFromPoint --> <li><dfn>Element from point</dfn> as <a href="https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint">elementFromPoint()</a>
-   <!-- elementsFromPoint --> <li><dfn>Elements from point</dfn> as <a href=https://drafts.csswg.org/cssom-view/#dom-document-elementsfrompoint>elementsFromPoint()</a>
+   <!-- elementsFromPoint --> <li><dfn data-lt="paint order">Elements from point</dfn> as <a href=https://drafts.csswg.org/cssom-view/#dom-document-elementsfrompoint>elementsFromPoint()</a>
    <!-- getClientRects --> <li><dfn data-lt="DOM client rectangle"><a href=http://www.w3.org/TR/cssom-view/#dom-range-getclientrects>getClientRects</a></dfn>
    <!-- innerHeight --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-innerheight>innerHeight</a></dfn>
    <!-- innerWidth --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-innerwidth>innerWidth</a></dfn>
@@ -1385,7 +1385,7 @@ var respecConfig = {
   <td><code>element click intercepted</code>
   <td>The <a>Element Click</a> <a>command</a> could not be completed
    because the <a>element</a> receiving the events
-   is not the same element that was requested clicked.
+   is <a>obscuring</a> the element that was requested clicked.
  </tr>
 
  <tr>
@@ -3889,7 +3889,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  keyboard interactions must be targeted to
  its <a><code>ownerDocument</code></a>.
 
-<p>An <a>element</a>’s <dfn>in-view centerpoint</dfn>
+<p>An <a>element</a>’s <dfn data-lt=centerpoint>in-view centerpoint</dfn>
  is the origin position of the rectangle
  that is the intersection between
  the element’s first <a>DOM client rectangle</a>
@@ -3927,6 +3927,11 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  <li><p>Return <var>x</var> and <var>y</var> as a pair.
 </ol>
 
+<p>An <a>element</a> is said to be <dfn data-lt=obscuring>obscured</dfn>
+ if it is not <a>pointer-interactable</a>
+ and the <a>first pointer-interactable element</a>
+ at its <a>centerpoint</a> is not itself.
+
 <p>In order to produce a <dfn>pointer-interactable elements tree</dfn>
  from an <var><a>element</a></var>:
 
@@ -3954,7 +3959,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
   given the coordinates <var>centre point</var>.
 </ol>
 
-<p>To <dfn>get the first pointer-interactable element</dfn>
+<p>To <dfn data-lt="first pointer-interactable element">get the first pointer-interactable element</dfn>
  given a <a>pointer-interactable elements tree</a>,
  return with <a>success</a> the first <a>element</a>
  which style property <code>opacity</code>
@@ -4944,8 +4949,12 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
 <p>The <dfn>Element Click</dfn> <a>command</a>
  <a>scrolls into view</a> the <a>element</a>
- and clicks the <a>in-view centerpoint</a>.
- If the <a>element</a> is not <a>pointer-interactable</a>,
+ if it is not already <a>pointer-interactable</a>,
+ and clicks its <a>in-view centerpoint</a>.
+ If the <a>element</a>’s <a>centerpoint</a>
+ is <a>obscured</a> by another element,
+ an <a>element click intercepted</a> <a>error</a> is returned.
+ If the element is outside the <a>viewport</a>,
  an <a>element not interactable</a> <a>error</a> is returned.
 
 <p>The <a>remote end steps</a> are:

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4980,10 +4980,6 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  <li><p>If <var>container element</var> is still not <a>pointer-interactable</a>,
   return <a>error</a> with <a>error code</a> <a>element not interactable</a>.
 
- <li><p>Wait in an implementation-specific way
-  up to the <a>session implicit wait timeout</a>
-  for the <var>container element</var> to become <a>pointer-interactable</a>.
-
  <li><p>If <a>element from point</a> for
   the <a>in-view centerpoint</a> of <var>element</var>
   is not equal to the <var>container element</var>,

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2292,8 +2292,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  the <a>element location strategy</a>
  when <a href=#element-retrieval>retreiving elements</a> and when
  waiting for an <a>element</a> to become <a>interactable</a> when
- performing <a>element interaction</a> . Unless stated otherwise it is
- zero milliseconds.
+ performing <a href=#element-interaction>element interaction</a> .
+ Unless stated otherwise it is zero milliseconds.
 
 <p>A <a>session</a> has an associated <dfn>page loading strategy</dfn>,
  which is one of <a>none</a>, <a>normal</a>, and <a>eager</a>.
@@ -4925,7 +4925,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 </section> <!-- /Element State -->
 
 <section>
-<h2><dfn>Element Interaction</dfn></h2>
+<h2>Element Interaction</h2>
 
 <p>The <a>element</a> interaction <a>commands</a>
  provide a high-level instruction set for manipulating form controls.

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -433,7 +433,7 @@ var respecConfig = {
  <dd>The following terms are defined in
   the CSS Device Adaptation Module Level 1 specification: [[!CSS-DEVICE-ADAPT]]
    <ul>
-    <!-- Initial viewport --><li><dfn data-lt="viewport|in view"><a href=https://drafts.csswg.org/css-device-adapt/#initial-viewport>Initial viewport</a></dfn>,
+    <!-- Initial viewport --><li><dfn data-lt=viewport><a href=https://drafts.csswg.org/css-device-adapt/#initial-viewport>Initial viewport</a></dfn>,
      sometimes here referred to as the <i>viewport</i>.
    </ul>
 
@@ -3927,7 +3927,10 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  <li><p>Return <var>x</var> and <var>y</var> as a pair.
 </ol>
 
-<p>An <a>element</a> is said to be <dfn data-lt=obscuring>obscured</dfn>
+<p>An <a>element</a> is <dfn>in view</dfn>
+ if it is a member of its own <a>pointer-interactable elements tree</a>.
+
+<p>An <a>element</a> is <dfn data-lt=obscuring>obscured</dfn>
  if it is not <a>pointer-interactable</a>
  and the <a>first pointer-interactable element</a>
  at its <a>centerpoint</a> is not itself.

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4975,21 +4975,23 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
   or it does not have a <a>container</a> <a>element</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
- <li><p><a>Scroll into view</a>
-  the <var><a>element</a></var>’s <a>container</a> <a>element</a>.
+ <li><p>Let <var>container element</var> be
+  the <a>element</a>’s <a>container</a> <a>element</a>.
+
+ <li><p>If <var>container element</var> is not <a>pointer-interactable</a>,
+  <a>scroll into view</a> <var>container element</var>.
+
+ <li><p>If <var>container element</var> is still not <a>pointer-interactable</a>,
+  return <a>error</a> with <a>error code</a> <a>element not interactable</a>.
 
  <li><p>Wait in an implementation-specific way
   up to the <a>session implicit wait timeout</a>
-  for the <a>container</a> to become <a>pointer-interactable</a>.
+  for the <var>container element</var> to become <a>pointer-interactable</a>.
 
  <li><p>If <a>element from point</a> for
   the <a>in-view centerpoint</a> of <var>element</var>
-  is not equal to the <var>element</var>’s <a>container</a>,
+  is not equal to the <var>container element</var>,
   return <a>error</a> with <a>error code</a> <a>element click intercepted</a>.
-
- <li><p>If <var>element</var>’s <a>container</a>
-  is not <a>pointer-interactable</a>,
-  return <a>error</a> with <a>error code</a> <a>element not interactable</a>.
 
  <li><p>Run the substeps of the first step that case-insensitively
   matches the <var>element</var>'s tag name:

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3878,7 +3878,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
 <p>A <dfn data-lt="pointer-interactable">pointer-interactable element</dfn>
  is defined to be the first non-transparent <a>element</a>,
- defined by the paint order found at the <a>center point</a>
+ defined by the <a>paint order</a> found at the <a>center point</a>
  of its rectangle that is inside the <a>viewport</a>,
  excluding the size of any rendered scrollbars.
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4951,7 +4951,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  <a>scrolls into view</a> the <a>element</a>
  if it is not already <a>pointer-interactable</a>,
  and clicks its <a>in-view centerpoint</a>.
- If the <a>element</a>’s <a>centerpoint</a>
+ If the element’s <a>centerpoint</a>
  is <a>obscured</a> by another element,
  an <a>element click intercepted</a> <a>error</a> is returned.
  If the element is outside the <a>viewport</a>,
@@ -4971,22 +4971,15 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
   or it does not have a <a>container</a> <a>element</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
- <li><p>Let <var>container element</var> be
-  the <a>element</a>’s <a>container</a> <a>element</a>.
+ <li><p><a>Scroll into view</a> <var>element</var>’s <a>container</a>
+  if it is not <a>pointer-interactable</a>.
 
- <li><p>If <var>container element</var> is not <a>pointer-interactable</a>,
-  <a>scroll into view</a> <var>container element</var>.
-
- <li><p>If <var>container element</var> is still not <a>pointer-interactable</a>,
+ <li><p>If <var>element</var>’s <a>container</a> is still not <a>in view</a>,
   return <a>error</a> with <a>error code</a> <a>element not interactable</a>.
 
- <li><p>If <a>element from point</a> for
-  the <a>in-view centerpoint</a> of <var>element</var>
-  is not equal to the <var>container element</var>,
+ <li><p>If <var>element</var>’s <a>container</a>
+  is <a>obscured</a> by another <a>element</a>,
   return <a>error</a> with <a>error code</a> <a>element click intercepted</a>.
-
- <li><p>Run the substeps of the first step that case-insensitively
-  matches the <var>element</var>'s tag name:
 
  <li><p>Matching on <var>element</var>:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4976,6 +4976,10 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
  <li><p><a>Scroll into view</a> <var>element</var>’s <a>container</a>
   if it is not <a>pointer-interactable</a>.
+ 
+ <li><p>Wait in an implementation-specific way
+  up to the <a>session implicit wait timeout</a>
+  for the <a>container</a> to become <a>pointer-interactable</a>.
 
  <li><p>If <var>element</var>’s <a>container</a> is still not <a>in view</a>,
   return <a>error</a> with <a>error code</a> <a>element not interactable</a>.

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3878,7 +3878,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
 <p>A <dfn data-lt="pointer-interactable">pointer-interactable element</dfn>
  is defined to be the first non-transparent <a>element</a>,
- defined by the paint order found at the centerpoint
+ defined by the paint order found at the <a>center point</a>
  of its rectangle that is inside the <a>viewport</a>,
  excluding the size of any rendered scrollbars.
 
@@ -3889,7 +3889,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  keyboard interactions must be targeted to
  its <a><code>ownerDocument</code></a>.
 
-<p>An <a>element</a>’s <dfn data-lt=centerpoint>in-view centerpoint</dfn>
+<p>An <a>element</a>’s <dfn data-lt="center point">in-view center point</dfn>
  is the origin position of the rectangle
  that is the intersection between
  the element’s first <a>DOM client rectangle</a>
@@ -3933,7 +3933,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>An <a>element</a> is <dfn data-lt=obscuring>obscured</dfn>
  if it is not <a>pointer-interactable</a>
  and the <a>first pointer-interactable element</a>
- at its <a>centerpoint</a> is not itself.
+ at its <a>center point</a> is not itself.
 
 <p>In order to produce a <dfn>pointer-interactable paint tree</dfn>
  from an <var><a>element</a></var>:
@@ -3955,7 +3955,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
   return an empty sequence.
 
  <li><p>Let <var>center point</var> be
-  the <a>in-view centerpoint</a> of <var>element</var>
+  the <a>in-view center point</a> of <var>element</var>
   given the first indexed element of <var>rectangles</var>.
 
  <li><p>Return the <a>elements from point</a>
@@ -4953,8 +4953,8 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 <p>The <dfn>Element Click</dfn> <a>command</a>
  <a>scrolls into view</a> the <a>element</a>
  if it is not already <a>pointer-interactable</a>,
- and clicks its <a>in-view centerpoint</a>.
- If the element’s <a>centerpoint</a>
+ and clicks its <a>in-view center point</a>.
+ If the element’s <a>center point</a>
  is <a>obscured</a> by another element,
  an <a>element click intercepted</a> <a>error</a> is returned.
  If the element is outside the <a>viewport</a>,
@@ -7819,7 +7819,7 @@ must run the following steps:
 
                   <li><p>Let <var>x element</var> and <var>y
                   element</var> be the result of calculating the
-                    <a>in-view centerpoint</a>
+                    <a>in-view center point</a>
                     of <var>element</var>.</li>
 
                   <li><p>Let <var>x</var> equal <var>x element</var>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3878,7 +3878,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
 <p>A <dfn data-lt="pointer-interactable">pointer-interactable element</dfn>
  is defined to be the first non-transparent <a>element</a>,
- defined by the paint order found at the centre point
+ defined by the paint order found at the centerpoint
  of its rectangle that is inside the <a>viewport</a>,
  excluding the size of any rendered scrollbars.
 
@@ -3928,14 +3928,14 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 </ol>
 
 <p>An <a>element</a> is <dfn>in view</dfn>
- if it is a member of its own <a>pointer-interactable elements tree</a>.
+ if it is a member of its own <a>pointer-interactable paint tree</a>.
 
 <p>An <a>element</a> is <dfn data-lt=obscuring>obscured</dfn>
  if it is not <a>pointer-interactable</a>
  and the <a>first pointer-interactable element</a>
  at its <a>centerpoint</a> is not itself.
 
-<p>In order to produce a <dfn>pointer-interactable elements tree</dfn>
+<p>In order to produce a <dfn>pointer-interactable paint tree</dfn>
  from an <var><a>element</a></var>:
 
 <ol>
@@ -3945,7 +3945,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
  <li><p>Let <var>rectangles</var> be
   the <a><code>DOMRect</code></a> sequence
-  returned by calling <a>getClientRects</a> on <var><a>element</a></var>.
+  returned by calling <var>element</var>’s <a>getClientRects</a>.
 
  <!--
   An element which style property `display` is "none"
@@ -3954,16 +3954,16 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  <li><p>If <var>rectangles</var> has the length of 0,
   return an empty sequence.
 
- <li><p>Let <var>centre point</var> be
+ <li><p>Let <var>center point</var> be
   the <a>in-view centerpoint</a> of <var>element</var>
   given the first indexed element of <var>rectangles</var>.
 
  <li><p>Return the <a>elements from point</a>
-  given the coordinates <var>centre point</var>.
+  given the coordinates <var>center point</var>.
 </ol>
 
 <p>To <dfn data-lt="first pointer-interactable element">get the first pointer-interactable element</dfn>
- given a <a>pointer-interactable elements tree</a>,
+ given a <a>pointer-interactable paint tree</a>,
  return with <a>success</a> the first <a>element</a>
  which style property <code>opacity</code>
  has the <a>computed value</a> of "1";

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -433,7 +433,7 @@ var respecConfig = {
  <dd>The following terms are defined in
   the CSS Device Adaptation Module Level 1 specification: [[!CSS-DEVICE-ADAPT]]
    <ul>
-    <!-- Initial viewport --><li><dfn data-lt=viewport><a href=https://drafts.csswg.org/css-device-adapt/#initial-viewport>Initial viewport</a></dfn>,
+    <!-- Initial viewport --><li><dfn data-lt="viewport|in view"><a href=https://drafts.csswg.org/css-device-adapt/#initial-viewport>Initial viewport</a></dfn>,
      sometimes here referred to as the <i>viewport</i>.
    </ul>
 
@@ -470,7 +470,7 @@ var respecConfig = {
   <ul>
    <!-- elementFromPoint --> <li><dfn>Element from point</dfn> as <a href="https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint">elementFromPoint()</a>
    <!-- elementsFromPoint --> <li><dfn>Elements from point</dfn> as <a href=https://drafts.csswg.org/cssom-view/#dom-document-elementsfrompoint>elementsFromPoint()</a>
-   <!-- getClientRects --> <li><dfn><a href=http://www.w3.org/TR/cssom-view/#dom-range-getclientrects>getClientRects</a></dfn>
+   <!-- getClientRects --> <li><dfn data-lt="DOM client rectangle"><a href=http://www.w3.org/TR/cssom-view/#dom-range-getclientrects>getClientRects</a></dfn>
    <!-- innerHeight --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-innerheight>innerHeight</a></dfn>
    <!-- innerWidth --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-innerwidth>innerWidth</a></dfn>
    <!-- moveTo --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-moveto>moveTo(x, y)</a></dfn>
@@ -3889,13 +3889,13 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
  keyboard interactions must be targeted to
  its <a><code>ownerDocument</code></a>.
 
-<p>An <a>element</a>’s <dfn>in-view centre point</dfn>
- is the centre point of the area
- of the first <a data-lt="getClientRects">DOM client rectangle</a>
- that is inside the <a>viewport</a>.
- It can be calculated this way,
- given an element, here called <var>rectangle</var>,
- off a <a><code>DOMRect</code></a> sequence:
+<p>An <a>element</a>’s <dfn>in-view centerpoint</dfn>
+ is the origin position of the rectangle
+ that is the intersection between
+ the element’s first <a>DOM client rectangle</a>
+ and the <a>initial viewport</a>.
+ Given an <a>element</a> that is known to be <a>in view</a>,
+ it can be calculated this way:
 
 <ol>
  <li><p>Let <var>rectangle</var> be
@@ -3947,7 +3947,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
   return an empty sequence.
 
  <li><p>Let <var>centre point</var> be
-  the <a>in-view centre point</a> of <var>element</var>
+  the <a>in-view centerpoint</a> of <var>element</var>
   given the first indexed element of <var>rectangles</var>.
 
  <li><p>Return the <a>elements from point</a>
@@ -4944,7 +4944,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
 
 <p>The <dfn>Element Click</dfn> <a>command</a>
  <a>scrolls into view</a> the <a>element</a>
- and clicks the <a>in-view centre point</a>.
+ and clicks the <a>in-view centerpoint</a>.
  If the <a>element</a> is not <a>pointer-interactable</a>,
  an <a>element not interactable</a> <a>error</a> is returned.
 
@@ -4974,7 +4974,7 @@ named "<code>firstMatch</code>" from <var>capabilities request</var>.
   for the <a>container</a> to become <a>pointer-interactable</a>.
 
  <li><p>If <a>element from point</a> for
-  the <a>in-view centre point</a> of <var>element</var>
+  the <a>in-view centerpoint</a> of <var>element</var>
   is not equal to the <var>element</var>’s <a>container</a>,
   return <a>error</a> with <a>error code</a> <a>element click intercepted</a>.
 
@@ -7820,7 +7820,7 @@ must run the following steps:
 
                   <li><p>Let <var>x element</var> and <var>y
                   element</var> be the result of calculating the
-                    <a>in-view centre point</a>
+                    <a>in-view centerpoint</a>
                     of <var>element</var>.</li>
 
                   <li><p>Let <var>x</var> equal <var>x element</var>


### PR DESCRIPTION
This PR addresses some fundamental misconceptions about pointer-interactability. My changes from earlier today in https://github.com/w3c/webdriver/pull/613 were misleading because I also mis-remembered how it worked.

Pointer-interactability and whether an element is obscured by another is the same basic idea: pointer-interactability assumes the element is inside the viewport, looks at the paint order and checks if the topmost non-transparent at the element’s centrepoint is itself. The obscured element test that was added recently to return a distinctive error message _is exactly the same_ as this check.

This PR changes the behaviour of the _element not interactable_ error to mean that it is outside the viewport. If the element is not pointer-interactable (that is, it is not ‘obscured’), an _element click intercepted_ error is returned instead, preserving existing behaviour.

I’ve implemented this algorithm in Marionette and it seems to work fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/616)
<!-- Reviewable:end -->
