### PR TITLE
Add states to prompt handling to allow notification of handled prompts

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html
  data-issue-url="https://github.com/w3c/webdriver/"
  data-issue-param-milestone="Level 1">
@@ -8733,6 +8733,20 @@ is also removed.
  </tr>
 
  <tr>
+  <td>"<code>dismiss and notify</code>"
+  <td><dfn>Dismiss and notify state</dfn>
+  <td>All <a>simple dialogs</a> encountered should be <a>dismissed</a>,
+      and an error returned that the dialog was handled.
+ </tr>
+
+ <tr>
+  <td>"<code>accept and notify</code>"
+  <td><dfn>Accept and notify state</dfn>
+  <td>All <a>simple dialogs</a> encountered should be <a>accepted</a>,
+      and an error returned that the dialog was handled.
+ </tr>
+
+ <tr>
   <td>"<code>ignore</code>"
   <td><dfn>Ignore state</dfn>
   <td>All <a>simple dialogs</a> encountered should be left to the user to handle.
@@ -8769,6 +8783,22 @@ argument <var>value</var>:
 
    <dt><a>accept state</a>
    <dd><p><a>Accept</a> the <a>current user prompt</a>.
+
+   <dt><a>dismiss and notify state</a>
+   <dd>
+    <ol>
+     <li><p><a>Dismiss</a> the <a>current user prompt</a>.
+     <li><p>Return <a>error</a> with <a>error code</a>
+      <a>unexpected alert open</a>.
+    </ol>
+
+   <dt><a>accept and notify state</a>
+   <dd>
+    <ol>
+     <li><p><a>Accept</a> the <a>current user prompt</a>.
+     <li><p>Return <a>error</a> with <a>error code</a>
+      <a>unexpected alert open</a>.
+    </ol>
 
    <dt><a>ignore state</a>
    <dd><p>Return <a>error</a> with <a>error code</a>


### PR DESCRIPTION
Setting a user prompt handler accepts or dismisses a prompt with no
notification to the user that the prompt was handled. In the primary use
case of testing, this hides important information from the user, that a
prompt the test did not expect was encountered, and handled. If the user
wishes to have their test ignore this case, they should make a fully
informed and conscious decision to do so. This change adds options to the
user prompt handler to allow for the case to inform the user of the
handled propmt via an error. To maintain compatibility with previous spec
language, the added values are the ones that describe the new behavior.

Closes issue #912.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/996)
<!-- Reviewable:end -->
