### PR TITLE
Remove obsolete W3C bug tracker link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,4 @@ This repository contains the ongoing work on the W3C specification
 for the browser automation protocol known as _WebDriver_.
 It is being developed by the [Browser Testing and Tools Working Group](http://www.w3.org/testing/browser/).
 
-Bugs can be filed against the [W3C bug tracker](https://www.w3.org/Bugs/Public/enter_bug.cgi?comment=&blocked=20860&short_desc=%5BWebDriver%20Spec%5D%3A%20&product=Browser%20Test%2FTools%20WG&component=WebDriver),
-and pull requests should patch `webdriver-spec.html`.
+Pull requests should patch `webdriver-spec.html`.


### PR DESCRIPTION
Remove obsolete W3C bug tracker link.

The component no longer exists, and the link leads to the message:
Sorry, the product Browser Test/Tools WG has to have at least one
active component in order for you to enter a bug into it.

As issues should just be filed using the GitHub issue tracker
here, I chose to simply remove the old link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/978)
<!-- Reviewable:end -->
