### PR TITLE
Remove prompt check from newSession as it happens to early. Fixes #829

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2142,7 +2142,7 @@ with a "<code>moz:</code>" prefix:
      <dt><var>value</var> is <a><code>null</code></a>
      <dd><p>Let <var>deserialized</var> be set to
       <a><code>null</code></a>.
- 
+
      <dt><var>name</var> equals "<code>acceptInsecureCerts</code>"
      <dd><p>If <var>value</var> is not a <a>boolean</a> return
       an <a>error</a> with <a>error code</a> <a>invalid
@@ -2158,7 +2158,7 @@ with a "<code>moz:</code>" prefix:
       set to <var>value</var>.
 
      <dt><var>name</var> equals "<code>pageLoadStrategy</code>"
-     <dd><p>Let <var>deserialized</var> be the result of <a>trying</a> to 
+     <dd><p>Let <var>deserialized</var> be the result of <a>trying</a> to
       <a>deserialize as a page load strategy</a> with argument
       <var>value</var>.
 
@@ -2319,7 +2319,7 @@ with a "<code>moz:</code>" prefix:
        using an implementation-defined comparison algorithm.
        The comparison is to accept a <var>value</var>
        that places constraints on the version using
-       the "<code>&lt;</code>", "<code>&lt;=</code>", "<code>&gt;</code>", 
+       the "<code>&lt;</code>", "<code>&lt;=</code>", "<code>&gt;</code>",
        and "<code>&gt;=</code>" operators.
 
       <p>If the two values do not match, return <a>success</a> with
@@ -2384,7 +2384,7 @@ with a "<code>moz:</code>" prefix:
      <dt><strong>Otherwise</strong>
      <dd><p>If <var>name</var> is not the key of an
       <a>extension capability</a> and the <a>remote end</a> is
-      an <a>endpoint node</a> return <a>success</a> with data 
+      an <a>endpoint node</a> return <a>success</a> with data
       <code>null</code>.
 
       <p>Let <var>value</var> be the result of <a>trying</a>
@@ -2616,9 +2616,6 @@ with a "<code>moz:</code>" prefix:
 
  <li><p>If the <a>maximum active sessions</a> is equal to
   the length of the list of <a>active sessions</a>,
-  return <a>error</a> with <a>error code</a> <a>session not created</a>.
-
- <li><p>If there is a <a>current user prompt</a>,
   return <a>error</a> with <a>error code</a> <a>session not created</a>.
 
  <li><p>Let <var>capabilities</var> be the result
@@ -3028,9 +3025,9 @@ with a "<code>moz:</code>" prefix:
   the <a>table of page load strategies</a>.
 
  <li><p>Wait for the the <a>current browsing context</a>’s
-  <a>document readiness</a> state to reach 
-  <var>readiness target</var>, or for the 
-  <a>session page load timeout</a> to pass, whichever 
+  <a>document readiness</a> state to reach
+  <var>readiness target</var>, or for the
+  <a>session page load timeout</a> to pass, whichever
   occurs sooner.
 
  <li><p>If the previous step completed by the
@@ -4126,7 +4123,7 @@ with a "<code>moz:</code>" prefix:
  <li><p>Otherwise return false.
 </ol>
 
-<p>An <var><a>element</a></var> is 
+<p>An <var><a>element</a></var> is
 <dfn data-lt="scroll into view|scrolls into view">scrolled into view</dfn>
 by following these steps:
 <ol>


### PR DESCRIPTION
If there is a prompt before we do newSession it will be hard to do
anything until we have a session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/854)
<!-- Reviewable:end -->
