### PR TITLE
New Session: firstMatch must have entries

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2099,8 +2099,9 @@ with a "<code>moz:</code>" prefix:
    <li><p>If <var>all first match capabilities</var> is <a>undefined</a>,
     set the value to a JSON <a>List</a> with a single entry of an empty JSON <a>Object</a>.
 
-   <li><p>If <var>all first match capabilities</var> is not a JSON <a>List</a>,
-   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+   <li><p>If <var>all first match capabilities</var> is not a
+   JSON <a>List</a> with one or more entries, return <a>error</a>
+   with <a>error code</a> <a>invalid argument</a>.
   </ol>
 
  <li><p>Let <var>validated first match capabilities</var> be an empty


### PR DESCRIPTION
Unless we have at least one entry in the list of
`firstMatch` the `New Session` algorithm will
never attempt to perform merging with `alwaysMatch`
meaning that a structure like this:

```
{
 "capabilities": {
  "alwaysMatch": {},
  "firstMatch": [],
 }
}
```

won't successfully start a session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1019)
<!-- Reviewable:end -->
