### PR TITLE
Scope extension commands to current session

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1690,13 +1690,13 @@ in the spec, as demonstrated in a (yet to be developed)
  that is an <a>ASCII lower alpha</a> string,
  and which should bear some resemblance to what the command performs.
  The name is used to form an <a>extension command</a>’s
- <a data-lt="extension command URL">URL</a>.
+ <a data-lt="extension command URI template">URI template</a>.
 
-<p>The <a>extension command</a>’s <dfn>extension command URL</dfn>
- is a <a>URL</a> composed of the <a>extension command prefix</a>,
- followed by "<code>/</code>",
+<p>The <a>extension command</a>’s <dfn>extension command URI template</dfn>
+ is a <a>URI template</a> composed of "<code>/session/{session id}/</code>",
+ followed by the <a>extension command prefix</a>, followed by "<code>/</code>",
  and the <a>extension command</a>’s <a data-lt="extension command name">name</a>.
- The <a>extension command URL</a>,
+ The <a>extension command URI template</a>,
  along with the HTTP method and <a>extension command</a>,
  is added to the <a>table of endpoints</a>
  and thus follows the same rules for <a>request routing</a>


### PR DESCRIPTION
Extension commands are expected to be executed in the context of the
remote end's current session. This expectation is normatively enforced
by the remote end's processing model and further suggested by the first
example in the section titled "Protocol Extensions."

Update the extension mechanism to be phrased in terms of a URI template
that includes the current session ID (instead of a URL that does not).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/952)
<!-- Reviewable:end -->
