### PR TITLE
Mark navigator.webdriver as unforgeable

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -698,7 +698,7 @@ in the spec, as demonstrated in a (yet to be developed)
 <h2>Interface</h2>
 
 <pre class=idl>partial interface Navigator {
-  readonly attribute boolean webdriver;
+	[Unforgeable] readonly attribute boolean webdriver;
 };</pre>
 
 <p data-dfn-for="Navigator">The <dfn><code>webdriver</code></dfn> IDL attribute


### PR DESCRIPTION
This makes the navigator.webdriver property unconfigurable.

Fixes: https://github.com/w3c/webdriver/issues/914

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/918)
<!-- Reviewable:end -->
