### PR TITLE
Allow hit testing to handle first interactable element. Fixes #746

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2476,7 +2476,7 @@ with a "<code>moz:</code>" prefix:
     take implementation-defined steps to set the user agent proxy
     using the extracted <var>proxy</var> configuration.  If the
     defined proxy cannot be configured or is not a
-    <a>proxy configuration object</a>, return <a>error</a> with 
+    <a>proxy configuration object</a>, return <a>error</a> with
     <a>error code</a> <a>session not created</a>.
 
    <li><p>Let <var>timeouts</var> be the result of getting property
@@ -3908,7 +3908,7 @@ with a "<code>moz:</code>" prefix:
  <a>pointer-interactable</a> or <a>keyboard-interactable</a>.
 
 <p>A <dfn data-lt="pointer-interactable">pointer-interactable element</dfn>
- is defined to be the first <a>non-transparent</a> <a>element</a>,
+ is defined to be the first <a>element</a>,
  defined by the <a>paint order</a> found at the <a>center point</a>
  of its rectangle that is inside the <a>viewport</a>,
  excluding the size of any rendered scrollbars.
@@ -3958,10 +3958,6 @@ with a "<code>moz:</code>" prefix:
  <li><p>Return <var>x</var> and <var>y</var> as a pair.
 </ol>
 
-<p>An <a>element</a> is considered <dfn data-lt="non-transparent">transparent</dfn>
- if its <code>opacity</code> style property
- has the <a>computed value</a> of "1".
-
 <p>An <a>element</a> is <dfn>in view</dfn>
  if it is a member of its own <a>pointer-interactable paint tree</a>.
 
@@ -3999,7 +3995,7 @@ with a "<code>moz:</code>" prefix:
 
 <p>To <dfn data-lt="first pointer-interactable element">get the first pointer-interactable element</dfn>
  given a <a>pointer-interactable paint tree</a>,
- return with <a>success</a> the first <a>transparent</a> <a>element</a>.
+ return with <a>success</a> the first <a>element</a>.
  Otherwise, if there are no such elements, return an <a>error</a>.
 </section> <!-- /Element Interactability -->
 


### PR DESCRIPTION
This removes the check for opacity in interactability checks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/747)
<!-- Reviewable:end -->
