### PR TITLE
use key of 'pageLoad' instead of 'page load' in timeout capability

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2596,9 +2596,9 @@ with a "<code>moz:</code>" prefix:
       to the value of property "<code>implicit</code>".
       Otherwise, set the <a>session implicit wait timeout</a> to 0 (zero) milliseconds.
 
-     <li><p>If <var>timeouts</var> has a numeric property with key "<code>page load</code>",
+     <li><p>If <var>timeouts</var> has a numeric property with key "<code>pageLoad</code>",
       set the <a>current session</a>’s <a>session page load timeout</a>
-      to the value of property "<code>page load</code>".
+      to the value of property "<code>pageLoad</code>".
       Otherwise, set the <a>session page load timeout</a> to 300,000 milliseconds.
 
      <li><p>If <var>timeouts</var> has a numeric property with key "<code>script</code>",
@@ -2724,7 +2724,7 @@ with a "<code>moz:</code>" prefix:
    <dt>"<code>script</code>"
    <dd><a>session script timeout</a>
 
-   <dt>"<code>page load</code>"
+   <dt>"<code>pageLoad</code>"
    <dd><a>session page load timeout</a>
 
    <dt>"<code>implicit</code>"
@@ -2774,7 +2774,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 
  <tr>
-  <td>"<code>page load</code>"
+  <td>"<code>pageLoad</code>"
   <td><a>session page load timeout</a>
   <td>Provides the timeout limit used to interrupt
   <a data-lt=navigate>navigation</a> of the <a>browsing context</a>.


### PR DESCRIPTION
Almost every other key in the spec uses camel case instead of spaces. This makes it easy in Ruby to implement with immutable symbols. Having a space in a key requires it to be a string. I can obviously make a special translation method if this needs to have a space, but it would be great if that could be avoided.

The only other keys I see that have spaces are the locator strategies, but those are easily handled in the implementation abstraction rather than being part of a user-facing object (like `Capabilities`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/787)
<!-- Reviewable:end -->
