### PR TITLE
Specify that remote end must be a HTTP server. Fixes #661

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -796,7 +796,7 @@ var respecConfig = {
 <section>
 <h3>Processing Model</h3>
 
-<p>The <a>remote end</a> acts as an HTTP server
+<p>The <a>remote end</a> is an HTTP server
  reading requests from the client and writing responses,
  typically over a TCP socket.
  For the purposes of this specification we model the data transmission between


### PR DESCRIPTION
Instead of acting like one we now need it to be a HTTP server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/729)
<!-- Reviewable:end -->
