### PR TITLE
The `global key state` definition is not referred to

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -7648,26 +7648,6 @@ must run the following steps:
     <section> <!-- Pointer Actions -->
       <h2>Pointer Actions</h2>
 
-      <p>When required to <dfn data-lt="key-state">get a global key
-        state</dfn> with argument <var>key</var>, a <a>remote end</a> must
-        run the following steps:
-        <ol>
-          <li>Let <var>input state</var> be the <a>current
-              session</a>'s <a>input state</a> object.
-
-          <li>For each <var>device input state</var> that is a value
-            of the <var>input state</var> map:
-
-            <ol>
-              <li>If <var>device input state</var> is a <a>key input
-              state</a> object, and its <code>pressed</code> property
-                contains <var>key</var> return true.
-            </ol>
-          </li>
-
-          <li><p>Return false.</li>
-        </ol>
-
       <p>When required to <dfn>dispatch a pointerDown action</dfn>
         with arguments <var>source id</var>, <var>action
         object</var>, <var>input state</var> and <var>tick


### PR DESCRIPTION
It's safe to remove this from the spec, as it's not
used by anything.

Closes #500. Closes #501 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/684)
<!-- Reviewable:end -->
