### PR TITLE
Account for "Status" command in processing model

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -889,12 +889,12 @@ in the spec, as demonstrated in a (yet to be developed)
   <p>Otherwise, let <var>command</var> and <var>url variables</var>
    be <var>request match</var>’s data.
 
- <li><p>Let <var>session id</var> be the corresponding variable
-  from <var>url variables</var>.
-
- <li><p>If <var>command</var> is not <a>New Session</a>:
+ <li><p>If <var>command</var> is neither <a>New Session</a> nor <a>Status</a>:
 
   <ol>
+   <li><p>Let <var>session id</var> be the corresponding variable
+    from <var>url variables</var>.
+
    <li><p>Let the <a>current session</a> be the <a>session</a>
      with <a data-lt="session id">ID</a> <var>session id</var> in the
      list of <a>active sessions</a>, or <a><code>null</code></a> if


### PR DESCRIPTION
Similar to the "New Session" command, the "Status" command does not
specify a session identifier, nor does it depend on the "current
session" variable. The substeps related to those values should therefore
be skipped for the "Status" command.

Furthermore, processing either command should not involve extracting the
"session id" value from the variable named "url variables". Re-locate
that step to the branch that concerns only those commands where it is
relevant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/954)
<!-- Reviewable:end -->
