### PR TITLE
Re-phrase language for branching logic

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -8433,7 +8433,7 @@ argument <var>value</var>:
  <li><p>If there is no <a>current user prompt</a>,
   abort these steps and return <a>success</a>.
 
- <li><p>Run the substeps of the first matching
+ <li><p>Perform the following substeps based on the <a>current session</a>'s
   <a>user prompt handler</a>:
 
   <dl class=switch>


### PR DESCRIPTION
In the phrase, "the first matching user prompt handler," the word
"first" may be interpreted in one of two ways:

1. There are multiple user prompt handlers from which the match may draw
2. There are multiple matching options in the list that follows

The first interpretation is incorrect because a session has exactly one
value for the user prompt handler. The second interpretation is also
incorrect because the available options are mutually exclusive (so
their sequence does not matter).

Re-phrase the language to avoid this ambiguity, borrowing verbiage from
the "close the session" algorithm as currently defined in the
specification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/873)
<!-- Reviewable:end -->
