### PR TITLE
Action examples diagrams should group actions by ticks

### DIFF
--- a/graphics/note1actions.svg
+++ b/graphics/note1actions.svg
@@ -46,9 +46,9 @@
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" font-family="sans-serif" transform="matrix(1,0,0,1,34,81)" stroke-linecap="butt">
       <text x="98.5042" xml:space="preserve" y="15.9727" clip-path="url(#clipPath2)" stroke="none">pointerDown(element2)</text>
       <rect x="89.5208" y="-5.5625" clip-path="url(#clipPath2)" fill="none" width="155" rx="4" ry="4" height="34" stroke="rgb(153,153,153)"/>
-      <text x="145.5228" xml:space="preserve" y="102.4727" clip-path="url(#clipPath2)" stroke="none">Batch 1</text>
-      <text x="336.5228" xml:space="preserve" y="102.4727" clip-path="url(#clipPath2)" stroke="none">Batch 2</text>
-      <text x="515.0228" xml:space="preserve" y="102.4727" clip-path="url(#clipPath2)" stroke="none">Batch 3</text>
+      <text x="145.5228" xml:space="preserve" y="102.4727" clip-path="url(#clipPath2)" stroke="none">Tick 1</text>
+      <text x="336.5228" xml:space="preserve" y="102.4727" clip-path="url(#clipPath2)" stroke="none">Tick 2</text>
+      <text x="515.0228" xml:space="preserve" y="102.4727" clip-path="url(#clipPath2)" stroke="none">Tick 3</text>
     </g>
     <g fill="rgb(204,255,255)" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,34,81)" stroke="rgb(204,255,255)">
       <rect x="-18.4792" y="-59.5625" clip-path="url(#clipPath2)" width="84" rx="4" ry="4" height="34" stroke="none"/>

--- a/graphics/note2actions.svg
+++ b/graphics/note2actions.svg
@@ -38,9 +38,9 @@
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" font-family="sans-serif" transform="matrix(1,0,0,1,87,121)" stroke-linecap="butt">
       <text x="45.5042" xml:space="preserve" y="-21.5898" clip-path="url(#clipPath2)" stroke="none">pointerDown(element2)</text>
       <rect x="36.5208" y="-43.125" clip-path="url(#clipPath2)" fill="none" width="155" rx="4" ry="4" height="34" stroke="rgb(153,153,153)"/>
-      <text x="92.5228" xml:space="preserve" y="64.9102" clip-path="url(#clipPath2)" stroke="none">Batch 1</text>
-      <text x="283.5228" xml:space="preserve" y="64.9102" clip-path="url(#clipPath2)" stroke="none">Batch 2</text>
-      <text x="462.0228" xml:space="preserve" y="64.9102" clip-path="url(#clipPath2)" stroke="none">Batch 3</text>
+      <text x="92.5228" xml:space="preserve" y="64.9102" clip-path="url(#clipPath2)" stroke="none">Tick 1</text>
+      <text x="283.5228" xml:space="preserve" y="64.9102" clip-path="url(#clipPath2)" stroke="none">Tick 2</text>
+      <text x="462.0228" xml:space="preserve" y="64.9102" clip-path="url(#clipPath2)" stroke="none">Tick 3</text>
     </g>
     <g fill="rgb(204,255,255)" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,87,121)" stroke="rgb(204,255,255)">
       <rect x="-71.4792" y="-97.125" clip-path="url(#clipPath2)" width="84" rx="4" ry="4" height="34" stroke="none"/>

--- a/graphics/note3actions.svg
+++ b/graphics/note3actions.svg
@@ -38,9 +38,9 @@
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" font-family="sans-serif" transform="matrix(1,0,0,1,51,-55)" stroke-linecap="butt">
       <text x="81.0042" xml:space="preserve" y="151.9727" clip-path="url(#clipPath2)" stroke="none">pointerDown(element3)</text>
       <rect x="72.0208" y="130.4375" clip-path="url(#clipPath2)" fill="none" width="155" rx="4" ry="4" height="34" stroke="rgb(153,153,153)"/>
-      <text x="128.0228" xml:space="preserve" y="238.4727" clip-path="url(#clipPath2)" stroke="none">Batch 1</text>
-      <text x="319.0228" xml:space="preserve" y="238.4727" clip-path="url(#clipPath2)" stroke="none">Batch 2</text>
-      <text x="497.5228" xml:space="preserve" y="238.4727" clip-path="url(#clipPath2)" stroke="none">Batch 3</text>
+      <text x="128.0228" xml:space="preserve" y="238.4727" clip-path="url(#clipPath2)" stroke="none">Tick 1</text>
+      <text x="319.0228" xml:space="preserve" y="238.4727" clip-path="url(#clipPath2)" stroke="none">Tick 2</text>
+      <text x="497.5228" xml:space="preserve" y="238.4727" clip-path="url(#clipPath2)" stroke="none">Tick 3</text>
     </g>
     <g fill="rgb(204,255,255)" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,51,-55)" stroke="rgb(204,255,255)">
       <rect x="-35.9792" y="76.4375" clip-path="url(#clipPath2)" width="84" rx="4" ry="4" height="34" stroke="none"/>


### PR DESCRIPTION
Fixes https://github.com/w3c/webdriver/issues/842

The new tick labels have not been centered with the above rectangles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/843)
<!-- Reviewable:end -->
