### PR TITLE
`New Session`: ignore wild cards

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2134,8 +2134,8 @@ with a "<code>moz:</code>" prefix:
     <dl class=switch>
      <dt>"<code>browserName</code>"
      <dd><p>If <var>capability value</var> is
-      <a>null</a>, <a>undefined</a>, or equal to the string "<code>*</code>",
-      it is considered a match for the entry in <var>matched capabilities</var>.
+      <a>null</a> it is considered a match for the entry
+      in <var>matched capabilities</var>.
 
       <p>Otherwise, if <var>capability value</var> is not a string equal
        to the "<code>browserName</code>" entry in <var>matched capabilities</var>,
@@ -2143,8 +2143,8 @@ with a "<code>moz:</code>" prefix:
 
      <dt>"<code>browserVersion</code>"
      <dd><p>If <var>capability value</var> is
-      <a>null</a>, <a>undefined</a>, or equal to the string "<code>*</code>",
-      it is to be considered a match for the entry in <var>matched capabilities</var>.
+      <a>null</a> it is to be considered a match for the entry
+      in <var>matched capabilities</var>.
 
       <p>Otherwise, compare <var>capability value</var>
        to the "<code>browserVersion</code>" entry in <var>matched capabilities</var>
@@ -2162,8 +2162,8 @@ with a "<code>moz:</code>" prefix:
 
      <dt>"<code>platformName</code>"
      <dd><p>If <var>capability value</var> is
-      <a>null</a>, <a>undefined</a>, or equal to the string "<code>*</code>",
-      it is considered a match for the entry in <var>matched capabilities</var>.
+      <a>null</a> it is considered a match for the entry
+      in <var>matched capabilities</var>.
 
       <p>Otherwise, if <var>capability value</var> is not a string equal
        to the "<code>platformName</code>" entry in <var>matched capabilities</var>,
@@ -2171,8 +2171,8 @@ with a "<code>moz:</code>" prefix:
 
      <dt>"<code>platformVersion</code>"
      <dd><p>If <var>capability value</var> is
-      <a>null</a>, <a>undefined</a>, or equal to the string "<code>*</code>",
-      it is considered a match for the entry in <var>matched capabilities</var>.
+      <a>null</a> it is considered a match for the entry
+      in <var>matched capabilities</var>.
 
       <p>Otherwise, if <var>capability value</var> is not a string equal
        to the "<code>platformVersion</code>" entry in <var>matched capabilities</var>,


### PR DESCRIPTION
Local end should remove `*` and `ANY` entries from capability
objects. They may, optionally, instead set the value to null.

Closes #711

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/728)
<!-- Reviewable:end -->
