### PR TITLE
Ensure deserialization of parameters happens before other checks.

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3207,8 +3207,6 @@ with a "<code>moz:</code>" prefix:
  <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
- <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
-
  <li><p>Let <var>url</var> be the result of
   <a>getting the property</a> <code>url</code>
   from the <var>parameters</var> argument.
@@ -3217,6 +3215,8 @@ with a "<code>moz:</code>" prefix:
   or is not an <a>absolute URL with fragment</a> or not a
   <a>local scheme</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
 
  <li><p>Let <var>current URL</var> be the <a>current top-level browsing context</a>’s
  <a>active document</a>’s <a>document URL</a>.
@@ -3613,16 +3613,16 @@ with a "<code>moz:</code>" prefix:
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If there is an active <a>user prompt</a>, that prevents the
-  focussing of another <a>top-level browsing context</a>,
-  return <a>error</a> with <a>error code</a> <a>unexpected alert open</a>.
-
  <li><p>Let <var>handle</var> be the result of
   <a>getting the property</a> "<code>handle</code>"
   from the <var>parameters</var> argument.
 
  <li><p>If <var>handle</var> is <a>undefined</a> return <a>error</a>
   with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>If there is an active <a>user prompt</a>, that prevents the
+  focussing of another <a>top-level browsing context</a>,
+  return <a>error</a> with <a>error code</a> <a>unexpected alert open</a>.
 
  <li><p>If <var>handle</var> is equal to the associated <a>window handle</a>
   for some <a>top-level browsing context</a> in the <a>current session</a>,
@@ -3693,14 +3693,19 @@ with a "<code>moz:</code>" prefix:
 <p>The <a>remote end steps</a> are:
 
 <ol>
+ <li><p>Let <var>id</var> be the result of
+  <a>getting the property</a> "<code>id</code>"
+  from the <var>parameters</var> argument.
+
+ <li><p>If <var>id</var> is not <a><code>null</code></a>,
+ a <code>Number</code> object, or an <a>Object</a> that <a>represents a web
+ element</a>, <p>return <a>error</a> with <a>error code</a> <a>no such
+ frame</a>.
+
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
-
- <li><p>Let <var>id</var> be the result of
-  <a>getting the property</a> "<code>id</code>"
-  from the <var>parameters</var> argument.
 
  <li><p>Run the substeps of the first matching condition:
 
@@ -3752,12 +3757,6 @@ with a "<code>moz:</code>" prefix:
      <li><p>Set the <a>current browsing context</a> to <var>element</var>’s
       <a>nested browsing context</a>.
     </ol>
-
-  <dt>Otherwise</dt>
-  <dd>
-   <ol>
-    <li><p>Return <a>error</a> with <a>error code</a> <a>no such frame</a>.
-   </ol>
  </dl>
 
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
@@ -3989,16 +3988,6 @@ with a "<code>moz:</code>" prefix:
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
-  return <a>error</a> with <a>error code</a> <a>no such window</a>.
-
- <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
-
- <li><p>If the <a>remote end</a> does not support
-  the <a>Set Window Rect</a> <a>command</a> for
-  the <a>current top-level browsing context</a> for any reason,
-  return <a>error</a> with <a>error code</a> <a>unsupported operation</a>.
-
  <li><p>Let <var>width</var> be the result of
   <a>getting a property</a> named <code>width</code>
   from the <var>parameters</var> argument, else let it be <a><code>null</code></a>.
@@ -4022,6 +4011,16 @@ with a "<code>moz:</code>" prefix:
  <li><p>If <var>x</var> or <var>y</var> is neither <a><code>null</code></a>
   nor a <a>Number</a> from −(2<sup>63</sup>) to 2<sup>63</sup> − 1,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>If the <a>remote end</a> does not support
+  the <a>Set Window Rect</a> <a>command</a> for
+  the <a>current top-level browsing context</a> for any reason,
+  return <a>error</a> with <a>error code</a> <a>unsupported operation</a>.
+
+ <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+  return <a>error</a> with <a>error code</a> <a>no such window</a>.
+
+ <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
 
  <li><p><a>Fully exit fullscreen</a>.
 
@@ -4108,15 +4107,15 @@ with a "<code>moz:</code>" prefix:
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
-  return <a>error</a> with <a>error code</a> <a>no such window</a>.
-
- <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
-
  <li><p>If the <a>remote end</a> does not support
   the <a>Maximize Window</a> command
   for the <a>current top-level browsing context</a> for any reason,
   return <a>error</a> with <a>error code</a> <a>unsupported operation</a>.
