### PR TITLE
Add current top-level browsing context check to Release Actions

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -8268,6 +8268,9 @@ is also removed.
 <p>The <a>remote end steps</a> are:
 
 <ol>
+ <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+  return <a>error</a> with <a>error code</a> <a>no such window</a>.
+
  <li><p>Let <var>undo actions</var> be equal to the
   <a>current session</a>'s <a>input cancel list</a> in reverse order.
 


### PR DESCRIPTION
A fix for https://github.com/w3c/webdriver/issues/865 (provided this is indeed missing)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/866)
<!-- Reviewable:end -->
