### PR TITLE
Define extension command URI parts as templates

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -430,7 +430,6 @@ in the spec, as demonstrated in a (yet to be developed)
  <dd>The following terms are defined
   in the Infra standard: [[!INFRA]]
    <ul>
-    <!-- ASCII lower alpha --> <li><dfn><a href=https://infra.spec.whatwg.org/#ascii-lower-alpha>ASCII lower alpha</a></dfn>
     <!-- ASCII lowercase --> <li><dfn data-lt="lowercase"><a href=https://infra.spec.whatwg.org/#ascii-lowercase>ASCII lowercase</a></dfn>
    </ul>
 
@@ -1690,25 +1689,31 @@ in the spec, as demonstrated in a (yet to be developed)
 
 <p>Each <a>extension command</a> has an associated
  <dfn>extension command name</dfn>
- that is an <a>ASCII lower alpha</a> string,
+ that is a <a>URI Template</a> string,
  and which should bear some resemblance to what the command performs.
  The name is used to form an <a>extension command</a>’s
- <a data-lt="extension command URL">URL</a>.
+ <a data-lt="extension command URI Template">URI Template</a>.
 
-<p>The <a>extension command</a>’s <dfn>extension command URL</dfn>
- is a <a>URL</a> composed of the <a>extension command prefix</a>,
+<p>The <a>extension command</a>’s <dfn>extension command URI Template</dfn>
+ is a <a>URI Template</a> composed of the <a>extension command prefix</a>,
  followed by "<code>/</code>",
  and the <a>extension command</a>’s <a data-lt="extension command name">name</a>.
- The <a>extension command URL</a>,
+ The <a>extension command URI Template</a>,
  along with the HTTP method and <a>extension command</a>,
  is added to the <a>table of endpoints</a>
  and thus follows the same rules for <a>request routing</a>
  as that of other built-in <a>commands</a>.
 
+<aside class=note>
+ If the <a>extension command URI Template</a> includes a variable named
+ <var>session id</var>, the value of this variable will be used to define the
+ <a>current session</a> during command processing.
+</aside>
+
 <aside class=example>
  <p>This might lead to a URL of the form
   <code>/session/5d376174-36f0-11e5-9b9a-6bdf200a3f7f/<var>ms</var>/<var>edge</var>/<var>context</var></code>,
-  where <var>ms/edge</var> is an <a>extension command prefix</a>
+  where <var>/session/{<var>session id</var>}/ms/edge</var> is an <a>extension command prefix</a>
   based on the vendor prefix associated with Microsoft,
   and <var>context</var> the <a>extension command name</a>
   that, in the context of Edge, allows a <a>local end</a>
@@ -1718,7 +1723,7 @@ in the spec, as demonstrated in a (yet to be developed)
 </aside>
 
 <p>An <dfn>extension command prefix</dfn>
- is an <a>ASCII lower alpha</a> string that forms a <a>URL</a> path part,
+ is a <a>URI Template</a> string that forms a <a>URL</a> path part,
  separating <a>extension commands</a> from other <a>commands</a>
  in order to avoid potential resource conflicts with other implementations.
  It is suggested that vendors use their vendor prefixes


### PR DESCRIPTION
Interpret the URI parts specified by extension commands as templates,
thereby allowing for extension commands such as `/session/{session
id}/permissions/grant`. Include a non-normative note to call attention
to the implicit "session retrieval" behavior of the command processing
model.

---

This is an initial pass at resolving gh-961. There, I pointed out that the command processing model's "session retrieval" behavior may not be apparent to those reading this section. I believe this justifies a non-normative note to call attention to that behavior.

@shs96c RFC6570 defines [distinct "levels" for templates](https://tools.ietf.org/html/rfc6570#section-1.2). So far, it seems as though WebDriver and its extensions may only need the capabilities of so-called "Level 1 templates". Do you see any value in restricting extension command templates to Level 1?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/962)
<!-- Reviewable:end -->
