### PR TITLE
There is never a `null` `page loading strategy`

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3026,9 +3026,6 @@ with a "<code>moz:</code>" prefix:
  argument <var>value</var>:
 
 <ol>
- <li><p>If <var>value</var> is <code>null</code>, let <var>value</var>
-  be set to "<code>normal</code>".
-
  <li><p>If <var>value</var> is not a <a>string</a> return
   an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 


### PR DESCRIPTION
In the other places where the spec talks about
the `page loading strategy` we already state
that it defaults to `normal`, and we will have
removed `null` values while processing
capabilities.

If a user attempts to set the `page loading
strategy` to `null` via `Set Timeouts`, then
that is clearly an error.

Closes #834

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/907)
<!-- Reviewable:end -->
