### PR TITLE
Processing Model: allow any sessionless command to proceed

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -933,8 +933,8 @@ in the spec, as demonstrated in a (yet to be developed)
     </ol>
 
    <li><p>If the <a>current session</a> is <a><code>null</code></a>
-    and <var>command</var> is not <a>Delete Session</a>
-    <a>send an error</a> with <a>error code</a>
+    and <var>session id</var> is among the variables defined by
+    <var>url variables</var> <a>send an error</a> with <a>error code</a>
     <a>invalid session id</a>, then jump to step 1 in this overall
     algorithm.
   </ol>


### PR DESCRIPTION
The spec carefully carved out space for commands to not
require a session (which is good), and then only singled
out `Delete Session` (which is an oversight). Fix this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/976)
<!-- Reviewable:end -->
