### PR TITLE
Correct specification of command arguments

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -927,7 +927,9 @@ in the spec, as demonstrated in a (yet to be developed)
 
  <li><p>Let <var>response result</var> be the return value
   obtained by running the <a>remote end steps</a> for <var>command</var>
-  with <var>url variables</var> as arguments.
+  with one named argument for each entry in <var>url variables</var> and an
+  additional argument named <var>parameters</var> whose value is
+  <var>parameters</var>.
 
  <li><p>If <var>response result</var> is an <a>error</a>,
   <a>send an error</a> with <a>error code</a>


### PR DESCRIPTION
WebDriver commands are currently written to reference "URL variables" by
name. For example (from the "Element Send Keys" command):

>     <li><p>Let <var>element</var> be the result
>      of <a>trying</a> to <a>get a known element</a>
>      with argument <var>element id</var>.

This is in conflict with the current command invocation, where
they are specified as a collection of name-value pairs.

In addition, some commands reference an argument named "parameters" that
is expected to contain the parsed request body. For example (again from
the "Element Send Keys" command);

>     <li><p>Let <var>text</var> be the result
>      of <a>getting a property</a> called "<code>text</code>"
>      from the <var>parameters</var> argument.

However, this argument is not currently provided when the commands are
invoked.

Clarify the text at the command invocation site to expand the "URL
variables" into named arguments and to include the "parameters"
argument.

---

This is the lowest-friction way to address the issue, but I'm not sure it's the
best. My preference would be to be more explicit by invoking all commands with
exactly two arguments, one for each of "url variables" and "parameters". That
would make commands a little more verbose, but it would be easier to understand
where the values were coming from. It would also make for a much larger change
set, so I thought I'd ask for feedback before attempting it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/901)
<!-- Reviewable:end -->
