### PR TITLE
Simplify the introduction of New Session command

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2528,9 +2528,7 @@ with a "<code>moz:</code>" prefix:
 
 <p>The <dfn data-lt="creating a new session">New Session</dfn> <a>command</a>
  creates a new WebDriver <a>session</a> with the <a>endpoint node</a>.
- If the <a>maximum active sessions</a> has been reached,
- there is a problem processing the given <a>capabilities</a>,
- or the provisioning of a <a>remote end</a> is impossible,
+ If the creation fails,
  a <a>session not created</a> <a>error</a> is returned.
 
 <p>If the <a>remote end</a> is an <a>intermediary node</a>,


### PR DESCRIPTION
Fixes https://github.com/w3c/webdriver/issues/826

The introduction of the New Session command lists a number of reasons
for failing to create a new session, but these are already defined in
the algorithm. This causes the overhead of keeping the introduction
in sync with any algorithm changes.

Currently, the introduction was missing:
* a definition for: provisioning of a remote end
* failing due to a user prompt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/827)
<!-- Reviewable:end -->
