### PR TITLE
Look up proxyType case insensitively

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -419,6 +419,7 @@ var respecConfig = {
   in the Infra standard: [[!INFRA]]
    <ul>
     <!-- ASCII lower alpha --> <li><dfn><a href=https://infra.spec.whatwg.org/#ascii-lower-alpha>ASCII lower alpha</a></dfn>
+    <!-- ASCII lowercase --> <li><dfn><a href=https://infra.spec.whatwg.org/#ascii-lowercase>ASCII lowercase</a></dfn>
    </ul>
 
  <dt>Page Visibility
@@ -2021,6 +2022,9 @@ with a "<code>moz:</code>" prefix:
 
    <li><p>Let <var>value</var> be the result of <a>getting a
     property</a> named <var>name</var> from <var>parameter</var>.
+
+   <li><p>Let <var>key</var> be the result of
+    <a data-lt="ASCII lowercase">lowercasing</a> <var>key</var>.
 
    <li><p>If there is no matching <code>key</code> for <var>key</var>
     in the <a>proxy configuration</a> table return an <a>error</a>


### PR DESCRIPTION
When deserializing, be kind to folks who are using enums
in the local end and have sent the names of the proxyType
in upper case.

Closes #803

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/811)
<!-- Reviewable:end -->
