### PR TITLE
Make Minimize Window idempotent

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4108,16 +4108,7 @@ with a "<code>moz:</code>" prefix:
 
  <li><p><a>Fully exit fullscreen</a>.
 
- <li><p>Switching on the <a>visibility state</a>
-  of the <a>current top-level browsing context</a>’s <a>active document</a>:
-
-  <dl class=switch>
-   <dt><a data-lt="visibility hidden">hidden</a>
-   <dd><p><a>Restore the window</a>.
-
-   <dt>Otherwise
-   <dd><p><a>Iconify the window</a>.
-  </dl>
+ <li><p><a>Iconify the window</a>.
 
  <li><p>Return <a>success</a>
   with the <a data-lt="json serialization of window rect">JSON serialization</a>


### PR DESCRIPTION
Minimize Window is the only window manipulation command
that toggles the state of the window when called.

This helps to address #1007. The way to restore a
window from minimized, fullscreen, or maximized state
is to call `Set Window Rect`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1013)
<!-- Reviewable:end -->