+
+ <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+  return <a>error</a> with <a>error code</a> <a>no such window</a>.
+
+ <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
 
  <li><p><a>Fully exit fullscreen</a>.
 
@@ -4155,15 +4154,15 @@ with a "<code>moz:</code>" prefix:
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
-  return <a>error</a> with <a>error code</a> <a>no such window</a>.
-
- <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
-
  <li><p>If the <a>remote end</a> does not support
   the <a>Minimize Window</a> command
   for the <a>current top-level browsing context</a> for any reason,
   return <a>error</a> with <a>error code</a> <a>unsupported operation</a>.
+
+ <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
+  return <a>error</a> with <a>error code</a> <a>no such window</a>.
+
+ <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
 
  <li><p><a>Fully exit fullscreen</a>.
 
@@ -4199,13 +4198,13 @@ with a "<code>moz:</code>" prefix:
 <p>The <a>remote end steps</a> are:
 
 <ol>
+ <li><p>If the <a>remote end</a> does not <a>support fullscreen</a>
+  return <a>error</a> with <a>error code</a> <a>unsupported operation</a>.
+
  <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
-
- <li><p>If the <a>remote end</a> does not <a>support fullscreen</a>
-  return <a>error</a> with <a>error code</a> <a>unsupported operation</a>.
 
  <li><p>Call <a>fullscreen an element</a>
   with the <a>current top-level browsing context</a>’s
@@ -4791,16 +4790,6 @@ by following these steps:
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current browsing context</a> is <a>no longer
-  open</a>, return <a>error</a> with <a>error code</a> <a>no such
-  window</a>.
-
- <li><p>Let <var>start node</var> be
-  the <a>current browsing context</a>’s <a>document element</a>.
-
- <li><p>If <var>start node</var> is <a><code>null</code></a>, return
-  <a>error</a> with <a>error code</a> <a>no such element</a>.
-
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".
 
@@ -4813,6 +4802,16 @@ by following these steps:
 
  <li><p>If <var>selector</var> is <a>undefined</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>If the <a>current browsing context</a> is <a>no longer
+  open</a>, return <a>error</a> with <a>error code</a> <a>no such
+  window</a>.
+
+ <li><p>Let <var>start node</var> be
+  the <a>current browsing context</a>’s <a>document element</a>.
+
+ <li><p>If <var>start node</var> is <a><code>null</code></a>, return
+  <a>error</a> with <a>error code</a> <a>no such element</a>.
 
  <li><p>Let <var>result</var> be the result of <a>trying</a> to <a>Find</a>
   with <var>start node</var>, <var>location strategy</var>,
@@ -4845,16 +4844,6 @@ by following these steps:
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current browsing context</a> is <a>no longer
-  open</a>, return <a>error</a> with <a>error code</a> <a>no such
-  window</a>.
-
- <li><p>Let <var>start node</var> be
-  the <a>current browsing context</a>’s <a>document element</a>.
-
- <li><p>If <var>start node</var> is <a><code>null</code></a>, return
-  <a>error</a> with <a>error code</a> <a>no such element</a>.
-
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".
 
@@ -4867,6 +4856,16 @@ by following these steps:
 
  <li><p>If <var>selector</var> is <a>undefined</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>If the <a>current browsing context</a> is <a>no longer
+  open</a>, return <a>error</a> with <a>error code</a> <a>no such
+  window</a>.
+
+ <li><p>Let <var>start node</var> be
+  the <a>current browsing context</a>’s <a>document element</a>.
+
+ <li><p>If <var>start node</var> is <a><code>null</code></a>, return
+  <a>error</a> with <a>error code</a> <a>no such element</a>.
 
  <li>Return the result of <a>trying</a> to <a>Find</a> with
   <var>start node</var>, <var>location strategy</var>, and <var>selector</var>.
@@ -4895,14 +4894,6 @@ by following these steps:
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current browsing context</a> is <a>no longer
-  open</a>, return <a>error</a> with <a>error code</a> <a>no such
-  window</a>.
-
- <li><p>Let <var>start node</var> be the result
-  of <a>trying</a> to <a>get a known element</a>
-  with argument <var>element id</var>.
-
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".
 
