### PR TITLE
is stale: take document into account

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -144,9 +144,10 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- getAttribute --> <li><dfn><a href=https://dom.spec.whatwg.org/#dom-element-getattribute>getAttribute</a></dfn>
    <!-- getElementsByTagName --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-element-getelementsbytagname"><code>getElementsByTagName</code></a></dfn>
    <!-- hasAttribute --> <li><dfn data-lt="has the attribute"><a href=https://dom.spec.whatwg.org/#dom-element-hasattribute>hasAttribute</a></dfn>
-   <!-- HTMLCollection --><li><dfn><a href="https://dom.spec.whatwg.org/#htmlcollection"><code>HTMLCollection</code></a></dfn>
+   <!-- HTMLCollection --> <li><dfn><a href=https://dom.spec.whatwg.org/#htmlcollection><code>HTMLCollection</code></a></dfn>
    <!-- Inclusive descendant --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant>Inclusive descendant</a></dfn>
    <!-- isTrusted --> <li><dfn data-lt='is trusted'><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">isTrusted</a></dfn>
+   <!-- Node document --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-node-document>Node document</a></dfn>
    <!-- Node length --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-node-length">Node Length</a></dfn>
    <!-- Node --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-node>Node</a></dfn>
    <!-- NodeList --> <li><dfn><a href=https://dom.spec.whatwg.org/#nodelist><code>NodeList</code></a></dfn>
@@ -4343,8 +4344,9 @@ with a "<code>moz:</code>" prefix:
  <li><p>Return <a>success</a> with data <var>element</var>.
 </ol>
 
-<p>A <a>element</a> <dfn>is stale</dfn>
- if its <a>context object</a> is not <a>connected</a>.
+<p>An <a>element</a> <dfn>is stale</dfn>
+ if its <a>node document</a> is not the <a>active document</a>
+ or if its <a>context object</a> is not <a>connected</a>.
 
 <p>To <dfn data-lt="scrolls into view|scrolled into view">scroll into view</dfn>
  an <var><a>element</a></var>


### PR DESCRIPTION
The check for whether an element is connected does not take into account
that the document may have changed.  This is a special case for WebDriver,
where element references are preserved across documents.

To work around this issue we compare the element's node document
(element.ownerDocument) to the current browsing context's active document
(element.ownerDocument.defaultView.document).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1072)
<!-- Reviewable:end -->
