### PR TITLE
Clarify that proxy hosts are domains and ports.

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1912,7 +1912,7 @@ with a "<code>moz:</code>" prefix:
    and <a><code>ftpProxyPort</code></a> to the <a>port</a>
    when the <a><code>proxyType</code></a>
    is equal to "<code>manual</code>".
-  <td>A URL consisting of just the <a>domain</a> and optional <a>port</a>
+  <td>A <a>domain</a>, and optional <a>port</a> preceeded by a colon (eg. <code>example.com</code> or <code>example.com:1234</code>)
  </tr>
 
  <tr>
@@ -1936,7 +1936,7 @@ with a "<code>moz:</code>" prefix:
    and <a><code>httpProxyPort</code></a> to the <a>port</a>
    when the <a><code>proxyType</code></a>
    is equal to "<code>manual</code>".
-  <td>A URL consisting of just the <a>domain</a> and optional <a>port</a>
+  <td>A <a>domain</a>, and optional <a>port</a> preceeded by a colon
  </tr>
 
  <tr>
@@ -1958,7 +1958,7 @@ with a "<code>moz:</code>" prefix:
    If a <a>URL</a> is passed through this property,
    set <a><code>sslProxy</code></a> to the <a>host</a>
    and <a><code>sslProxyPort</code></a> to the <a>port</a>.
-  <td>A URL consisting of just the <a>domain</a> and optional <a>port</a>
+  <td>A <a>domain</a>, and optional <a>port</a> preceeded by a colon
  </tr>
 
  <tr>
@@ -1980,7 +1980,7 @@ with a "<code>moz:</code>" prefix:
    If a <a>URL</a> is passed through this property,
    set <a><code>socksProxy</code></a> to the <a>host</a>
    and <a><code>socksProxyPort</code></a> to the <a>port</a>.
-  <td>A URL consisting of just the <a>domain</a> and optional <a>port</a>
+  <td>A <a>domain</a>, and optional <a>port</a> preceeded by a colon
  </tr>
 
  <tr>


### PR DESCRIPTION
As pointed out in #839, a URL "consisting of just
the domain and the port" is unclear. We already
link to the relevant parts in the URL spec to
define both `domain` and `port`, so just rely on
those instead.

Closes #839

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/909)
<!-- Reviewable:end -->
