### PR TITLE
Simplify language when checking if session is present

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -937,6 +937,11 @@ in the spec, as demonstrated in a (yet to be developed)
      list of <a>active sessions</a>, or <a><code>null</code></a> if
      there is no such matching <a>session</a>.
 
+   <li><p>If the <a>current session</a> is <a><code>null</code></a>
+    <a>send an error</a> with <a>error code</a>
+    <a>invalid session id</a>, then jump to step 1 in this overall
+    algorithm.
+
    <li><p>If the <a>current session</a> is not <a><code>null</code></a>:
 
     <ol>
@@ -951,12 +956,6 @@ in the spec, as demonstrated in a (yet to be developed)
        <a>current session</a>, set the <a>current session</a> to
        <a><code>null</code></a>.
     </ol>
-
-   <li><p>If the <a>current session</a> is <a><code>null</code></a>
-    and <var>session id</var> is among the variables defined by
-    <var>url variables</var> <a>send an error</a> with <a>error code</a>
-    <a>invalid session id</a>, then jump to step 1 in this overall
-    algorithm.
   </ol>
 
  <li><p>If <var>request</var>’s <a>method</a> is POST:


### PR DESCRIPTION
The text modified is already in a block where we've checked
for the presence of the session id in the url variables. If
there's no session, we should exit immediately. Moved that
step up to bring it closer to the loading of the session and
the declaration of session id from the url variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1065)
<!-- Reviewable:end -->
