### PR TITLE
invalid element state: correct description

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1550,10 +1550,10 @@ in the spec, as demonstrated in a (yet to be developed)
   <td><dfn>invalid element state</dfn>
   <td>400
   <td><code>invalid element state</code>
-  <td>A <a>command</a> could not be completed
-   because the element is in an invalid state,
-   e.g. attempting to click an element
-   that is no longer attached to the <a>document</a>.
+  <td>The target <a>element</a> is in an invalid state,
+   rendering it impossible to interact with,
+   for example if you <a data-lt="element click">click</a>
+   a <a>disabled</a> <a>element</a>.
  </tr>
 
  <tr>


### PR DESCRIPTION
That an element is in an invalid state does not mean it has been detached
from the document.  It usually means the element is in a state in which
it is impossible for WebDriver to interact with it, e.g. if you try to use
the high-level Element Click command to click an element that is disabled.

Fixes: https://github.com/w3c/webdriver/issues/989
Reported-by: @titusfortner

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/990)
<!-- Reviewable:end -->
