### PR TITLE
Correct use of `lowercase`

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -431,7 +431,7 @@ in the spec, as demonstrated in a (yet to be developed)
   in the Infra standard: [[!INFRA]]
    <ul>
     <!-- ASCII lower alpha --> <li><dfn><a href=https://infra.spec.whatwg.org/#ascii-lower-alpha>ASCII lower alpha</a></dfn>
-    <!-- ASCII lowercase --> <li><dfn><a href=https://infra.spec.whatwg.org/#ascii-lowercase>ASCII lowercase</a></dfn>
+    <!-- ASCII lowercase --> <li><dfn data-lt="lowercase"><a href=https://infra.spec.whatwg.org/#ascii-lowercase>ASCII lowercase</a></dfn>
    </ul>
 
  <dt>Page Visibility
@@ -2039,9 +2039,6 @@ with a "<code>moz:</code>" prefix:
    <li><p>Let <var>value</var> be the result of <a>getting a
     property</a> named <var>name</var> from <var>parameter</var>.
 
-   <li>If <var>key</var> is equal to "proxyType", let <var>value</var> be the
-   result of <a data-lt="ASCII lowercase">lowercasing</a> <var>value</var>.
-
    <li><p>If there is no matching <code>key</code> for <var>key</var>
     in the <a>proxy configuration</a> table return an <a>error</a>
     with <a>error code</a> <a>invalid argument</a>.
@@ -2276,13 +2273,13 @@ with a "<code>moz:</code>" prefix:
 
   <dl>
    <dt>"<code>browserName</code>"
-   <dd>Lowercase name of the user agent as a <a>string</a>.
+   <dd><a>Lowercase</a> name of the user agent as a <a>string</a>.
 
    <dt>"<code>browserVersion</code>"
    <dd>The user agent version, as a <a>string</a>.
 
    <dt>"<code>platformName</code>"
-   <dd>Lowercase name of the current platform as a <a>string</a>.
+   <dd><a>Lowercase</a> name of the current platform as a <a>string</a>.
 
    <dt>"<code>acceptInsecureCerts</code>"
    <dd><a>Boolean</a> initially set to <code>false</code>,


### PR DESCRIPTION
We mis-used this for `proxyType`, and failed to
reference it when matching capabilities.

Closes #835

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/908)
<!-- Reviewable:end -->
