### PR TITLE
`Actions`: Remove duplicated input state check

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6954,12 +6954,6 @@ is also removed.
   or <code>"pointerCancel"</code> return an <a>error</a> with
   <a>error code</a> <a>invalid argument</a>.
 
- <li><p>If the <a>current session</a>'s <a>input state table</a>
-  already has an entry corresponding to <a>input id</a> <var>id</var>
-  and that entry has a <code>subtype</code> property with value
-  different to <var>subtype</var> return <a>error</a> with <a>error
-  code</a> <a>invalid argument</a>.
-
  <li><p>Let <var>action</var> be an <a>action object</a> constructed
   with arguments <var>id</var>, <code>"pointer"</code>, and
   <var>subtype</var>.


### PR DESCRIPTION
By the time we're processing pointer actions we've
already been through the steps of processing an action
sequence. Within _those_ steps we've already checked
that the input state within the `input state table`
correctly matches expected type for the pointer action.

Address issue #691

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/781)
<!-- Reviewable:end -->
