### PR TITLE
maximize window: transition to maximized state and make wm provisions

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3974,9 +3974,20 @@ with a "<code>moz:</code>" prefix:
   return <a>error</a> with <a>error code</a> <a>unsupported operation</a>.
 
  <li><p>Run the implementation-specific steps
-  to increase the dimensions of the operating system level window
+  to transition the operating system level window
   containing the <a>current top-level browsing context</a>
-  to the maximum available size allowed by the window manager.
+  into the maximized state.
+
+  <p>If the window manager supports window resizing
+   but does not have a concept of window maximation,
+   the window dimensions must be increased
+   to the maximum available size
+   permitted by the window manager
+   for the current screen.
+
+  <p>Continue to the next step
+   when the window has completed the transition,
+   or within an implementation-defined timeout.
 
  <li><p>Return <a>success</a>
   with the <a data-lt="json serialization of window rect">JSON serialization</a>


### PR DESCRIPTION
A window's maximized state is often not the same as increasing its
dimensions to the maximum allowed screen size.  We need to be explicit
that the OS window should be moved into the maximized state.

Furthermore, a certain variety of window managers does not support the
concept of window maximation at all.  In this case, it is permissable for
WebDriver to increase the window's boundaries to the maximum screen size.

In the latter case, it is impossible to tell when if the window
has reached the full dimensions of the available screen, because
the window may have decorated borders.  This causes there to be an
unknown disjunction between window.screen.availHeight/availWidth and
window.outerWidth/outerHeight.  In this case we need to permit the
WebDriver implementation to return after a timeout so that it does not
hang indefinitely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/986)
<!-- Reviewable:end -->
