### PR TITLE
Return an unknown error if an http request makes no sense

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -893,8 +893,10 @@ in the spec, as demonstrated in a (yet to be developed)
   complete <a>HTTP request</a> can be constructed from the data.
   Let <var>request</var> be a <a>request</a> constructed from the
   received data, according to the requirements of [[!RFC7230]]. If it
-  is not possible to construct a complete <a>HTTP request</a> <a>send
-  an error</a> with <a>error code</a> <a>unknown error</a>.
+  is not possible to construct a complete <a>HTTP request</a>,
+  the <a>remote end</a> must either close the <a>connection</a>,
+  return an HTTP response with status code 500, or return
+  an <a>error</a> with <a>error code</a> <a>unknown error</a>.
 
  <li><p>Let <var>request match</var> be the result of the algorithm
   to <a>match a request</a> with <var>request</var>’s

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -888,16 +888,13 @@ in the spec, as demonstrated in a (yet to be developed)
 <p>After such a <a>connection</a> has been established,
  a <a>remote end</a> MUST run the following steps:</p>
 
-<p class=issue>Should mention what happens if it can’t be decoded as HTTP.
- Note that <a href=https://fetch.spec.whatwg.org/>Fetch</a> isn’t quite right
- because it doesn’t specify how to construct a request from network data, or serialize a response.
-
 <ol>
- <li><p><a>Read bytes</a> from the <a>connection</a>
-  until a complete <a>HTTP request</a> can be constructed from the data.
-  Let <var>request</var> be a <a>request</a>
-  constructed from the received data,
-  according to the requirements of [[!RFC7230]].
+ <li><p><a>Read bytes</a> from the <a>connection</a> until a
+  complete <a>HTTP request</a> can be constructed from the data.
+  Let <var>request</var> be a <a>request</a> constructed from the
+  received data, according to the requirements of [[!RFC7230]]. If it
+  is not possible to construct a complete <a>HTTP request</a> <a>send
+  an error</a> with <a>error code</a> <a>unknown error</a>.
 
  <li><p>Let <var>request match</var> be the result of the algorithm
   to <a>match a request</a> with <var>request</var>’s


### PR DESCRIPTION
Resolves issue 1 on the spec. The language is wooly, but then
all the language around how to handle the network connection
is wooly. The key benefit of unknown error is that it sets the
http status code to 500, which is what I'd expect to happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1024)
<!-- Reviewable:end -->
