### PR TITLE
Avoid capitalisation of definitions in Nodes chapter

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -648,14 +648,14 @@ var respecConfig = {
 <p>The WebDriver protocol consists of communication between:
 
 <dl>
- <dt><dfn data-lt="local ends|local">Local End</dfn>
+ <dt><dfn data-lt="local ends|local">Local end</dfn>
  <dd><p>The local end represents the client side of the protocol,
   which is usually in the form of language-specific libraries
   providing an API on top of the WebDriver <a href=#protocol>protocol</a>.
   This specification does not place any restrictions on the details of those libraries
   above the level of the wire protocol.
 
- <dt><dfn data-lt="remote ends|remote">Remote End</dfn>
+ <dt><dfn data-lt="remote ends|remote">Remote end</dfn>
  <dd>The remote end hosts the server side of the <a href=#protocol>protocol</a>.
   Defining the behaviour of a remote end in response to the WebDriver protocol
   forms the largest part of this specification.
@@ -665,7 +665,7 @@ var respecConfig = {
  classes, known as <dfn data-lt="node type">node types</dfn>:
 
 <dl>
- <dt><dfn data-lt="intermediary nodes">Intermediary Node</dfn>
+ <dt><dfn data-lt="intermediary nodes">Intermediary node</dfn>
  <dd>Intermediary nodes are those that act as proxies,
   implementing both the client and server sides of the <a href=#protocol>protocol</a>.
   Intermediary nodes must be black-box indistinguishable from a <a>remote end</a>
@@ -673,7 +673,7 @@ var respecConfig = {
   and so are bound by the requirements on a <a>remote end</a> in terms of the wire protocol.
   However they are not expected to implement <a>remote end steps</a> directly.
 
- <dt><dfn>Endpoint Node</dfn>
+ <dt><dfn>Endpoint node</dfn>
  <dd>An endpoint node is the final <a>remote end</a>
   in a chain of nodes that is not an <a>intermediary node</a>.
   The endpoint node is implemented by a user agent or a similar program.
@@ -685,12 +685,12 @@ var respecConfig = {
  for each <a>node type</a> said to be:
 
 <dl class=switch>
- <dt><a>intermediary node</a>
+ <dt><a>Intermediary node</a>
  <dd><p>False if it is known to be in a state
   in which attempting to create a <a>new session</a> would fail.
   Otherwise true.
 
- <dt><a>endpoint node</a>
+ <dt><a>Endpoint node</a>
  <dd><p>False if the <a>maximum active sessions</a>
   is equal to the length of the list of <a>active sessions</a>
   or there is a <a>current user prompt</a> present.


### PR DESCRIPTION
It’s worth pointing out that ReSpec takes care of this and lower-cases them when viewing the HTML document in a browser. However, it’s worth having the same consistency before us when we edit the document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/623)
<!-- Reviewable:end -->