@@ -4915,6 +4906,14 @@ by following these steps:
 
  <li><p>If <var>selector</var> is <a>undefined</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>If the <a>current browsing context</a> is <a>no longer
+  open</a>, return <a>error</a> with <a>error code</a> <a>no such
+  window</a>.
+
+ <li><p>Let <var>start node</var> be the result
+  of <a>trying</a> to <a>get a known element</a>
+  with argument <var>element id</var>.
 
  <li>Let <var>result</var> be the value of <a>trying</a> to <a>Find</a> with
   <var>start node</var>, <var>location strategy</var>,
@@ -4948,14 +4947,6 @@ by following these steps:
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current browsing context</a> is <a>no longer
-  open</a>, return <a>error</a> with <a>error code</a> <a>no such
-  window</a>.
-
- <li><p>Let <var>start node</var> be the result
-  of <a>trying</a> to <a>get a known element</a>
-  with argument <var>element id</var>.
-
  <li><p>Let <var>location strategy</var> be the result
   of <a>getting a property</a> called "<code>using</code>".
 
@@ -4968,6 +4959,14 @@ by following these steps:
 
  <li><p>If <var>selector</var> is <a>undefined</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>If the <a>current browsing context</a> is <a>no longer
+  open</a>, return <a>error</a> with <a>error code</a> <a>no such
+  window</a>.
+
+ <li><p>Let <var>start node</var> be the result
+  of <a>trying</a> to <a>get a known element</a>
+  with argument <var>element id</var>.
 
  <li>Return the result of <a>trying</a> to <a>Find</a> with
   <var>start node</var>, <var>location strategy</var>, and <var>selector</var>.
@@ -5950,6 +5949,13 @@ must run the following steps:
 <p>The <a>remote end steps</a> for <a>Element Send Keys</a> are:
 
 <ol>
+ <li><p>Let <var>text</var> be the result
+  of <a>getting a property</a> called "<code>text</code>"
+  from the <var>parameters</var> argument.
+
+ <li><p>If <var>text</var> is not a <a>String</a>,
+  return an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
@@ -5967,13 +5973,6 @@ must run the following steps:
 
  <li><p>If <var>element</var> is not <a>keyboard-interactable</a>,
   return <a>error</a> with <a>error code</a> <a>element not interactable</a>.
-
- <li><p>Let <var>text</var> be the result
-  of <a>getting a property</a> called "<code>text</code>"
-  from the <var>parameters</var> argument.
-
- <li><p>If <var>text</var> is not a <a>String</a>,
-  return an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>If <var>element</var> is not the <a>active element</a> run
   the <a>focusing steps</a> for the <var>element</var>.
@@ -6250,17 +6249,10 @@ must run the following steps:
   </ol>
 </ol>
 
-<p>The steps for <dfn>extracting the script arguments from a
- request</dfn> with argument <var>parameters</var> are:
+<p>When required to <dfn>extract the script arguments from a
+ request</dfn> with argument <var>parameters</var> the implementation must:
 
 <ol>
- <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
-  return <a>error</a> with <a>error code</a> <a>no such window</a>.
-
- <li><p>Let <var>script</var> be the result of
-  <a>getting a property</a> named <code>script</code>
-  from the <var>parameters</var>.
-
  <li><p>If <var>script</var> is not a <a>String</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
@@ -6376,20 +6368,14 @@ must run the following steps:
 <p>The <a>remote end steps</a> are:
 
 <ol>
+ <li><p>Let <var>body</var> and <var>arguments</var> be the result of
+  <a>trying</a> to <a>extract the script arguments from a request</a>
+  with argument <var>parameters</var>.
+
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
  <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
-
- <li><p>Let <var>script arguments</var> be the result of
-  <a>extracting the script arguments from a request</a>
-  with argument <var>parameters</var>.
-
- <li><p>If <var>script arguments</var> is an <a>error</a>,
-  return <var>script arguments</var>.
-
- <li><p>Let <var>body</var> and <var>arguments</var>
-  be <var>script arguments</var>’ data.
 
  <li><p>Let <var>promise</var> be <a>a new Promise</a>.
 
@@ -6442,20 +6428,14 @@ must run the following steps:
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
-  return <a>error</a> with <a>error code</a> <a>no such window</a>.
+  <li><p>Let <var>body</var> and <var>arguments</var> by the result of <a>trying</a> to
+     <a>extract the script arguments from a request</a> with
+     argument <var>parameters</var>.
 
