### PR TITLE
Normalize references to URL templates

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1047,7 +1047,7 @@ in the spec, as demonstrated in a (yet to be developed)
 
  <li><p>Remove each entry from <var>endpoints</var>
   for which the concatenation of the <a>URL prefix</a>
-  and the entry’s <var>URI template</var>
+  and the entry’s <a>URI template</a>
   does not match <var>URL</var>’s <a>path</a>.
 
  <li><p>If there are no entries in <var>endpoints</var>,
@@ -1064,7 +1064,7 @@ in the spec, as demonstrated in a (yet to be developed)
   let <var>entry</var> be this entry.
 
  <li><p>Let <var>parameters</var> be the result of extracting the variables
-  from <var>URL</var> using <var>entry</var>’s <var>URI template</var>.
+  from <var>URL</var> using <var>entry</var>’s <a>URI template</a>.
 
  <li><p>Let <var>command</var> be <var>entry</var>’s <a>command</a>.
 
@@ -2566,7 +2566,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -2758,7 +2758,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>DELETE</td>
@@ -2787,7 +2787,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -2839,7 +2839,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -2877,7 +2877,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -3119,7 +3119,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -3224,7 +3224,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -3257,7 +3257,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -3304,7 +3304,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -3347,7 +3347,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -3388,7 +3388,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -3481,7 +3481,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -3510,7 +3510,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>DELETE</td>
@@ -3542,7 +3542,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
   <tr>
     <th>HTTP Method</th>
-    <th>Path Template</th>
+    <th>URI Template</th>
   </tr>
   <tr>
     <td>POST</td>
@@ -3582,7 +3582,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -3620,7 +3620,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -3718,7 +3718,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -3797,7 +3797,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -3831,7 +3831,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -3952,7 +3952,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -3998,7 +3998,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -4041,7 +4041,7 @@ with a "<code>moz:</code>" prefix:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -4353,7 +4353,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -4624,7 +4624,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -4678,7 +4678,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -4727,7 +4727,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -4780,7 +4780,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -4906,7 +4906,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -4962,7 +4962,7 @@ by following these steps:
 <table class="simple jsoncommand">
   <tr>
     <th>HTTP Method</th>
-    <th>Path Template</th>
+    <th>URI Template</th>
   </tr>
   <tr>
     <td>GET</td>
@@ -5022,7 +5022,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -5065,7 +5065,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -5108,7 +5108,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -5165,7 +5165,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -5204,7 +5204,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -5283,7 +5283,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -5341,7 +5341,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -5507,7 +5507,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -5592,7 +5592,7 @@ by following these steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -5924,7 +5924,7 @@ must run the following steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -6212,7 +6212,7 @@ must run the following steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -6275,7 +6275,7 @@ must run the following steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -6513,7 +6513,7 @@ must run the following steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -6547,7 +6547,7 @@ must run the following steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -6586,7 +6586,7 @@ must run the following steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -6669,7 +6669,7 @@ must run the following steps:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>DELETE</td>
@@ -6704,7 +6704,7 @@ must run the following steps:
 <table class=simple>
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>DELETE</td>
@@ -8370,7 +8370,7 @@ is also removed.
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -8416,7 +8416,7 @@ is also removed.
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>DELETE</td>
@@ -8636,7 +8636,7 @@ argument <var>value</var>:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -8672,7 +8672,7 @@ argument <var>value</var>:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -8705,7 +8705,7 @@ argument <var>value</var>:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -8740,7 +8740,7 @@ argument <var>value</var>:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>POST</td>
@@ -8889,7 +8889,7 @@ argument <var>value</var>:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>
@@ -8933,7 +8933,7 @@ argument <var>value</var>:
 <table class="simple jsoncommand">
  <tr>
   <th>HTTP Method</th>
-  <th>Path Template</th>
+  <th>URI Template</th>
  </tr>
  <tr>
   <td>GET</td>


### PR DESCRIPTION
- Update the "match a request" algorithm to refer to the term URI
  template definition (instead of a local variable bearing that name).
- Update each Command's "overview" table to refer to "URI Template"
  (instead of "Path Template") in order to align with the
  specification's "table of endpoints".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/953)
<!-- Reviewable:end -->
