### PR TITLE
delete session: close session only if it is still active

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2759,7 +2759,8 @@ with a "<code>moz:</code>" prefix:
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p><a>Try</a> to <a>close the session</a>.
+ <li><p>If the <a>current session</a> is an <a>active session</a>,
+  <a>try</a> to <a>close the session</a>.
 
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>


### PR DESCRIPTION
For implementation compatibility we should not try to close the session
if the session does not exist.  This can be interpreted in different
ways because of the use of the "try" algorithm.

Instead we make the Delete Session algorithm explicitly call out that
the session must be active in order to attempt closing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/926)
<!-- Reviewable:end -->
