### PR TITLE
Simplify definition of "readiness state"

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -754,20 +754,18 @@ in the spec, as demonstrated in a (yet to be developed)
   and so are bound by the requirements on a <a>remote end</a> in terms
   of the wire protocol.
 
-<p>A <a>remote end</a>’s <dfn>readiness state</dfn> is
- for each <a>node type</a> said to be:
+<p>A <a>remote end</a>’s <dfn>readiness state</dfn> is the value corresponding
+ to the first matching statement:
 
 <dl class=switch>
- <dt><a>Intermediary node</a>
- <dd><p>False if it is known to be in a state
-  in which attempting to create a <a>new session</a> would fail.
-  Otherwise true.
+ <dt>the maximum <a>active sessions</a> is equal to the length of the list of
+  <a>active sessions</a>
+ <dt>the node is an <a>intermediary node</a> and is known to be in a state in
+   which attempting to create a <a>new session</a> would fail
+ <dd><p>False
 
- <dt><a>Endpoint node</a>
- <dd><p>False if the <a>maximum active sessions</a>
-  is equal to the length of the list of <a>active sessions</a>
-  or there is a <a>current user prompt</a> present.
-  Otherwise true.
+ <dt>Otherwise
+ <dd><p>True
 </dl>
 
 <p class=example>If the <a>intermediary node</a>


### PR DESCRIPTION
The definition of "maximum active sessions" states:

> [...] must be exactly one for a remote end that is an endpoint node.

This restriction is further supported by the definition of "active
sessions," which states:

> A remote end that is not an intermediary node has at most one active
> session at a given time.

Therefore, the "readiness state" for endpoint nodes can be described in
terms of a precise number ("one") of active sessions. The additional
state concerning the current user prompt is subsumed by this condition.

Simplify the definition of "readiness state" to reflect the limitations
of endpoint nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/883)
<!-- Reviewable:end -->
