### PR TITLE
Account for any session-independent commands

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -889,12 +889,15 @@ in the spec, as demonstrated in a (yet to be developed)
   <p>Otherwise, let <var>command</var> and <var>url variables</var>
    be <var>request match</var>’s data.
 
- <li><p>Let <var>session id</var> be the corresponding variable
-  from <var>url variables</var>.
+  <li><p>If <var>session id</var> is among the variables defined by <var>url variables</var>:
 
- <li><p>If <var>command</var> is not <a>New Session</a>:
+   <p class=note>This condition is intended to exclude the <a>New Session</a> and <a>Status</a>
+    <a>commands</a> and any <a>extension commands</a> which do not operate on a particular <a>session</a>.
 
   <ol>
+   <li><p>Let <var>session id</var> be the corresponding variable
+    from <var>url variables</var>.
+
    <li><p>Let the <a>current session</a> be the <a>session</a>
      with <a data-lt="session id">ID</a> <var>session id</var> in the
      list of <a>active sessions</a>, or <a><code>null</code></a> if


### PR DESCRIPTION
The "New Session" command does not specify a session identifier, nor
does it depend on the "current session" variable. This is also true of
the "Status" command, and any number of extension commands may likewise
operate outside the context of any particular session.

Skip the substeps related to the current session for any command that
does not specify a "session id" variable. Introduce a non-normative note
documenting the intention of this condition since it is partially
intended to satisfy externally-defined criteria.

Furthermore, processing such commands should not involve extracting the
"session id" value from the variable named "url variables". Re-locate
that step to the branch that concerns only those commands where it is
relevant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/956)
<!-- Reviewable:end -->
