### PR TITLE
Bump version of the Selenium atoms to use

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -446,8 +446,8 @@ in the spec, as demonstrated in a (yet to be developed)
   the <a href="http://www.seleniumhq.org">Selenium</a> project, at
   revision <code>1721e627e3b5ab90a06e82df1b088a33a8d11c20</code>.
   <ul>
-   <!-- bot.dom.getVisibleText --> <li><dfn><a href="https://github.com/SeleniumHQ/selenium/blob/1721e627e3b5ab90a06e82df1b088a33a8d11c20/javascript/atoms/dom.js#L979"><code>bot.dom.getVisibleText</code></a></dfn>
-   <!-- bot.dom.isShown --> <li><dfn><a href="https://github.com/SeleniumHQ/selenium/blob/1721e627e3b5ab90a06e82df1b088a33a8d11c20/javascript/atoms/dom.js#L548"><code>bot.dom.isShown</code></a></dfn>
+   <!-- bot.dom.getVisibleText --> <li><dfn><a href="https://github.com/SeleniumHQ/selenium/blob/e09e28f016c9f53196cf68d6f71991c5af4a35d4/javascript/atoms/dom.js#L981"><code>bot.dom.getVisibleText</code></a></dfn>
+   <!-- bot.dom.isShown --> <li><dfn><a href="https://github.com/SeleniumHQ/selenium/blob/e09e28f016c9f53196cf68d6f71991c5af4a35d4/javascript/atoms/dom.js#L437"><code>bot.dom.isShown</code></a></dfn>
   </ul>
 
  <dt>Styling


### PR DESCRIPTION
This includes an update to the atoms that better
handles the ShadowDOM using the final APIs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1002)
<!-- Reviewable:end -->
