### PR TITLE
Try getting element in view before testing pointer-interactability

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4971,12 +4971,12 @@ with a "<code>moz:</code>" prefix:
   or it does not have a <a>container</a> <a>element</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
- <li><p><a>Scroll into view</a> <var>element</var>’s <a>container</a>
-  if it is not <a>pointer-interactable</a>.
+ <li><p><a>Scroll into view</a> the <var>element</var>’s <a>container</a>
+  if it is not <a>in view</a>.
 
  <li><p>Wait in an implementation-specific way
   up to the <a>session implicit wait timeout</a>
-  for the <a>container</a> to become <a>pointer-interactable</a>.
+  for the <a>container</a> to become <a>in view</a>.
 
  <li><p>If <var>element</var>’s <a>container</a> is still not <a>in view</a>,
   return <a>error</a> with <a>error code</a> <a>element not interactable</a>.


### PR DESCRIPTION
We want to check if we are able to get the the element to click into the viewport before checking if we can pointer-interact with it.

If the element is obscured by another element or otherwise cannot be brought into view, we would otherwise end up waiting for the timeout duration before returning an error to the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/718)
<!-- Reviewable:end -->
