### PR TITLE
Socks Proxy requires Socks Version

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2048,6 +2048,12 @@ with a "<code>moz:</code>" prefix:
   "<code>proxyType</code>" return an <a>error</a> with <a>error
   code</a> <a>invalid argument</a>.
 
+ <li><p>If the result of <a>getting a property</a>
+  named <var>proxyType</var> from <var>proxy</var> equals
+  "<code>pac</code>", and <var>proxy</var> does not have an
+  <a>own property</a> for "<code>proxyAutoconfigUrl</code>" return
+  an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
  <li><p>If <var>proxy</var> has an <a>own property</a> for
   "<code>socksProxy</code>" and does not have an <a>own property</a>
   for "<code>socksVersion</code>" return an <a>error</a> with <a>error

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2046,8 +2046,14 @@ with a "<code>moz:</code>" prefix:
 
  <li><p>If <var>proxy</var> does not have an <a>own property</a> for
   "<code>proxyType</code>" return an <a>error</a> with <a>error
-  code</a> <a>invalid argument</a>. Otherwise return <a>success</a>
-  with data <var>proxy</var>.
+  code</a> <a>invalid argument</a>.
+
+ <li><p>If <var>proxy</var> has an <a>own property</a> for
+  "<code>socksProxy</code>" and does not have an <a>own property</a>
+  for "<code>socksVersion</code>" return an <a>error</a> with <a>error
+  code</a> <a>invalid argument</a>.
+
+ <li><p>Return <a>success</a> with data <var>proxy</var>.
 </ol>
 
 <p>A <dfn>proxy configuration object</dfn> is a


### PR DESCRIPTION
If someone tries to set the socks proxy they
also need to declare the socks version.

Closes #1008

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1012)
<!-- Reviewable:end -->
