### PR TITLE
Pointer actions: correct algorithm reference

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -8219,7 +8219,7 @@ is also removed.
    <dd>
     <ol>
      <li><p>Let <var>element</var> be equal to the result
-      of <a>trying</a> to <var>get a known element</var> with
+      of <a>trying</a> to <a>get a known element</a> with
       argument <var>origin</var>.
 
      <li><p>Let <var>x element</var> and <var>y element</var> be the


### PR DESCRIPTION
Because "get a known element" is a algorithm with a formal definition,
it should be referenced with an anchor tag. Correct one such reference
which erroneously used the `<var>` tag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/942)
<!-- Reviewable:end -->
