### PR TITLE
Null data on response should be wrapped in JSON object

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -966,9 +966,9 @@ var respecConfig = {
    <dd>"<code>no-cache</code>"
   </dl>
 
- <li><p>If <var>data</var> is not <a><code>null</code></a>, let <var>response</var>’s
-  <a>body</a> be a JSON <a>Object</a> with a key <code>value</code>
-  set to the <a>JSON serialization</a> of <var>data</var>.
+ <li><p>Let <var>response</var>’s <a>body</a> be a JSON <a>Object</a> with
+  a key <code>value</code> set to the <a>JSON serialization</a> of
+  <var>data</var>.
 
  <li><p>Let <var>response bytes</var> be the byte sequence resulting
   from serializing <var>response</var> according to the rules in [[!RFC7230]].


### PR DESCRIPTION
In the `send a response` algorithm, when the data to be returned as the
response for a command is `null`, it should be wrapped in a JSON object
with a `value` property set to `null` rather than sending no body. Fixes
issue #807.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/808)
<!-- Reviewable:end -->
