### PR TITLE
Remove undefined argument

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4303,8 +4303,7 @@ with a "<code>moz:</code>" prefix:
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li>Return the result of <a>Find</a> with
-  <var>all</var>, <var>start node</var>,
-  <var>location strategy</var>, and <var>selector</var>.
+  <var>start node</var>, <var>location strategy</var>, and <var>selector</var>.
 </ol>
 </section> <!-- /Find Elements -->
 
@@ -4397,8 +4396,7 @@ with a "<code>moz:</code>" prefix:
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li>Return the result of <a>Find</a> with
-  <var>all</var>, <var>start node</var>,
-  <var>location strategy</var>, and <var>selector</var>.
+  <var>start node</var>, <var>location strategy</var>, and <var>selector</var>.
 </ol>
 </section> <!-- /Find Elements From Element -->
 </section> <!-- /Element Retrieval -->


### PR DESCRIPTION
The variable named "all" is not defined in the call sites for "Find,"
and "Find" does not define such a parameter. Remove the references to
the variable named "all" from the call sites.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/679)
<!-- Reviewable:end -->
