### PR TITLE
Clarify that noProxy expects a list of comma-separated entries.

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1986,8 +1986,9 @@ with a "<code>moz:</code>" prefix:
  <tr>
   <td><dfn><code>noProxy</code></dfn>
   <td>array
-  <td>Lists the address for which the proxy should be bypassed when
-   the <a><code>proxyType</code></a> is "<code>manual</code>".
+  <td>Comma-separated list of hosts for which the proxy should be bypassed if
+   <a><code>proxyType</code></a> is equal to "<code>manual</code>".
+  <td>
   <td>A <a>List</a> containing any number of any
    of <a>domains</a>, <a>IPv4 addresses</a>, or <a>IPv6 addresses</a>.
  </tr>
@@ -6049,7 +6050,7 @@ must run the following steps:
 
    <dt><var><a>element</a></var> is <a>content editable</a>
    <dd>Set the text insertion caret after any child content.
-   
+
    <dt>Otherwise
    <dd>
     <ol>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1044)
<!-- Reviewable:end -->
