### PR TITLE
Find Element(s): check for null documentElement

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4605,6 +4605,9 @@ by following these steps:
  <li><p>Let <var>start node</var> be
   the <a>current browsing context</a>’s <a>document element</a>.
 
+ <li><p>If <var>start node</var> is <a><code>null</code></a>, return
+  <a>error</a> with <a>error code</a> <a>no such element</a>.
+
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".
 
@@ -4655,6 +4658,9 @@ by following these steps:
 
  <li><p>Let <var>start node</var> be
   the <a>current browsing context</a>’s <a>document element</a>.
+
+ <li><p>If <var>start node</var> is <a><code>null</code></a>, return
+  <a>error</a> with <a>error code</a> <a>no such element</a>.
 
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".


### PR DESCRIPTION
In rare circumstances, the current browsing context's document element
may be null. This will be the case, for example, after execution of the
following JavaScript:

    document.documentElement.remove();

Without accounting for this condition in the "Find Element" and "Find
Elements" commands, the element location strategies may be invoked with
the null value as the "start node." From WebDriver's "find" algorithm:

> 5. Let elements returned be the result of the relevant element
>    location strategy call with arguments start node, and selector.

This invocation would produce a TypeError, which would be reported as an
"invalid selector" error:

> 6. If a DOMException, SyntaxError, XPathException, or other error
>    occurs during the execution of the element location strategy,
>    return error invalid selector.

Because the selector may be valid in this case and because the actual
problem stems from the missing document element, the "no such element"
error is more appropriate.

Insert a step in both algorithms to report a "no such element" error in
this case. To promote symmetry with the "Find Element from Element" and
"Find Elements from Element" commands, conduct this check prior to
parameter validation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/935)
<!-- Reviewable:end -->
