### PR TITLE
Session request queue

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -904,26 +904,29 @@ in the spec, as demonstrated in a (yet to be developed)
      list of <a>active sessions</a>, or <a><code>null</code></a> if
      there is no such matching <a>session</a>.
 
-   <li><p>If the <a>current session</a> is not <a><code>null</code></a>:
+   <li><p>If <var>command</var> is not <a>Delete Session</a>:
 
     <ol>
-      <li><p>Enqueue <var>request</var> in the <a>current session</a>'s <a>request queue</a>.
+     <li><p>If the <a>current session</a> is not <a><code>null</code></a>:
 
-      <li><p>Wait until the first element in the <a>current session</a>'s <a>request queue</a>
-       is <var>request</var>:
+      <ol>
+        <li><p>Enqueue <var>request</var> in the <a>current session</a>'s <a>request queue</a>.
 
-      <li><p>Dequeue <var>request</var> from the <a>current session</a>'s <a>request queue</a>.
+        <li><p>Wait until the first element in the <a>current session</a>'s <a>request queue</a>
+         is <var>request</var>.
 
-      <li><p>If the list of <a>active sessions</a> no longer contains the
-       <a>current session</a>, set the <a>current session</a> to
-       <a><code>null</code></a>.
-    </ol>
+        <li><p>Dequeue <var>request</var> from the <a>current session</a>'s <a>request queue</a>.
 
-   <li><p>If the <a>current session</a> is <a><code>null</code></a>
-    and <var>command</var> is not <a>Delete Session</a>
-    <a>send an error</a> with <a>error code</a>
-    <a>invalid session id</a>, then jump to step 1 in this overall
-    algorithm.
+        <li><p>If the list of <a>active sessions</a> no longer contains the
+         <a>current session</a>, set the <a>current session</a> to
+         <a><code>null</code></a>.
+      </ol>
+
+     <li><p>If the <a>current session</a> is <a><code>null</code></a>
+      <a>send an error</a> with <a>error code</a>
+      <a>invalid session id</a>, then jump to step 1 in this overall
+      algorithm.
+   </ol>
   </ol>
 
  <li><p>If <var>request</var>’s <a>method</a> is POST:

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -432,6 +432,7 @@ in the spec, as demonstrated in a (yet to be developed)
    <ul>
     <!-- ASCII lower alpha --> <li><dfn><a href=https://infra.spec.whatwg.org/#ascii-lower-alpha>ASCII lower alpha</a></dfn>
     <!-- ASCII lowercase --> <li><dfn data-lt="lowercase"><a href=https://infra.spec.whatwg.org/#ascii-lowercase>ASCII lowercase</a></dfn>
+    <!-- queue --> <li><dfn><a href=https://infra.spec.whatwg.org/#queues>queue</a></dfn>
    </ul>
 
  <dt>Page Visibility
@@ -902,6 +903,21 @@ in the spec, as demonstrated in a (yet to be developed)
      with <a data-lt="session id">ID</a> <var>session id</var> in the
      list of <a>active sessions</a>, or <a><code>null</code></a> if
      there is no such matching <a>session</a>.
+
+   <li><p>If the <a>current session</a> is not <a><code>null</code></a>:
+
+    <ol>
+      <li><p>Enqueue <var>request</var> in the <a>current session</a>'s <a>request queue</a>.
+
+      <li><p>Wait until the first element in the <a>current session</a>'s <a>request queue</a>
+       is <var>request</var>:
+
+      <li><p>Dequeue <var>request</var> from the <a>current session</a>'s <a>request queue</a>.
+
+      <li><p>If the list of <a>active sessions</a> no longer contains the
+       <a>current session</a>, set the <a>current session</a> to
+       <a><code>null</code></a>.
+    </ol>
 
    <li><p>If the <a>current session</a> is <a><code>null</code></a>
     and <var>command</var> is not <a>Delete Session</a>
@@ -2527,6 +2543,10 @@ with a "<code>moz:</code>" prefix:
 
 <p>A <a>session</a> has an associated <a>input cancel list</a>.
 
+<p>A <a>session</a> has an associated <dfn>request queue</dfn> which is a
+ <a>queue</a> of <a data-lt=request>requests</a> that are currently awaiting
+ processing.
+
 <p>When asked to <dfn>close the session</dfn>,
  a <a>remote end</a> must take the following steps:
 
@@ -2753,6 +2773,8 @@ with a "<code>moz:</code>" prefix:
    only web browsers). Implementations might choose to use an existing
    browser instance, eg. by selecting the window that currently has
    focus.
+
+ <li><p>Set the <a>request queue</a> to a new <a>queue</a>.
 
  <li><p>Return <a>success</a> with data <var>body</var>.
 </ol>


### PR DESCRIPTION
This patch standardizes the expected behavior as described in the discussion of
gh-950:

> There's the text in the preamble for Section 6 that says that implementations
> must be HTTP compliant. An intermediary node is welcome to handle more than
> one command at a time. The only caveat is that each session should only have
> one command issued against it at a time, though we never spell this out in
> the spec.
>
> [...]
>
> Actually, this is also incorrect. It should always be possible to execute the
> "Delete Session" command even if another command is running for that session. 
>
> [...]
>
> There are three possible conditions that need to be tracked for an endpoint
> node:
>
> 1/ Sessionless commands can be processed regardless of whether or not there's
>    a currently active session.
> 2/ Delete Session can (optionally) be executed immediately
> 3/ All other commands should be pleased in a queue per session and executed
>    serially.
>
> I'm not aware of any implementations that don't merge those last two
> branches, as that hugely simplifies the implementation.

That last allowance for the "Delete Session" command has given me pause. It
doesn't seem sufficient to allow for the condition in the processing model
alone--I believe all commands will have to be updated to support interruption.
If this is true, and if all existing implementations queue Delete commands,
then it might be best to omit this special case behavior. (I've implemented
that part in a separate commit to simplify its removal.)

Note that the phrasing proposed here uses [a specification queue](https://infra.spec.whatwg.org/#queues) in a somewhat non-traditional way: algorithm execution blocks on the identity of "the first member of the queue." While the Infra spec does not describe this kind of operation, I'm taking a cue (please note the pun) from [the `ServiceWorkerContainer#ready` attribute of the Service Worker specification](https://w3c.github.io/ServiceWorker/#navigator-service-worker-ready), whose associated algorithm includes the following steps:

> 2. If registration is null, then:
>    1. Wait until scope to registration map has a new entry.
>    2. Jump to the step labeled CheckRegistration.

While the primitive is different in this case (i.e. a map and not a queue),
this text sets a precedent for the general operation of reacting to changes in
data structure membership.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/965)
<!-- Reviewable:end -->
