### PR TITLE
Rephrase description of navigator.webdriver

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -705,10 +705,8 @@ in the spec, as demonstrated in a (yet to be developed)
  of the <code><a>Navigator</a></code> interface must return
  the value of the <dfn>webdriver-active flag</dfn>, which is initially false.
 
-<p>This property allows websites to determine
- that the user agent is under control by WebDriver,
- and can be used to help mitigate
- <a href=https://en.wikipedia.org/wiki/Denial-of-service_attack>denial-of-service attacks</a>.
+<p>This property defines a standard way for a co-operating user agent to inform a website
+  that it is controlled by WebDriver.
 </section>
 
 <section>


### PR DESCRIPTION
Remove mentioning of DoS attacks and accent that this is a _standard_ way of advertising by UA that it is controlled by WebDriver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/920)
<!-- Reviewable:end -->
