### PR TITLE
switch to frame: set browsing context from child window variable

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3669,9 +3669,8 @@ with a "<code>moz:</code>" prefix:
       a <code>Window</code> object</a> <var>window</var> with
       argument <var>id</var>.
 
-
      <li><p>Set the <a>current browsing context</a> to
-      <var>new window</var>’s browsing context.</li>
+      <var>child window</var>’s <a>browsing context</a>.
     </ol>
 
    <dt><var>id</var> <a>represents a web element</a>


### PR DESCRIPTION
We want to set the session's current browsing context from the associated
browsing context of the found WindowProxy object.  Each WindowProxy
has an associated browsing context, and the "new window" variable we
currently use is not defined.

Fixes: https://github.com/w3c/webdriver/issues/973

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/975)
<!-- Reviewable:end -->
