### PR TITLE
When cloning a JS Object, look for `toJSON`

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6009,6 +6009,11 @@ must run the following steps:
   </ol>
  </dd>
 
+ <dt>has an <a>own property</a> named "<code>toJSON</code>" that is
+  a <a>Function</a>
+ <dd>Return <a>success</a> with the value returned by
+  a <a>[[\CALL]]</a> to the "<code>toJSON</code>" <a>own property</a>.
+
  <dt>Otherwise</dt>
  <dd><p><a>Error</a> with <a>error code</a> <a>javascript error</a>.
 </dl>


### PR DESCRIPTION
This is what `JSON.stringify` does, and so brings
our algorithm more closely into line with what a
user might expect to happen, and prevents some of
the potential failures from calling `Execute Script`
(eg. `return window.performance`)

Closes #849

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/906)
<!-- Reviewable:end -->
