### PR TITLE
Fix up links identified as being dead or incorrect

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -279,7 +279,6 @@ var respecConfig = {
    <!-- Code entry-point --> <li><dfn><a href=https://html.spec.whatwg.org/#code-entry-point>Code entry-point</a></dfn>
    <!-- Cookie-averse Document object --> <li><dfn><a href=https://html.spec.whatwg.org/#cookie-averse-document-object>Cookie-averse <code>Document</code> object</a></dfn>
    <!-- Current entry --> <li><dfn><a href=https://html.spec.whatwg.org/#current-entry>Current entry</a></dfn>
-   <!-- Determine the value of an indexed property --> <li><dfn data-lt="determining the value of an indexed property"><a href=https://html.spec.whatwg.org/#dom-window-item>Determine the value of an indexed property</a></dfn> of a <a><code>Window</code></a> object
    <!-- Disabled --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-disabled>Disabled</a></dfn>
    <!-- Document address --> <li><dfn data-lt=address><a href=https://dom.spec.whatwg.org/#concept-document-url>Document address</a></dfn>
    <!-- Document readiness --> <li><dfn><a href=https://html.spec.whatwg.org/#current-document-readiness>Document readiness</a></dfn>
@@ -292,7 +291,8 @@ var respecConfig = {
    <!-- File upload state --> <li><dfn><a href="https://html.spec.whatwg.org/#file-upload-state-(type=file)">File upload state</a></dfn>
    <!-- Focusing steps --> <li><dfn><a href="https://html.spec.whatwg.org/#focusing-steps">Focusing steps</a></dfn>
    <!-- Fousable area --><li><dfn><a href=https://html.spec.whatwg.org/#focusable-area>Focusable area</a></dfn>
-   <!-- Getting innerText --> <li><dfn><a href=http://rocallahan.github.io/innerText-spec/index.html#setting-innertext>Getting <code>innerText</code></a></dfn>
+   <!-- GetOwnProperty of a Window object --> <li><dfn><a href=https://html.spec.whatwg.org/#windowproxy-getownproperty><code>[[\GetOwnProperty]]</code> of a <code>Window</code> object</a></dfn>
+   <!-- Getting innerText --> <li><dfn><a href=https://html.spec.whatwg.org/#the-innertext-idl-attribute>Getting <code>innerText</code></a></dfn>
    <!-- Hidden --> <li><dfn><a href="https://html.spec.whatwg.org/#hidden-state-%28type=hidden%29">Hidden</a></dfn> state
    <!-- Image Button --> <li><dfn><a href="https://html.spec.whatwg.org/#image-button-state-%28type=image%29">Image Button</a></dfn> state
    <!-- In parallel --> <li><dfn><a href="https://html.spec.whatwg.org/#in-parallel">In parallel</a></dfn>
@@ -314,14 +314,13 @@ var respecConfig = {
    <!-- Replacement enabled --> <li><dfn><a href=https://html.spec.whatwg.org/#replacement-enabled>Replacement enabled</a></dfn>
    <!-- Reset algorithm --><li><dfn><a href=https://html.spec.whatwg.org/#concept-form-reset-control>Reset algorithm</a></dfn>
    <!-- Reset Button --> <li><dfn><a href="https://html.spec.whatwg.org/#reset-button-state-%28type=reset%29">Reset Button</a></dfn> state
-   <!-- Script execution environment --> <li><dfn><a href=https://html.spec.whatwg.org/#script-execution-environment>Script execution environment</a></dfn>
+   <!-- Script execution environment --> <li><dfn><a href=https://html.spec.whatwg.org/#environment>Script execution environment</a></dfn>
    <!-- Script --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-script>Script</a></dfn>
    <!-- Selectedness --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-option-selectedness>Selectedness</a></dfn>
    <!-- Session history --> <li><dfn><a href=https://html.spec.whatwg.org/#session-history>Session history</a></dfn>
    <!-- setSelectionRange --> <li><dfn data-lt="set selection range"><a href=https://html.spec.whatwg.org/#dom-textarea/input-setselectionrange><code>setSelectionRange</code></a></dfn>
    <!-- Settings object --> <li><dfn><a href=https://html.spec.whatwg.org/#settings-object>Settings object</a></dfn>
    <!-- Simple dialogs --> <li><dfn data-lt="simple dialog"><a href=https://html.spec.whatwg.org/#simple-dialogs>Simple dialogs</a></dfn>
-   <!-- Strip leading and trailing white space --><li><dfn data-lt="stripping leading and trailing whitespace"><a href="https://html.spec.whatwg.org/#strip-leading-and-trailing-whitespace">Strip leading and trailing whitespace</a></dfn>
    <!-- Submit Button --> <li><dfn><a href="https://html.spec.whatwg.org/#submit-button-state-%28type=submit%29">Submit Button</a></dfn> state
    <!-- Submittable elements --> <li><dfn data-lt="submittable element"><a href=https://html.spec.whatwg.org/#category-submit>Submittable elements</a></dfn>
    <!-- Top-level browsing context --> <li><dfn data-lt="top-level browsing contexts"><a href=https://html.spec.whatwg.org/#top-level-browsing-context>Top-level browsing context</a></dfn>
@@ -360,7 +359,6 @@ var respecConfig = {
    <!-- Window object --> <li><dfn><a href=https://html.spec.whatwg.org/#the-window-object><code>Window</code></a></dfn> object
    <!-- WindowProxy exotic object --> <li><dfn><a href=https://html.spec.whatwg.org/#windowproxy><code>WindowProxy</code></a></dfn> exotic object
    <!-- readOnly attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#the-readonly-attribute><code>readOnly</code> attribute</a></dfn>
-   <!-- showModalDialog --> <li><dfn><a href=https://html.spec.whatwg.org/#dom-showmodaldialog><code>showModalDialog()</code></a></dfn>
    <!-- type attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-type><code>type</code> attribute</a></dfn>
    <!-- window confirm --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-confirm><code>confirm</code></a></dfn>
    <!-- window.alert --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-alert><code>alert</code></a></dfn>
@@ -440,7 +438,7 @@ var respecConfig = {
  <dd>The following properties are defined in
   the CSS Basic Box Model Level 3 specification: [[!CSS3-BOX]]
    <ul>
-    <!-- Visibility property --> <li>The <dfn><a href=https://drafts.csswg.org/css-box/#visibility><code>visibility</code></a></dfn> property
+    <!-- Visibility property --> <li>The <dfn><a href=https://drafts.csswg.org/css-box/#visibility-prop><code>visibility</code></a></dfn> property
    </ul>
 
  <dd>The following terms are defined in
@@ -516,6 +514,12 @@ var respecConfig = {
  <dd>The following terms are defined in the standard: [[!UAX29]]
   <ul>
    <!-- Breaking text into extended grapheme clusters --><li><dfn data-lt="breaking text into extended grapheme clusters"><a href=http://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries>Grapheme cluster boundaries</a></dfn>
+  </ul>
+
+ <dt>Unicode Standard Annex #44
+ <dd>The following terms are defined in the standard: [[!UAX44]]
+  <ul>
+   <!-- Unicode character property --> <li><dfn><a href=http://unicode.org/reports/tr44/#Properties>Unicode character property</a></dfn>
   </ul>
 
  <dt>URLs
@@ -3525,9 +3529,11 @@ with a "<code>moz:</code>" prefix:
       return <a>error</a> with <a>error code</a> <a>no such frame</a>.
 
      <li><p>Let <var>child window</var> be
-      the <a><code>WindowProxy</code></a> object
-      obtained by <a>determining the value of an indexed property</a>
-      of <var>window</var> with index <var>id</var>.
+      the <a><code>WindowProxy</code></a> object obtained by
+      calling <a><code>[[\GetOwnProperty]]</code> of
+      a <code>Window</code> object</a> <var>window</var> with
+      argument <var>id</var>.
+
 
      <li><p>Set the <a>current browsing context</a> to
       <var>new window</var>’s browsing context.</li>
@@ -4322,9 +4328,9 @@ with a "<code>moz:</code>" prefix:
     returned via a call to <a>Get Element Text</a>
     for <var>element</var>.
 
-   <li><p>Let <var>trimmed text</var> be the result of
-    <a>stripping leading and trailing whitespace</a>
-    from <var>rendered text</var>.
+   <li><p>Let <var>trimmed text</var> be the result of removing
+    all <a>whitespace</a> from the start and end of the
+    string <var>rendered text</var>.
 
    <li><p>If <var>trimmed text</var> equals <var>selector</var>,
     append <var>element</var> to <var>result</var>.
@@ -4880,24 +4886,16 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p>The <dfn>Get Element Text</dfn> <a>command</a>
- intends to return an <a>element</a>’s text “as rendered”.
- This is equivalent to calling <code>element.innerText</code>.
- An <a>element</a>’s rendered text is also used
- for locating <a><code>a</code> elements</a> by their
+<p>The <dfn>Get Element Text</dfn> <a>command</a> intends to return
+ an <a>element</a>’s text “as rendered”.  This is approximately
+ equivalent to calling <code>element.innerText</code>.
+ An <a>element</a>’s rendered text is also used for
+ locating <a><code>a</code> elements</a> by their
  <a>link text</a> and <a>partial link text</a>.
 
-<p class=note>For historical reasons,
- all user agents appear to have implemented
- different sets of heuristics
- for approximating what is considered rendered text.
- WebDriver relies on the unofficial draft of
- the <a href=http://rocallahan.github.io/innerText-spec/index.html><code>innerText</code> specification</a>,
- but please be aware that there may be
- compliance issues between different user agents
- for this command.
- It is expected that <code>innerText</code>
- will <a href=https://github.com/whatwg/html/issues/465>land soon in HTML</a>.
+<p>When processing text, <dfn>whitespace</dfn> is defined as
+ characters from the Unicode Character Database ([[UAX44]]) with the
+ <a>Unicode character property</a> <code>"WSpace=Y"</code>.
 
 <p>The <a>remote end steps</a> are:
 
@@ -8207,10 +8205,8 @@ is also removed.
 </table>
 
 <p>The <dfn>current user prompt</dfn> is said to be the active <a>user prompt</a>,
- which can be one of the entries on the <a>table of simple dialogs</a>,
- the <a>window.<code>print</code></a> dialog,
- or a dialog spawned by <a><code>showModalDialog()</code></a>
- should this be supported by the user agent.
+ which can be one of the entries on the <a>table of simple dialogs</a>, or
+ the <a>window.<code>print</code></a> dialog.
 
 <p>To <dfn data-lt="dismissed|dismisses">dismiss</dfn>
  the <a>current user prompt</a>,


### PR DESCRIPTION
In some cases, this means that we've also had to futz with
the spec text, but the logical meaning should be identical.

The W3C link validtor does not correctly check links into
PDF documents, however loading these in Chrome show that
they are valid.

I've removed the test about showModalDialog since this
method has been removed from modern browsers and is no
longer supported.

This does not fix the broken link in the execute script
section

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/791)
<!-- Reviewable:end -->
