### PR TITLE
find: Account for WebDriver error from locator

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4413,8 +4413,8 @@ by following these steps:
 
  <li><p>Let <var>selector</var> be equal to <var>value</var>.
 
- <li><p>Let <var>elements returned</var> be the result
-  of the relevant <a>element location strategy</a> call with arguments
+ <li><p>Let <var>elements returned</var> be the result of <a>trying</a> to call
+  the relevant <a>element location strategy</a> with arguments
   <var>start node</var>, and <var>selector</var>.
 
  <li>If


### PR DESCRIPTION
Each locator strategy may produce an error during execution. This
behavior is distinct from returning a WebDriver error value and is
handled by the text "if [an error] occurs," in the "find" algorithm.
However, in addition to producing an error in this way, the "xpath"
locator strategy may return a WebDriver error.

Update the "find" algorithm to handle this case by relying on the
specification's "try" construct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/941)
<!-- Reviewable:end -->
