### PR TITLE
Acknowledge the evil-bitness of interface change

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -730,6 +730,10 @@ in the spec, as demonstrated in a (yet to be developed)
 
 <p>This property defines a standard way for a co-operating user agent to inform a website
   that it is controlled by WebDriver.
+
+<p class="note" style="display: none">It is acknowledged that this is
+ complementary to the Evil Bit [[!RFC3514]].
+
 </section>
 
 <section>


### PR DESCRIPTION
Since many of the implementations of webdriver are OSS
it should be trivial to remove the interface change and
make automation undetectable unless you use some other
means to spot it.

The comment itself is frivolous and unhelpful to spec
developers, but it's quite fun to have it be there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1025)
<!-- Reviewable:end -->
