### PR TITLE
Only wait for navigation to complete if it can.

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3040,6 +3040,10 @@ with a "<code>moz:</code>" prefix:
   strategy</a> of <a>none</a> return <a>success</a> with
   data <a><code>null</code></a>.
 
+ <li><p>If the <a>current browsing context</a> is
+  <a>no longer open</a>, return <a>success</a> with
+  data <a><code>null</code></a>.
+
  <li><p>Start a <var>timer</var>. If this algorithm has not
   completed before <var>timer</var> reaches
   the <a>session</a>'s <a>session page load timeout</a> in


### PR DESCRIPTION
If the current browsing context is no longer open then
we can safely assume that its navigation has completed.
This might be the case where a `click` has caused some
long-running JS to complete and then close the current
div or window.

I think that this fully addresses the problems in #871.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/932)
<!-- Reviewable:end -->
