### PR TITLE
window rect: introduce window state concept

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3754,6 +3754,54 @@ with a "<code>moz:</code>" prefix:
  Where a <a>command</a> is not supported,
  an <a>unsupported operation</a> <a>error</a> is returned.
 
+<p>The <a>top-level browsing context</a>
+ has an associated <dfn data-lt="window states">window state</dfn>
+ which describes what visibility state its OS widget window is in.
+ It can be in one of the following states:
+
+<table class=simple>
+ <tr>
+  <th>State
+  <th>Keyword
+  <th>Default
+  <th>Description
+ </tr>
+
+ <tr>
+  <td><dfn>Maximized window state</dfn>
+  <td>"<code>maximized</code>"
+  <td>
+  <td>The window is maximized.
+ </tr>
+
+ <tr>
+  <td><dfn>Minimized window state</dfn>
+  <td>"<code>minimized</code>"
+  <td>
+  <td>The window is iconified.
+ </tr>
+
+ <tr>
+  <td><dfn>Normal window state</dfn>
+  <td>"<code>normal</code>"
+  <td>✓
+  <td>The window is shown normally.
+ </tr>
+
+ <tr>
+  <td><dfn>Fullscreen window state</dfn>
+  <td>"<code>fullscreen</code>"
+  <td>
+  <td>The window is in full screen mode.
+ </tr>
+</table>
+
+<p>If for whatever reason
+ the <a>top-level browsing context</a>’s OS window
+ cannot enter either of the <a>window states</a>,
+ or if this concept is not applicable on the current system,
+ the default state must be <a data-lt="normal window state">normal</a>.
+
 <p>A <a>top-level browsing context</a>’s <dfn>window rect</dfn>
  is defined as a dictionary of the <a>screenX</a>, <a>screenY</a>,
  <code>width</code> and <code>height</code> attributes
@@ -3778,6 +3826,9 @@ with a "<code>moz:</code>" prefix:
   including any browser chrome
   and externally drawn window decorations
   in <a>CSS reference pixels</a>.
+
+ <dt><code>state</code>
+ <dd><p>The <a>top-level browsing context</a>’s <a>window state</a>.
 </dl>
 
 <p class=example>In some user agents the operating system’s


### PR DESCRIPTION
When an OS window is minimised/maximized/fullscreened, there is currently
no homogenous way of telling what state it is in.

This introduces a "state" field on the window rect which returns the
window's state that is applicable for the current UA and the current
system.

The motivation behind this change is to make it easier to test the
specification, but I imagine it is also useful to users who want to
query the window's current state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/985)
<!-- Reviewable:end -->
