### PR TITLE
Get Window Rect: Make all parameters optional

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3558,11 +3558,6 @@ with a "<code>moz:</code>" prefix:
   the <a>current top-level browsing context</a> for any reason,
   return <a>error</a> with <a>error code</a> <a>unsupported operation</a>.
 
- <li><p>If the properties <code>width</code> or <code>height</code> or
-  <code>x</code> or <code>y</code> from the <var>parameters</var>
-   are not integers, or less than 0 or greater than 2<sup>64</sup> – 1,
-  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
-
  <li><p>Let <var>width</var> be the result of
   <a>getting a property</a> named <code>width</code>
   from the <var>parameters</var> argument, else let it be <code>null</code>.
@@ -3576,6 +3571,11 @@ with a "<code>moz:</code>" prefix:
 
   <li><p>Let <var>y</var> be the result of <a>getting a property</a>
    named <code>x</code> from the <var>parameters</var> argument, else let it be null.
+
+ <li><p>If any of <code>width</code> or <code>height</code> or <code>x</code>
+   or <code>y</code> is neither <code>null</code> nor an integer between 0 and
+   2<sup>64</sup> – 1 (inclusive), return <a>error</a> with <a>error code</a>
+   <a>invalid argument</a>.
 
  <li><p><a>Fully exit fullscreen</a>.
 


### PR DESCRIPTION
I believe this modification is in-line with the authors' underlying intent.
Please note that it also enables a new usage whose validity is a little more
ambiguous: the explicit specification of `null` parameter values, e.g.

```json
{
  "x": 23,
  "y": null,
  "width": 800,
  "height": 600
}
```

Commit message:

> Previously, the language that allowed for unspecified parameters was
> unreachable because a prior algorithm step returned an error in their
> absence.
>
> Defer enforcement of parameter type until after they have been extracted
> from the "parameters" argument. This ensures that unspecified values are
> accepted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/745)
<!-- Reviewable:end -->
