### PR TITLE
Define `input source state` and `input state table` and use them

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2329,7 +2329,7 @@ with a "<code>moz:</code>" prefix:
 <p>A <a>session</a> has an associated <a>user prompt handler</a>. Unless stated
   otherwise it is <code>null</code>.
 
-<p>A <a>session</a> has an associated <a>input state</a>.
+<p>A <a>session</a> has an associated <a>input state table</a>.
 
 <p>A <a>session</a> has an associated <a>input cancel list</a>.
 
@@ -5408,7 +5408,7 @@ must run the following steps:
     arguments <var>text</var> and <var>keyboard</var>.
 
  <li><p>Remove <var>keyboard</var> from the <a>current
-  session</a>'s <a>input state</a>
+  session</a>'s <a>input state table</a>
 
  <li><p>Return <a>success</a> with data null.
 </ol>
@@ -6355,8 +6355,8 @@ must run the following steps:
  and a <dfn>source type</dfn> which determines
  the kind of input the device can provide.
  As with real devices, virtual devices are stateful;
- this state is recorded in an <a data-lt="input state">input device state</a> object
- associated with each device.
+ this state is recorded in an <a>input source state</a> object
+ associated with each <a>input source</a>.
 
 <p>A <dfn>null input source</dfn> is an <a>input source</a> that is
  not associated with a specific physical device. Null input sources
@@ -6472,16 +6472,16 @@ must run the following steps:
  and do not correspond to ECMAScript objects.
  For convenience the same terminology is used for their manipulation.
 
-<p>Each <a>session</a> has an associated <dfn>input state</dfn> table.
+<p>Each <a>session</a> has an associated <dfn>input state table</dfn>.
  This is a map between <a>input id</a>
- and the <a data-lt="input state">device state</a> for that <a>input source</a>,
+ and the <a>input source state</a> for that <a>input source</a>,
  with one entry for each active <a>input source</a>.
 
-<p>A <a>null input source</a> has a corresponding <dfn>null input
- state</dfn> object. This is always an empty object.
+<p>A <a>null input source</a>'s <a>input source state</a> is
+ a <dfn>null input state</dfn>. This is always an empty object.
 
-<p>A <a>key input source</a> has a corresponding <dfn>key input
- state</dfn> object. This is an object with a
+<p>A <a>key input source</a>'s <a>input source state</a> is a
+ <dfn>key input state</dfn> object. This is an object with a
  property, <code>pressed</code>, which is a set of strings
  representing currently pressed keys and
  properties <code>alt</code>, <code>shift</code>, <code>ctrl</code>,
@@ -6493,9 +6493,9 @@ must run the following steps:
  and <code>alt</code>, <code>shift</code>, <code>ctrl</code>,
  and <code>meta</code> all set to <code>false</code>.
 
-<p>A <a>pointer input source</a> has a corresponding <dfn>pointer
- input state</dfn> object. This consists of a <code>subtype</code>
- property, which has the possible
+<p>A <a>pointer input source</a>'s <a>input source state</a> is
+ a <dfn>pointer input state</dfn> object. This consists of
+ a <code>subtype</code> property, which has the possible
  values <code>"mouse"</code>, <code>"pen"</code>,
  and <code>"touch"</code>, a <code>pressed</code> property which is a
  set of unsigned integers, an <code>x</code> property which is an
@@ -6508,7 +6508,10 @@ must run the following steps:
  to <var>subtype</var>, <code>pressed</code> set to an empty set and
  both <code>x</code> and <code>y</code> set to <code>0</code>.
 
-<p>The <dfn>corresponding input state type</dfn>
+<p>"<dfn>Input source state</dfn>" is used as a generic term to
+ describe the state associated with each <a>input source</a>.
+
+<p>The <dfn>corresponding <a>input source state</a> type</dfn>
  for a label <var>action type</var> is given by the following table:
 
 <table class=simple>
@@ -6639,10 +6642,10 @@ must run the following steps:
   to <a>process pointer parameters</a> with argument
   <var>parameters data</var>.
 
- <li><p>If the <a>current session</a>'s <a>input state</a> already has
-  an entry corresponding to <a>input id</a> <var>id</var> and that
-  entry has a type different to the <a>corresponding input state
-  type</a> for <var>type</var>, then return <a>error</a> with
+ <li><p>If the <a>current session</a>'s <a>input state table</a>
+  already has an entry corresponding to <a>input id</a> <var>id</var>
+  and that entry has a type different to the <a>corresponding input
+  source state type</a> for <var>type</var>, then return <a>error</a> with
   <a>error code</a> <a>invalid argument</a>.
 
  <li><p>Let <var>actions</var> be a new list.
@@ -6796,11 +6799,11 @@ must run the following steps:
   or <code>"pointerCancel"</code> return an <a>error</a> with
   <a>error code</a> <a>invalid argument</a>.
 
- <li><p>If the <a>current session</a>'s <a>input state</a> already has
-  an entry corresponding to <a>input id</a> <var>id</var> and that
-  entry has a <code>subtype</code> property with value different
-  to <var>subtype</var> return <a>error</a> with <a>error code</a>
-  <a>invalid argument</a>.
+ <li><p>If the <a>current session</a>'s <a>input state table</a>
+  already has an entry corresponding to <a>input id</a> <var>id</var>
+  and that entry has a <code>subtype</code> property with value
+  different to <var>subtype</var> return <a>error</a> with <a>error
+  code</a> <a>invalid argument</a>.
 
  <li><p>Let <var>action</var> be an <a>action object</a> constructed
   with arguments <var>id</var>, <code>"pointer"</code>, and
@@ -7016,15 +7019,15 @@ must run the following steps:
    <!-- TODO: this next bit doesn't really link to the right
     point in the spec for creating objects of the right type -->
 
-   <li><p>If the <a>current session</a>'s <a>input state</a> doesn't
+   <li><p>If the <a>current session</a>'s <a>input state table</a> doesn't
     have a property corresponding to <var>source id</var>, then let
     the property corresponding to <var>source id</var> be a new object
-    of the <a>corresponding input state type</a> for
+    of the <a>corresponding input source state type</a> for
     <var>source type</var>.
 
-   <li><p>Let <var>device state</var> be the <a>device state</a>
+   <li><p>Let <var>device state</var> be the <a>input source state</a>
     corresponding to <var>source id</var> in the
-    <a>current session</a>’s <a>input state</a> object.
+    <a>current session</a>’s <a>input state table</a>.
 
    <li><p>Let <var>algorithm</var> be the value of the column
     <i>dispatch action algorithm</i> from the following table of
@@ -7899,7 +7902,7 @@ must run the following steps:
  <li><p>Let the <a>current session</a>'s <a>input cancel list</a> be
   an empty <a>List</a>.
 
- <li><p>Let the <a>current session</a>'s <a>input state</a> be
+ <li><p>Let the <a>current session</a>'s <a>input state table</a> be
   an empty map.
 
  <li><p>Return <a>success</a> with data null.


### PR DESCRIPTION
This clears up the current respec warnings in the spec,
but it's a little clumsy --- the `input state table` is not
really necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/709)
<!-- Reviewable:end -->
