### PR TITLE
Refer to the page load types indirectly

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2910,7 +2910,7 @@ with a "<code>moz:</code>" prefix:
  and can additionally include arbitrary meta information
  that is specific to the implementation.
 
-<p>The readiness state is represented
+<p>The <a>readiness state</a> is represented
  by the <code>ready</code> property of the body,
  which is false if an attempt to <a data-lt="new session">create a session</a>
  at the current time would fail.

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4274,7 +4274,7 @@ with a "<code>moz:</code>" prefix:
 <p>Each <a>element</a> has an associated <dfn>web element
  reference</dfn> that uniquely identifies the <a>element</a> across
  all <a>browsing contexts</a>.  The <a>web element reference</a> for
- every <a>element</a> representing the same <a>element</a> is the
+ every <a>element</a> representing the same <a>element</a> must be the
  same. It must be a string, and should be the result of <a>generating
  a UUID</a>.
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -535,8 +535,8 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- scrollY --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-window-scrolly">scrollY</a></dfn>
    <!-- scrollIntoView --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview>scrollIntoView</a></dfn>
    <!-- ScrollIntoViewOptions --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dictdef-scrollintoviewoptions><code>ScrollIntoViewOptions</code></a></dfn>
-   <!-- ScrollIntoViewOptions block --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-scrollintoviewoptions-block>Logical scroll position <code>block</code></a></dfn>
-   <!-- ScrollIntoViewOptions inline --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-scrollintoviewoptions-inline>Logical scroll position <code>inline</code></a></dfn>
+   <!-- ScrollIntoViewOptions block --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-scrollintoviewoptions-block>Logical scroll position "<code>block</code>"</a></dfn>
+   <!-- ScrollIntoViewOptions inline --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-scrollintoviewoptions-inline>Logical scroll position "<code>inline</code>"</a></dfn>
   </ul>
 
  <dt>SOCKS Proxy and related specification:
@@ -4352,13 +4352,13 @@ with a "<code>moz:</code>" prefix:
   the following <a><code>ScrollIntoViewOptions</code></a>:
   
   <dl>
-   <dt><code>behavior</code>
+   <dt>"<code>behavior</code>"
    <dd>"<code>instant</code>"
 
-   <dt><a>Logical scroll position <code>block</code></a>
+   <dt><a>Logical scroll position "<code>block</code>"</a>
    <dd>"<code>end</code>"
 
-   <dt><a>Logical scroll position <code>inline</code></a>
+   <dt><a>Logical scroll position "<code>inline</code>"</a>
    <dd>"<code>nearest</code>"
   </dl>
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5128,9 +5128,6 @@ with a "<code>moz:</code>" prefix:
   of <a>trying</a> to <a>get a known element</a>
   with argument <var>element id</var>.
 
- <li><p>If <var>element</var> <a>is stale</a>,
-  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
-
  <li><p>Let <var>selected</var> be the value
   corresponding to the first matching statement:
 
@@ -5181,9 +5178,6 @@ with a "<code>moz:</code>" prefix:
   of <a>trying</a> to <a>get a known element</a>
   with argument <var>element id</var>.
 
- <li><p>If <var>element</var> <a>is stale</a>,
-  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
-
  <li>Let <var>result</var> be the result of the first matching condition:
 
    <dl class=switch>
@@ -5200,7 +5194,7 @@ with a "<code>moz:</code>" prefix:
   <li><p>Return <a>success</a> with data <var>result</var>.
 </ol>
 
-<p class=note>Please note that the behavior of this command
+<p class="note">Please note that the behavior of this command
  deviates from the behavior of <a>getAttribute</a> in [[DOM]],
  which in the case of a set <a>boolean attribute</a>
  would return an empty string.
@@ -5237,9 +5231,6 @@ with a "<code>moz:</code>" prefix:
  <li><p>Let <var>element</var> be the result
   of <a>trying</a> to <a>get a known element</a>
   with argument <var>element id</var>.
-
- <li><p>If <var>element</var> <a>is stale</a>,
-  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
 
  <li><p>Let <var>property</var> be the result of calling
   the <var>element</var>.<a>[[\GetProperty]]</a>(<var>name</var>).
@@ -5280,9 +5271,6 @@ with a "<code>moz:</code>" prefix:
  <li><p>Let <var>element</var> be the result
   of <a>trying</a> to <a>get a known element</a>
   with argument <var>element id</var>.
-
- <li><p>If <var>element</var> <a>is stale</a>,
-  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
 
  <li><p>Let <var>computed value</var> be
   the <a>computed value</a> of parameter <var>property name</var>
