### PR TITLE
Append Considerations to Privacy and Security chapter names

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -8498,7 +8498,7 @@ is also removed.
 </section> <!-- /Screen Capture -->
 
 <section class=appendix>
-<h2>Privacy</h2>
+<h2>Privacy Considerations</h2>
 
 <p>It is advisable that <a>remote ends</a>
  create a new profile when <a data-lt="new session">creating a new session</a>.
@@ -8509,7 +8509,7 @@ is also removed.
 </section>
 
 <section class=appendix>
-<h2>Security</h2>
+<h2>Security Considerations</h2>
 
 <p>A user agent can rely on a command-line flag
  or a configuration option


### PR DESCRIPTION
The 'Privacy' and 'Security' sections exist but the respec lib
complains because they are not named 'Privacy Considerations' or
'Security Considerations':

This specification doesn't appear to have any 'Privacy'
or 'Security' considerations sections. Please consider
adding one, see https://w3ctag.github.io/security-questionnaire/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/767)
<!-- Reviewable:end -->
