### PR TITLE
Intermediary Nodes: it's useful to define upstream and downstream

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -707,9 +707,15 @@ var respecConfig = {
 
 <dl>
  <dt><dfn data-lt="intermediary nodes">Intermediary node</dfn>
- <dd>Intermediary nodes are those that act as proxies,
-  implementing both the client and server sides of the <a href=#protocol>protocol</a>.
-  However they are not expected to implement <a>remote end steps</a> directly.
+ <dd>Intermediary nodes are those that act as proxies, implementing
+  both the <a>local end</a> and <a>remote end</a> of
+  the <a href=#protocol>protocol</a>.  However they are not expected
+  to implement <a>remote end steps</a> directly. All nodes between a
+  specific <a>intermediary node</a> and a <a>local end</a> are said to
+  be <dfn data-lt="downstream node">downstream</dfn> of that
+  node. Conversely, any nodes between a specific <a>intermediary
+  node</a> and an <a>endpoint node</a> are said to
+  be <dfn data-lt="upstream node">upstream</dfn>.
 
  <dt><dfn>Endpoint node</dfn>
  <dd>An endpoint node is the final <a>remote end</a>


### PR DESCRIPTION
What's in the spec for intermediary nodes isn't sufficient to
write one that correctly handles the webdriver protocol. We're
going to need some better definitions, and these will be
simpler to write if we've already defined what "upstream" and
"downstream" mean.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/820)
<!-- Reviewable:end -->
