### PR TITLE
Make proxyType value comparison case-insensitive.

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2037,8 +2037,8 @@ with a "<code>moz:</code>" prefix:
    <li><p>Let <var>value</var> be the result of <a>getting a
     property</a> named <var>name</var> from <var>parameter</var>.
 
-   <li><p>Let <var>key</var> be the result of
-    <a data-lt="ASCII lowercase">lowercasing</a> <var>key</var>.
+   <li>If <var>key</var> is equal to "proxyType", let <var>value</var> be the
+   result of <a data-lt="ASCII lowercase">lowercasing</a> <var>value</var>.
 
    <li><p>If there is no matching <code>key</code> for <var>key</var>
     in the <a>proxy configuration</a> table return an <a>error</a>


### PR DESCRIPTION
Some existing clients (Java, notably) send the value in all-caps.

Addresses #835.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/870)
<!-- Reviewable:end -->
