### PR TITLE
Go: Remove unnecessary step

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3152,11 +3152,6 @@ with a "<code>moz:</code>" prefix:
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
 
- <li><p>If the <code>url</code> property
-  is missing from the <var>parameters</var> argument
-  or it is not a string,
-  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
-
  <li><p>Let <var>url</var> be the result of
   <a>getting the property</a> <code>url</code>
   from the <var>parameters</var> argument.


### PR DESCRIPTION
The conditions described by this step (i.e. an unspecified property or a
non-string property value) are a subset of the cases described by a
subsequent step (i.e. value that is neither an absolute URL, an absolute
URL with fragment, nor a local scheme). Because the observable behavior
is identical in both cases, the former step is not necessary.

Remove the step in order to reduce algorithm complexity.

---

I'll admit that there's something to be said for explicitness, although if that
is the goal, there may be better alternatives to make this seem more
intentional (e.g. a non-normative Note explaining that missing or non-string
property values are also rejected by the URL validation step.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/945)
<!-- Reviewable:end -->