@@ -5376,9 +5364,6 @@ with a "<code>moz:</code>" prefix:
   of <a>trying</a> to <a>get a known element</a>
   with argument <var>element id</var>.
 
- <li><p>If <var>element</var> <a>is stale</a>,
-  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
-
  <li><p>Let <var>qualified name</var> be the result of getting
   <var>element</var>’s <a>tagName</a> content <a>attribute</a>.
 
@@ -5405,21 +5390,21 @@ with a "<code>moz:</code>" prefix:
  The returned value is a dictionary with the following members:
 
 <dl>
- <dt><dfn data-lt=elementrect-x>x</dfn>
+ <dt><dfn data-lt="elementrect-x">x</dfn>
  <dd>X axis position of the top-left corner of the <a>web element</a>
   relative to the <a>current browsing context</a>’s
   <a>document element</a> in <a>CSS reference pixels</a>.
 
- <dt><dfn data-lt=elementrect-y>y</dfn>
+ <dt><dfn data-lt="elementrect-y">y</dfn>
  <dd>Y axis position of the top-left corner of the <a>web element</a>
   relative to the <a>current browsing context</a>’s
   <a>document element</a> in <a>CSS reference pixels</a>.
 
- <dt><dfn data-lt=elementrect-height>height</dfn>
+ <dt><dfn data-lt="elementrect-height">height</dfn>
  <dd>Height of the <a>web element</a>’s
   <a>bounding rectangle</a> in <a>CSS reference pixels</a>.
 
- <dt><dfn data-lt=elementrect-width>width</dfn>
+ <dt><dfn data-lt="elementrect-width">width</dfn>
  <dd>Width of the <a>web element</a>’s
   <a>bounding rectangle</a> in <a>CSS reference pixels</a>.
 </dl>
@@ -5435,9 +5420,6 @@ with a "<code>moz:</code>" prefix:
  <li><p>Let <var>element</var> be the result
   of <a>trying</a> to <a>get a known element</a>
   with argument <var>element id</var>.
-
- <li><p>If the <var>element</var> <a>is stale</a>,
-  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
 
  <li><p><a>Calculate the absolute position</a> of <var>element</var>
   and let it be <var>coordinates</var>.
@@ -5495,9 +5477,6 @@ with a "<code>moz:</code>" prefix:
  <li><p>Let <var>element</var> be the result
   of <a>trying</a> to <a>get a known element</a>
   with argument <var>element id</var>.
-
- <li><p>If <var>element</var> <a>is stale</a>,
-  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
 
  <li><p>Let <var>enabled</var> be a boolean initially set to true
   if the <a>current browsing context</a>’s

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3309,19 +3309,6 @@ with a "<code>moz:</code>" prefix:
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
 
-<div class=issue>
- <p>Figure out if next paragraph is actually required:
-
- <blockquote>
-  <p>When a page contains a META tag with the "http-equiv" attribute set to "refresh",
-   a response MUST be returned if the timeout is greater than 1 second
-   and the other criteria for determining whether a page is loaded are met.
-   When the refresh period is 1 second or less
-   and the page loading strategy is "normal" or "conservative"
-   implementations MUST wait for the refresh to complete before responding.
- </blockquote>
-</div>
-
 </section> <!-- /Navigate To-->
 
 <section>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3534,9 +3534,9 @@ with a "<code>moz:</code>" prefix:
  if it has been <a>discarded</a>.
 
 <p>Each <a>browsing context</a> has an associated
- <dfn data-lt="window handles">window handle</dfn> (string)
- uniquely identifying it.
- It must not be "<code>current</code>".
+ <dfn data-lt="window handles">window handle</dfn> which uniquely
+ identifies it. This must be a <a>String</a> and must not be
+ "<code>current</code>".
 
 <p>The <dfn>web window identifier</dfn>
  is the string constant "<code>window-fcc6-11e5-b4f8-330a88ab9d7f</code>".

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2574,7 +2574,7 @@ with a "<code>moz:</code>" prefix:
  Unless stated otherwise it is zero milliseconds.
 
 <p>A <a>session</a> has an associated <dfn>page loading strategy</dfn>,
- which is one of <a>none</a>, <a>normal</a>, and <a>eager</a>.
+ which is one of the keywords from the <a>table of page load strategies</a>.
  Unless stated otherwise, it is <a>normal</a>.
 
 <p>A <a>session</a> has an associated <dfn>secure TLS</dfn> state


### PR DESCRIPTION
So if we ever add more, we don't need to find all the
places the valid values are listed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1069)
<!-- Reviewable:end -->
