### PR TITLE
Remove unnecessary name validation step from Get Element Attribute

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4989,10 +4989,7 @@ by following these steps:
  <li><p>If <var>element</var> <a>is stale</a>,
   return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
 
- <li><p>If <var>name</var> is <a>undefined</a>,
-  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
-
-  <li>Let <var>result</var> be the result of the first matching condition:
+ <li>Let <var>result</var> be the result of the first matching condition:
 
    <dl class=switch>
     <dt>If <var>name</var> is a <a>boolean attribute</a>
@@ -5456,7 +5453,7 @@ by following these steps:
 
      <li><p><a>Dispatch a pointerMove action</a> with
      arguments <var>mouse</var>'s <code><a>input
-     id</a></code>, <var>pointer move action</var>, 
+     id</a></code>, <var>pointer move action</var>,
      <var>mouse</var>'s <a>input source state</a>,
      and <code>0</code>.
 


### PR DESCRIPTION
The name variable can not be invalid as this would lead to a different
URL leading to Unknown Command error being thrown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/966)
<!-- Reviewable:end -->
