### PR TITLE
Omit ownerDocument when defining keyboard-interactable element

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4206,13 +4206,10 @@ by following these steps:
  of its rectangle that is inside the <a>viewport</a>,
  excluding the size of any rendered scrollbars.
 
-<p>A <dfn data-lt="keyboard-interactable">keyboard-interactable
- element</dfn> is defined to be any <a>element</a> that has
- a <a>focusable area</a>, or is the <a><code>body</code> element</a>,
- or is the <a>document element</a>. In the case of
- the <a><code>body</code> element</a> and the <a>document element</a>
- all keyboard interactions must be targeted to
- its <a><code>ownerDocument</code></a>.
+<p>A <dfn data-lt="keyboard-interactable">keyboard-interactable element</dfn>
+ is any <a>element</a> that has a <a>focusable area</a>,
+ or is the <a><code>body</code> element</a>,
+ or is the <a>document element</a>.
 
 <p>An <a>element</a>’s <dfn data-lt="center point">in-view center point</dfn>
  is the origin position of the rectangle


### PR DESCRIPTION
It does not make sense to talk about the target of keyboard interaction
when defining which elements are keyboard interactable.  This belongs in
the key dispatch section in the chapter on actions.

I believe it is also inferred what the default target of the interaction
should be through the pointer events standard.

Fixes: https://github.com/w3c/webdriver/issues/886

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/910)
<!-- Reviewable:end -->
