### PR TITLE
fix typo in capability matching section

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2405,7 +2405,7 @@ with a "<code>moz:</code>" prefix:
        data <a><code>null</code></a>.
    </dl>
 
-   <li><p><a>Set a property</a> on <var>matched capability</var>
+   <li><p><a>Set a property</a> on <var>matched capabilities</var>
     with name <var>name</var> and value <var>value</var>.
   </ol>
 


### PR DESCRIPTION
I didn't see a variable `matched capability` anywhere and it seemed more reasonable to suppose we're setting a name and value on the capabilit_ies_ object, so I figured this was a typo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/890)
<!-- Reviewable:end -->
