### PR TITLE
Set the top-level browser context to use for a session.

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2732,7 +2732,9 @@ with a "<code>moz:</code>" prefix:
  <li><p>Set the <a>webdriver-active flag</a> to true.</p>
 
  <li><p>Set the <a>current top-level browsing context</a>
-  for <var>session</var> in an implementation-specific way.
+  for <var>session</var> in an implementation-specific way. This
+  should be the <a>top-level browsing context</a> of the UA's
+  <a>current browsing context</a>.
 
   <p class="note">WebDriver implementations typically start a
    completely new browser instance, but there is no requirement in

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2731,6 +2731,16 @@ with a "<code>moz:</code>" prefix:
 
  <li><p>Set the <a>webdriver-active flag</a> to true.</p>
 
+ <li><p>Set the <a>current top-level browsing context</a>
+  for <var>session</var> in an implementation-specific way.
+
+  <p class="note">WebDriver implementations typically start a
+   completely new browser instance, but there is no requirement in
+   this specification (or for WebDriver only to be used to automate
+   only web browsers). Implementations might choose to use an existing
+   browser instance, eg. by selecting the window that currently has
+   focus.
+
  <li><p>Return <a>success</a> with data <var>body</var>.
 </ol>
 </section> <!-- /New Session -->


### PR DESCRIPTION
This, by necessity, needs to be done in an
implementation-spefific way. I've avoided using
language that ties the spec to only automating
browsers, since there are already implementations
for mobile devices, and even automating Windows
and OS X.

Closes #924

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/929)
<!-- Reviewable:end -->
