### PR TITLE
`Element Click`: no need to check enabled state

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5222,8 +5222,6 @@ with a "<code>moz:</code>" prefix:
   is <a>obscured</a> by another <a>element</a>,
   return <a>error</a> with <a>error code</a> <a>element click intercepted</a>.
 
- <li><p class=issue>Check if element is enabled.
-
  <li><p>Matching on <var>element</var>:
 
   <dl class=switch>


### PR DESCRIPTION
It's completely legit to click on an element that is not
enabled. Pointless, but still acceptable. The existing
Selenium implementations (based on the atoms) do not bother
with checking this state, so it seems unnecessary for
implementations of this spec to do so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/793)
<!-- Reviewable:end -->
