### PR TITLE
Change normalized key value to Enter instead of Return

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -7529,7 +7529,7 @@ is also removed.
  <tr><td><code>\uE003</code></td><td><code>"Backspace"</code></td></tr>
  <tr><td><code>\uE004</code></td><td><code>"Tab"</code></td></tr>
  <tr><td><code>\uE005</code></td><td><code>"Clear"</code></td></tr>
- <tr><td><code>\uE006</code></td><td><code>"Return"</code></td></tr>
+ <tr><td><code>\uE006</code></td><td><code>"Enter"</code></td></tr>
  <tr><td><code>\uE007</code></td><td><code>"Enter"</code></td></tr>
  <tr><td><code>\uE008</code></td><td><code>"Shift"</code></td></tr>
  <tr><td><code>\uE009</code></td><td><code>"Control"</code></td></tr>


### PR DESCRIPTION
While working on Marionette [1], I ran into an issue where the browser tells me "Return" is an invalid value for the key attribute of a KeyboardEvent. The UI Events spec [2] seems to agree: it should be "Enter", and that fixes the error encountered by Marionette.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1332279
[2] https://www.w3.org/TR/uievents-key/#keys-whitespace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/878)
<!-- Reviewable:end -->
