### PR TITLE
JSON clone: correct cycle detection

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5967,7 +5967,7 @@ must run the following steps:
 
 <ol>
  <li><p>If <var>seen</var> is not provided,
-  let <var>seen</var> be an empty set.
+  let <var>seen</var> be an empty <a>List</a>.
 
  <li><p>Jump to the first appropriate step below:
 
@@ -5995,7 +5995,7 @@ must run the following steps:
 
 <p>To perform a <dfn>JSON clone</dfn>
  return the result of calling the <a>internal JSON clone algorithm</a>
- with arguments <var>value</var> and an empty set.
+ with arguments <var>value</var> and an empty <a>List</a>.
 
 <p>When required to run the <dfn>internal JSON clone algorithm</dfn>
  with arguments <var>value</var> and <var>seen</var>,
@@ -6039,11 +6039,16 @@ must run the following steps:
    <li><p>If <var>value</var> is in <var>seen</var>,
     return <a>error</a> with <a>error code</a> <a>javascript error</a>.
 
-   <li><p>Add <var>value</var> to <var>seen</var>.
+   <li><p>Append <var>value</var> to <var>seen</var>.
 
-   <li><p>Produce the value of running the <a>clone an object</a> algorithm
-    with arguments <var>value</var> and <var>seen</var>,
-    and the <a>internal JSON clone algorithm</a> as the <var>clone algorithm</var>.
+   <li><p>Let <var>result</var> be the value of running the
+    <a>clone an object</a> algorithm with arguments <var>value</var> and
+    <var>seen</var>, and the <a>internal JSON clone algorithm</a> as the
+    <var>clone algorithm</var>.
+
+   <li><p>Remove the last element of <var>seen</var>.
+
+   <li><p>Return <var>result</var>.
   </ol>
  </dd>
 


### PR DESCRIPTION
The same object value may occur as the value of multiple properties
within a single data structure without producing cycles. The array
created in the following JavaScript program is one such example:

    var obj = {};
    [obj, obj];

Update the "internal JSON clone" algorithm to support such structures.

---

This patch is intended to resolve gh-931. As suggested there, I've taken a cue from [the JSON.stringify method defined in ECMA262](https://tc39.github.io/ecma262/#sec-json.stringify).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/943)
<!-- Reviewable:end -->
