### PR TITLE
`Processing Capabilities`: don't include null values when merging capabilities

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2091,27 +2091,51 @@ with a "<code>moz:</code>" prefix:
  an <a>endpoint node</a> must take the following steps:
 
 <ol>
- <li><p>Let <var>result</var> be a JSON <a>Object</a>
-  with the same entries as <var>primary</var>.
+ <li><p>Let <var>result</var> be a new JSON <a>Object</a>.
 
- <li><p>If <var>secondary</var> is <a>undefined</a>, return <var>result</var>.
-
- <li><p>For each <var>key</var> and <var>value</var>
-  of <var>secondary</var>'s <a>own properties</a>:
+ <li><p>For each enumerable <a>own property</a> in <var>primary</var>,
+  run the following substeps:
   <ol>
-   <li><p>Let <var>primary value</var> be the result of <a>getting a
-    property</a> from <var>primary</var> called <var>key</var>.
+   <li><p>Let <var>name</var> be the the name of the property.
 
-   <li><p>If <var>primary value</var> is not
-    <a><code>undefined</code></a> or equal to <var>value</var>
-    return an <a>error</a> with <a>error code</a>
-    <a>invalid argument</a>.
+   <li><p>Let <var>value</var> be the the result of <a>getting a
+    property</a> named <var>name</var> from <var>primary</var>.
 
-   <li><p><a data-lt="setting a property">Set</a>
-    <var>key</var> with value <var>value</var>
+   <li><p>If <var>value</var> is not <a><code>null</code></a>
+    <a>set a property</a> <var>name</var> to <var>value</var> 
     on <var>result</var>.
   </ol>
 
+ <li><p>If <var>secondary</var> is <a>undefined</a>, return <var>result</var>.
+
+ <li><p>For each enumerable <a>own property</a> in <var>secondary</var>,
+  run the following substeps:
+  <ol>
+   <li><p>Let <var>name</var> be the the name of the property.
+
+   <li><p>Let <var>value</var> be the the result of <a>getting a
+    property</a> named <var>name</var> from <var>secondary</var>.
+
+   <li><p>Let <var>primary value</var> be the result of
+    <a>getting a property</a> named <var>name</var> from
+    <var>primary</var>.
+
+   <li><p>Run the substeps of the first matching condition:
+    <dl class=switch>
+     <dt><var>value</var> is <a><code>null</code></a>
+     <dt><var>value</var> and <var>primary value</var> are equal.
+     <dd>Do nothing.
+
+     <dt><var>primary value</var> is <a><code>undefined</code></a>
+     <dd><a>Set a property</a> named <var>name</var>
+      to <var>value</var> on <var>result</var>.
+
+     <dt>Otherwise
+     <dd>Return an <a>error</a> with <a>error code</a>
+      <a>invalid argument</a>.
+    </dl>
+  </ol>
+   
  <li><p>Return <var>result</var>.
 </ol>
 
@@ -2160,20 +2184,12 @@ with a "<code>moz:</code>" prefix:
 
     <dl class=switch>
      <dt>"<code>browserName</code>"
-     <dd><p>If <var>capability value</var> is
-      <a>null</a> it is considered a match for the entry
-      in <var>matched capabilities</var>.
-
-      <p>Otherwise, if <var>capability value</var> is not a string equal
-       to the "<code>browserName</code>" entry in <var>matched capabilities</var>,
-       return <code>null</code>.
+     <dd><p>If <var>capability value</var> is not a string equal to
+       the "<code>browserName</code>" entry in
+       <var>matched capabilities</var>, return <code>null</code>.
 
      <dt>"<code>browserVersion</code>"
-     <dd><p>If <var>capability value</var> is
-      <a>null</a> it is to be considered a match for the entry
-      in <var>matched capabilities</var>.
-
-      <p>Otherwise, compare <var>capability value</var>
+     <dd><p>Compare <var>capability value</var>
        to the "<code>browserVersion</code>" entry in <var>matched capabilities</var>
        using an implementation-defined comparison algorithm.
        The comparison is to accept a <var>capability value</var>
@@ -2188,11 +2204,7 @@ with a "<code>moz:</code>" prefix:
        and standardizing these schemes is beyond the scope of this standard.
 
      <dt>"<code>platformName</code>"
-     <dd><p>If <var>capability value</var> is
-      <a>null</a> it is considered a match for the entry
-      in <var>matched capabilities</var>.
-
-      <p>Otherwise, if <var>capability value</var> is not a string equal
+     <dd><p>If <var>capability value</var> is not a string equal
        to the "<code>platformName</code>" entry in <var>matched capabilities</var>,
        return <code>null</code>.
 
@@ -2217,8 +2229,7 @@ with a "<code>moz:</code>" prefix:
 
      <dt>"<code>acceptInsecureCerts</code>"
      <dd><p>If <var>capability value</var> is not a boolean
-      or <code>null</code>, return <a>error</a> with <a>error
-      code</a> <a>invalid argument</a>.
+      return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
       <p>If <var>capability value</var> is <code>true</code>
        and the <a>endpoint node</a> does not support <a>insecure TLS certificates</a>,


### PR DESCRIPTION
This simplifies some of the later logic and means
that all the fields of the returned result have
defined values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/769)
<!-- Reviewable:end -->
