### PR TITLE
`New Session`: list commonly used platform names

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2170,6 +2170,27 @@ with a "<code>moz:</code>" prefix:
        to the "<code>platformName</code>" entry in <var>matched capabilities</var>,
        return null.
 
+      <div class=note>
+       <p>The following platform names are in common usage with
+        well-understood semantics, and should be treated as
+        valid <code>platformName</code>s for the following Operating
+        Systems:
+
+        <table class=simple>
+         <tr>
+          <th>Platform
+          <th>Operating System
+         </tr>
+         <tr><td>linux</td><td>Any OS based upon the Linux kernel and X Windows.</td></tr>
+         <tr><td>mac</td><td>Any version of Apple's OS X.</td></tr>
+         <tr><td>windows</td><td>Any version of Microsoft's Windows, including desktop and mobile versions.</td></tr>
+        </table>
+
+        <p>When an <a>endpoint node</a> reports
+         its <code>plaformName</code> the above platform names should
+         be used.
+      </div>
+
      <dt>"<code>platformVersion</code>"
      <dd><p>If <var>capability value</var> is
       <a>null</a>, <a>undefined</a>, or equal to the string "<code>*</code>",


### PR DESCRIPTION
I've used SHOULD instead of MUST to give implementations some
latitude in OS naming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/731)
<!-- Reviewable:end -->
