### PR TITLE
Allow extension commands to be routed

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1134,8 +1134,9 @@ in the spec, as demonstrated in a (yet to be developed)
 <h3>List of Endpoints</h3>
 
 <p>The following <dfn data-lt=endpoints>table of endpoints</dfn> lists
- the <a>method</a> and <a>URI template</a>
- for each <a>endpoint node</a> <a>command</a>.
+ the <a>method</a> and <a>URI template</a> for each <a>endpoint
+ node</a> <a>command</a>. <a>Extension commands</a> are implicitly
+ appended to this table.
 
 <table class=simple>
  <tr>


### PR DESCRIPTION
The `match a request` algorithm does not mention extension
commands, making them unroutable by a struct interpretation
of the spec. Acknowledge that they are appended to the
table of endpoints, and everything should Just Work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1067)
<!-- Reviewable:end -->
