### PR TITLE
Loosen `noProxy` values.

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2024,8 +2024,7 @@ with a "<code>moz:</code>" prefix:
   <td>array
   <td>Lists the address for which the proxy should be bypassed when
    the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>List</a> containing any number of any
-   of <a>domains</a>, <a>IPv4 addresses</a>, or <a>IPv6 addresses</a>.
+  <td>A <a>List</a> containing any number of <a>String</a>s.
  </tr>
 
  <tr>


### PR DESCRIPTION
Turns out the list of valid entries is far broader:

https://developer.mozilla.org/en-US/docs/No_Proxy_For_configuration

Closes #1068

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1070)
<!-- Reviewable:end -->
