### PR TITLE
Test in view with pointer events enabled

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4181,7 +4181,8 @@ by following these steps:
  </ul> <!-- /editable -->
 
 
-<p>An <a>element</a> is said to have <dfn>pointer events disabled</dfn>
+<p>An <a>element</a> is said to have
+ <dfn data-lt="pointer events are not disabled">pointer events disabled</dfn>
  if the <a>resolved value</a> of its "<code>pointer-events</code>" style property
  is "<code>none</code>".
 
@@ -4253,7 +4254,8 @@ by following these steps:
 </ol>
 
 <p>An <a>element</a> is <dfn>in view</dfn>
- if it is a member of its own <a>pointer-interactable paint tree</a>.
+ if it is a member of its own <a>pointer-interactable paint tree</a>,
+ given the pretense that its <a>pointer events are not disabled</a>.
 
 <p>An <a>element</a> is <dfn data-lt=obscuring>obscured</dfn>
  if it is not <a>pointer-interactable</a>


### PR DESCRIPTION
When an element has pointer events disabled, e.g.
`<input type=button style="pointer-events: none">`,
it does not appear in the paint tree acquired from
`document.elementsFromPoint`.

To circumvent this issue and make element in view checks possible for
elements which don’t have pointer events enabled, we need to run the
check as if pointer events were enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/896)
<!-- Reviewable:end -->
