### PR TITLE
Specify argument to "getting a known element"

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4333,7 +4333,7 @@ with a "<code>moz:</code>" prefix:
   window</a>.
 
  <li><p>Let <var>start node</var> be the result of
-  <a>getting a known element</a> by <a>UUID</a> <var>reference</var>.
+  <a>getting a known element</a> by <a>UUID</a> reference <var>element id</var>.
 
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".
@@ -4382,7 +4382,7 @@ with a "<code>moz:</code>" prefix:
   window</a>.
 
  <li><p>Let <var>start node</var> be the result
-  of <a>getting a known element</a> by <a>UUID</a> <var>reference</var>.
+  of <a>getting a known element</a> by <a>UUID</a> reference <var>element id</var>.
 
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".


### PR DESCRIPTION
I think we could do a bit more cleanup here while we're at it. It seems as though the words "reference" and "parameter" that follow most current usages of "getting a known element by UUID" should be removed. Is that right?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/667)
<!-- Reviewable:end -->
