### PR TITLE
fix capitalization of JSON serialization

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3452,7 +3452,7 @@ with a "<code>moz:</code>" prefix:
 <p>The <dfn>web frame identifier</dfn>
  is the string constant "<code>frame-075b-4da1-b6ba-e579c2d3230a</code>".
 
-<p>The <dfn>JSON Serialization of the <code>WindowProxy</code> object</dfn>
+<p>The <dfn>JSON serialization of the <code>WindowProxy</code> object</dfn>
  is the JSON <a>Object</a> obtained by applying the following algorithm
  to the given <a><code>WindowProxy</code></a> object <var>window</var>:
 
@@ -4382,7 +4382,7 @@ by following these steps:
   of the <a>current browsing context</a>’s <a>document element</a>.
 
  <li><p>Let <var>active web element</var>
-  be the <a data-lt="JSON Serialization of an element">JSON Serialization</a>
+  be the <a data-lt="JSON serialization of an element">JSON serialization</a>
   of <var>active element</var>.
 
  <li><p>Return <a>success</a> with data <var>active web element</var>.
@@ -4401,7 +4401,7 @@ by following these steps:
  Element retrieval searches are performed
  using pre-order traversal of the document’s nodes
  that match the provided selector’s expression.
- Elements are <a data-lt="JSON Serialization of an element">serialised</a>
+ Elements are <a data-lt="JSON serialization of an element">serialized</a>
  and returned as <a>web elements</a>.
 
 <p>When required to <dfn>find</dfn> with arguments
@@ -6020,7 +6020,7 @@ must run the following steps:
   return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
 
   <p>Otherwise, return <a>success</a>
-   with the <a data-lt="JSON Serialization of an element">JSON Serialization</a>
+   with the <a data-lt="JSON serialization of an element">JSON serialization</a>
    of the <a>web element</a> <var>value</var>.
 
  <dt>a <a><code>WindowProxy</code></a> object
@@ -6030,7 +6030,7 @@ must run the following steps:
   return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
 
   <p>Otherwise return <a>success</a>
-   with the <a data-lt="JSON Serialization of the WindowProxy object">JSON Serialization</a>
+   with the <a data-lt="JSON serialization of the WindowProxy object">JSON serialization</a>
    of <var>value</var>.
 
  <dt>instance of <a>NodeList</a>


### PR DESCRIPTION
We use lower casing in definitions, so we should use it consistently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/960)
<!-- Reviewable:end -->
