### PR TITLE
`Timeouts`: Standardise `pageLoad` rather than `page load`

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2065,7 +2065,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 
  <tr>
-  <td>"<code>page load</code>"
+  <td>"<code>pageLoad</code>"
   <td>number
   <td>Specifies the <a>session page load timeout</a>.
  </tr>


### PR DESCRIPTION
A previous change (#787) changed `page load` to `pageLoad`
but we missed the similar change in the `timeouts configuration
object`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/796)
<!-- Reviewable:end -->
