### PR TITLE
Return `invalid argument` when asking to handle insecure certificates…

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2206,7 +2206,7 @@ with a "<code>moz:</code>" prefix:
 
       <p>If <var>capability value</var> is <code>true</code>
        and the <a>endpoint node</a> does not support <a>insecure TLS certificates</a>,
-       return null.
+       return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
       <p>Otherwise, set the "<code>acceptInsecureCerts</code>" entry
        in <var>matched capabilities</var> to <var>capability value</var>.


### PR DESCRIPTION
…. Fixes #633

When an remote end is asked to accept insecure certificates and it
can not, return `invalid argument`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/737)
<!-- Reviewable:end -->
