### PR TITLE
Don't set expiry on a session cookie

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6356,13 +6356,13 @@ must run the following steps:
 <p>The following <dfn>table for cookie conversion</dfn>
  defines the cookie concepts relevant to WebDriver,
  how these are referred to in [[!RFC6265]],
- what keys they map to in a <a>serialised cookie</a>,
+ what keys they map to in a <a>serialized cookie</a>,
  as well as the attribute-value keys needed
  when constructing a list of arguments for <a>creating a cookie</a>.
 
 <p>For informational purposes,
  the table includes a legend of whether the field is optional
- in the <a>serialised cookie</a> provided to <a>Add Cookie</a>,
+ in the <a>serialized cookie</a> provided to <a>Add Cookie</a>,
  and a brief non-normative description of the field
  and the expected input type of its associated value.
 
@@ -6443,14 +6443,14 @@ must run the following steps:
   <td>"<code>expiry</code>"
   <td>"<code>Max-Age</code>"
   <td>✓
-  <td>When the cookie expires,
-   specified in seconds since <a>Unix Epoch</a>.
-   Defaults to 20 years into the future
-   if omitted when <a>adding a cookie</a>.
+  <td>When the cookie expires, specified in seconds since
+   <a>Unix Epoch</a>.  Must not be set if omitted when
+   <a>adding a cookie</a>.
+
  </tr>
 </table>
 
-<p>A <dfn>serialised cookie</dfn> is a JSON <a>Object</a>
+<p>A <dfn>serialized cookie</dfn> is a JSON <a>Object</a>
  where a <a>cookie</a>’s [[!RFC6265]] fields
  listed in the <a>table for cookie conversion</a>
  are mapped using the <i>JSON Key</i>
@@ -6556,7 +6556,7 @@ must run the following steps:
  <li><p>If the <var>name</var> matches a <a>cookie</a>’s <a>cookie name</a>
   amongst <a>all associated cookies</a>
   of the <a>current browsing context</a>’s <a>active document</a>,
-  return <a>success</a> with the <a>serialised cookie</a> as data.
+  return <a>success</a> with the <a>serialized cookie</a> as data.
 
   <p>Otherwise, return <a>error</a>
    with <a>error code</a> <a>no such cookie</a>.

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6634,8 +6634,8 @@ must run the following steps:
    <dd><p>The value if the entry exists, otherwise false.
 
    <dt><a>Cookie expiry time</a>
-   <dd><p>The value if the entry exists,
-    otherwise a <a>Unix timestamp</a> 20 years into the future from now.
+   <dd><p>The value if the entry exists, otherwise leave unset to
+    indicate that this is a session cookie.
   </dl>
 
   <p>If there is an <a>error</a> during this step,


### PR DESCRIPTION
Also Americanises the spelling of "serialised cookie".

Closes #957

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/969)
<!-- Reviewable:end -->
