### PR TITLE
Correct "error" example

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1422,7 +1422,8 @@ in the spec, as demonstrated in a (yet to be developed)
 <p><a>Errors</a> are represented in the WebDriver protocol
  by an <a>HTTP response</a> with an <a>HTTP status</a> in the 4xx or 5xx range,
  and a JSON body containing details of the <a>error</a>.
- This JSON body has three fields:
+ This JSON body has a field named <code>value</code> whose value is an object
+ bearing three fields:
  <code>error</code>, containing a string indicating the error type;
  <code>message</code>, containing an implementation-defined string
  with a human readable description of the kind of error that occurred;
@@ -1430,14 +1431,16 @@ in the spec, as demonstrated in a (yet to be developed)
  with a stack trace report of the active stack frames at the time when the error occurred.
 
 <aside class=example>
- <p>A <code>DELETE</code> request to <code>/session/1234</code>,
+ <p>A <code>GET</code> request to <code>/session/1234/url</code>,
  where <code>1234</code> is not the <a>session id</a> of a <a>current session</a>
  would return an <a>HTTP response</a> with the status 404 and a body of the form:
 
  <pre>{
-	"error": "invalid session id",
-	"message": "No active session with ID 1234",
-	"stacktrace": ""
+	"value": {
+		"error": "invalid session id",
+		"message": "No active session with ID 1234",
+		"stacktrace": ""
+	}
 }</pre>
 </aside>
 


### PR DESCRIPTION
Because the "send an error" algorithm provides error data as an
argument to the "send a response" algorithm, the JSON body is expected
to contain a "value" attribute whose value is an object describing the
error. Update the non-normative description and example to reflect this.

The remote end processing model explicitly allows invalid session IDs to
be specified to the Delete command. Update the example to use a command
which would respond to an invalid session ID with the "invalid session
id" error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/959)
<!-- Reviewable:end -->
