### PR TITLE
find: Avoid reliance on property value

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4567,9 +4567,10 @@ by following these steps:
 <h4>Tag Name</h4>
 
 <p>To find a <a>web element</a> with the <dfn>Tag
- Name</dfn> <a>strategy</a> return the result of calling <var>start
- node</var>'s <a><code>getElementsByTagName</code></a> with the
- argument <var>selector</var>.
+ Name</dfn> <a>strategy</a> return the result of calling
+ <a><code>getElementsByTagName</code></a> with the argument
+ <var>selector</var>, with the <a>context object</a> equal to the
+ <var>start node</var>.
 
 </section> <!-- /Tag Name -->
 


### PR DESCRIPTION
Because browsing contexts may modify the built-in
`Element.prototype.getElementsByTagName` property value (or define a
distinct value for a given Element instance), invoking the function as
defined by a given node may produce unpredictable results.

Modify the text to reference the built-in function generically, avoiding
this ambiguity and increasing parity with similar algorithm steps in
related locator strategies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/938)
<!-- Reviewable:end -->
