### PR TITLE
Fix respec warning about duplicate definition

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1816,7 +1816,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 
  <tr>
-  <td><dfn data-lt="window dimensioning/positioning">Window dimensioning/positioning</dfn>
+  <td><dfn>Window dimensioning/positioning</dfn>
   <td>"<code>setWindowRect</code>"
   <td>boolean
    <td>Indicates whether the remote end supports all of the <a>commands</a> in


### PR DESCRIPTION
Duplicate definition of 'window dimensioning/positioning'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/778)
<!-- Reviewable:end -->
