### PR TITLE
Correct `invalid element state` example

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1550,10 +1550,10 @@ in the spec, as demonstrated in a (yet to be developed)
   <td><dfn>invalid element state</dfn>
   <td>400
   <td><code>invalid element state</code>
-  <td>A <a>command</a> could not be completed
-   because the element is in an invalid state,
-   e.g. attempting to click an element
-   that is no longer attached to the <a>document</a>.
+  <td>A <a>command</a> could not be completed because the element is
+   in an invalid state, e.g. attempting to
+   <a data-lt="Element Clear">clear</a> an element that isn't
+   both <a>editable</a> and <a>resettable</a>.
  </tr>
 
  <tr>


### PR DESCRIPTION
To be something that is actually an invalid element state.

Closes #989

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1014)
<!-- Reviewable:end -->
