### PR TITLE
Limit valid range for socksVersion

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1999,7 +1999,7 @@ with a "<code>moz:</code>" prefix:
   <td>number
   <td>Defines the <a>SOCKS proxy</a> version
    when the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>Any <a>string</a>
+  <td>Any <a>integer</a> between 0 and 255 inclusive.
   </tr>
 
  <tr>


### PR DESCRIPTION
Both of the RFCs linked to limit the SOCKS
version to a single byte.

Closes #899

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/904)
<!-- Reviewable:end -->
