### PR TITLE
Find Element: Account for WebDriver err from find

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4662,7 +4662,7 @@ by following these steps:
  <li><p>If <var>selector</var> is <a>undefined</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
- <li><p>Let <var>result</var> be the result of <a>Find</a>
+ <li><p>Let <var>result</var> be the result of <a>trying</a> to <a>Find</a>
   with <var>start node</var>, <var>location strategy</var>,
   and <var>selector</var>.
 
@@ -4764,7 +4764,7 @@ by following these steps:
  <li><p>If <var>selector</var> is <a>undefined</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
- <li>Let <var>result</var> be the value of calling <a>Find</a> with
+ <li>Let <var>result</var> be the value of <a>trying</a> to <a>Find</a> with
   <var>start node</var>, <var>location strategy</var>,
   and <var>selector</var>.
 


### PR DESCRIPTION
During normal operation, the "find" algorithm returns a JSON List value.
Under exceptional circumstances, however, it returns a WebDriver error
value. Callers that manipulate the value must account for both cases
separately.

Update two such callers (the "Find Element" and "Find Element from
Element" commands) to account for the exceptional case by relying on the
specification's "try" construct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/944)
<!-- Reviewable:end -->
