### PR TITLE
Action example diagram should use source instead of action

### DIFF
--- a/graphics/note2actions.svg
+++ b/graphics/note2actions.svg
@@ -46,14 +46,14 @@
       <rect x="-71.4792" y="-97.125" clip-path="url(#clipPath2)" width="84" rx="4" ry="4" height="34" stroke="none"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" font-family="sans-serif" transform="matrix(1,0,0,1,87,121)" stroke-linecap="butt">
-      <text x="-51.0475" xml:space="preserve" y="-75.5898" clip-path="url(#clipPath2)" stroke="none">action1</text>
+      <text x="-51.0475" xml:space="preserve" y="-75.5898" clip-path="url(#clipPath2)" stroke="none">source 1</text>
       <rect x="-71.4792" y="-97.125" clip-path="url(#clipPath2)" fill="none" width="84" rx="4" ry="4" height="34" stroke="rgb(153,153,153)"/>
     </g>
     <g fill="rgb(255,255,204)" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,87,121)" stroke="rgb(255,255,204)">
       <rect x="-71.4792" y="-43.125" clip-path="url(#clipPath2)" width="84" rx="4" ry="4" height="34" stroke="none"/>
     </g>
     <g text-rendering="geometricPrecision" stroke-miterlimit="1.45" shape-rendering="geometricPrecision" font-family="sans-serif" transform="matrix(1,0,0,1,87,121)" stroke-linecap="butt">
-      <text x="-51.0475" xml:space="preserve" y="-21.5898" clip-path="url(#clipPath2)" stroke="none">action2</text>
+      <text x="-51.0475" xml:space="preserve" y="-21.5898" clip-path="url(#clipPath2)" stroke="none">source 2</text>
       <rect x="-71.4792" y="-43.125" clip-path="url(#clipPath2)" fill="none" width="84" rx="4" ry="4" height="34" stroke="rgb(153,153,153)"/>
     </g>
     <g fill="rgb(204,255,255)" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,87,121)" stroke="rgb(204,255,255)">


### PR DESCRIPTION
In the rest of the diagram examples the actions are horizontally
grouped by source, not action. Also, it's referenced like that in the
diagram explanation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/846)
<!-- Reviewable:end -->