- <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
+  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
+   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
- <li><p>Let <var>script arguments</var> be the result
-  of <a>extracting the script arguments from a request</a>
-  with argument <var>parameters</var>.
-
- <li><p>If <var>script arguments</var> is an <a>error</a>,
-  return <var>script arguments</var>.
-
- <li><p>Let <var>body</var> and <var>arguments</var>
-  be <var>script arguments</var>’ data.
+   <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
 
   <li><p>Let <var>promise</var> be <a>a new Promise</a>.
 
@@ -6760,6 +6740,14 @@ must run the following steps:
 <p>The <a>remote end steps</a> are:
 
 <ol>
+ <li><p>Let <var>data</var> be the result of <a>getting a property</a>
+  named <code>cookie</code> from the <var>parameters</var> argument.
+
+ <li><p>If <var>data</var> is not a JSON <a>Object</a>
+  with all the required (non-optional) JSON keys
+  listed in the <a>table for cookie conversion</a>,
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
@@ -6768,14 +6756,6 @@ must run the following steps:
  <li><p>If the <a>current browsing context</a>’s <a>document element</a>
   is a <a>cookie-averse <code>Document</code> object</a>,
   return <a>error</a> with <a>error code</a> <a>invalid cookie domain</a>.
-
- <li><p>Let <var>data</var> be the result of <a>getting a property</a>
-  named <code>cookie</code> from the <var>parameters</var> argument.
-
- <li><p>If <var>data</var> is not a JSON <a>Object</a>
-  with all the required (non-optional) JSON keys
-  listed in the <a>table for cookie conversion</a>,
-  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>If <a>cookie name</a> or <a>cookie value</a> is <a><code>null</code></a>,
   <a>cookie domain</a> is not equal to
@@ -7287,10 +7267,6 @@ is also removed.
  following steps:
 
 <ol>
- <li><p>If the <a>current browsing context</a> is <a>no longer
-  open</a>, return <a>error</a> with <a>error code</a>
-  <a>no such window</a>.
-
  <li><p>Let <var>actions</var> be the result
   of <a>getting a property</a> from <var>parameters</var>
   named <code>actions</code>.
@@ -8618,16 +8594,16 @@ is also removed.
 <p>The <a>remote end steps</a> are:</p>
 
 <ol>
+ <li><p>Let <var>actions by tick</var> be the result of <a>trying</a>
+  to <a>extract an action sequence</a> with
+  argument <var>parameters</var>.
+
  <li><p>If the <a>current browsing context</a> is <a>no longer
   open</a>, return <a>error</a> with <a>error code</a> <a>no such
   window</a>.
 
  <li><p><a>Handle any user prompts</a>. If this results in
   an <a>error</a>, return that <a>error</a>.
-
- <li><p>Let <var>actions by tick</var> be the result of <a>trying</a>
-  to <a>extract an action sequence</a> with
-  argument <var>parameters</var>.
 
  <li><p><a>Dispatch actions</a> with argument
   <var>actions by tick</var>. If this results in an <a>error</a>
@@ -9013,6 +8989,13 @@ argument <var>value</var>:
 <p>The <a>remote end steps</a> are:
 
 <ol>
+ <li><p>Let <var>text</var> be the result of
+  <a>getting the property</a> "<code>text</code>"
+  from <var>parameters</var>.
+
+ <li><p>If <var>text</var> is not a <a>String</a>,
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
  <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
@@ -9035,13 +9018,6 @@ argument <var>value</var>:
    <dd><p>Return <a>error</a> with
     <a>error code</a> <a>unsupported operation</a>.
   </dl>
-
- <li><p>Let <var>text</var> be the result of
-  <a>getting the property</a> "<code>text</code>"
-  from <var>parameters</var>.
-
- <li><p>If <var>text</var> is not a <a>String</a>,
-  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>Perform user agent dependent steps
   to set the value of <a>current user prompt</a>’s text field


### PR DESCRIPTION
For an implementation that deseralizes the parameters in a frontend
before contacting the browser it's difficult to check for unexpected
alerts or perform other actions that require the browser before
completing deserialization. So ensure that deserialization is always
fully complete before taking other actions. In practice the only
observable change here is the error observed if there is both an
invalid request and e.g. an unexpected alert open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1036)
<!-- Reviewable:end -->
