### PR TITLE
element click: deselect selected <option> in <select multiple>

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5395,7 +5395,13 @@ by following these steps:
        <li><p>Let <var>previous selectedness</var> be equal to <var>element</var>
          <a>selectedness</a>.
 
-       <li><p>Set <var>element</var>’s <a>selectedness</a> state to true.
+       <li><p>If <var>element</var>’s <a>container</a>
+        has the <a><code>multiple</code> attribute</a>,
+        toggle the <var>element</var>’s <a>selectedness</a> state
+        by setting it to the opposite value of its current <a>selectedness</a>.
+       
+        <p>Otherwise,
+         set the <var>element</var>’s <a>selectedness</a> state to true.
 
        <li><p>If <var>previous selectedness</var> is false:
          <ol>


### PR DESCRIPTION
To align the specification with existing implementations, `<option>`
elements which are in the selectedness state and whose container element
is `<select multiple>` should be deselected when they are clicked.

`<option>`s that are child elements of a regular `<select>` dropdown should
not be deselected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/991)
<!-- Reviewable:end -->
