### PR TITLE
Introduce capability: `setWindowRect`

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1812,6 +1812,14 @@ with a "<code>moz:</code>" prefix:
  </tr>
 
  <tr>
+  <td><dfn data-lt="window dimensioning/positioning">Window dimensioning/positioning</dfn>
+  <td>"<code>setWindowRect</code>"
+  <td>boolean
+   <td>Indicates whether the remote end supports all of the <a>commands</a> in
+   <a href=#h-resizing-and-positioning-windows>Resizing and Positioning Windows</a>.
+ </tr>
+
+ <tr>
   <td><dfn>Session timeouts configuration</dfn>
   <td>"<code>timeouts</code>"
   <td>JSON <a>Object</a>
@@ -2164,6 +2172,10 @@ with a "<code>moz:</code>" prefix:
    <dd>Boolean initially set to false,
     indicating the session will not implicitly trust untrusted
     or self-signed TLS certificates on <a data-lt=go>navigation</a>.
+
+   <dt>"<code>setWindowRect</code>"
+   <dd>Boolean indicating whether the <a>remote end</a> is supports all of the
+    <a>commands</a> in <a href=#h-resizing-and-positioning-windows>Resizing and Positioning Windows</a>.
   </dl>
 
  <li><p>Add any implementation-specific capabilities as entries
@@ -2260,6 +2272,14 @@ with a "<code>moz:</code>" prefix:
 
       <p>Otherwise, set the "<code>proxy</code>" entry
        in <var>matched capabilities</var> to <var>capability value</var>.
+
+     <dt>"<code>setWindowRect</code>"
+     <dd><p>If <var>capability value</var> is not a boolean
+      return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+      <p>If <var>capability value</var> is not equal to the
+       "<code>setWindowRect</code>" entry in
+       <var>matched capabilities</var>, return <code>null</code>.
 
      <dt>"<code>timeouts</code>"
      <dd><p>If <var>capability value</var>
@@ -3506,6 +3526,8 @@ with a "<code>moz:</code>" prefix:
  containing the <a>current top-level browsing context</a>.
  Because different operating system’s window managers provide different abilities,
  not all of the commands in this section can be supported by all <a>remote ends</a>.
+ Support for these <a>commands</a> is determined by the <a>window
+ dimensioning/positioning</a> <a>capability</a>.
  Where a <a>command</a> is not supported,
  an <a>unsupported operation</a> <a>error</a> is returned.
 


### PR DESCRIPTION
I initially attempted to define this capability in terms of, "querying/modifying the top-level browsing context's window rect." That language is not quite accurate, though, since it doesn't necessarily describe "Minimize Window." So that's why I'm suggesting referencing "the commands in Resizing and Positioning Windows" instead. It's less precise, and I couldn't find any precedent for it, so I'm wondering if there's a better way.

I believe this exposes the following behavior, given the listed "capabilities" objects:

- `{ "setWindowRect": true }`: user agent MUST support *every* command in
  "Resizing and Positioning Windows"
- `{ "setWindowRect": false }`: user agent MUST NOT support *one or more*
  commands in "Resizing and Positioning Windows"
- `{}`: user agent MAY support all commands in "Resizing and Positioning
  Windows"

...but I would appreciate confirmation.

This is intended to resolve gh-765.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/775)
<!-- Reviewable:end -->
