### PR TITLE
Correct contradictory description

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -8226,7 +8226,7 @@ must run the following steps:
 
 <p>The <dfn>Get Alert Text</dfn> <a>command</a>
  returns the message of the <a>current user prompt</a>.
- If there is no <a>current user prompt</a>, it returns with null.
+ If there is no <a>current user prompt</a>, it returns an <a>error</a>.
 
 <p>The <a>remote end steps</a> are:
 


### PR DESCRIPTION
Step 2 of the Get Alert Text command dictates that an error must be
returned in the absence of a dialog. Update the command's description to
accurately summarize this behavior.

This resolves gh-631.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/688)
<!-- Reviewable:end -->
