### PR TITLE
not in the same tree: use node document over ownerDocument attribute

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -147,15 +147,16 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- HTMLCollection --><li><dfn><a href="https://dom.spec.whatwg.org/#htmlcollection"><code>HTMLCollection</code></a></dfn>
    <!-- Inclusive descendant --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant>Inclusive descendant</a></dfn>
    <!-- isTrusted --> <li><dfn data-lt='is trusted'><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">isTrusted</a></dfn>
+   <!-- Node document --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-node-document>Node document</a></dfn>
    <!-- Node length --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-node-length">Node Length</a></dfn>
    <!-- Node --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-node>Node</a></dfn>
    <!-- NodeList --> <li><dfn><a href=https://dom.spec.whatwg.org/#nodelist><code>NodeList</code></a></dfn>
-   <!-- ownerDocument --> <li><dfn><a href=https://dom.spec.whatwg.org/#dom-node-ownerdocument>ownerDocument</a></dfn>
    <!-- querySelectorAll --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall"><code>querySelectorAll</code></a></dfn>
    <!-- querySelector --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselector"><code>querySelector</code></a></dfn>
    <!-- tagName --> <li><dfn><a href=https://dom.spec.whatwg.org/#dom-element-tagname>tagName</a></dfn>
    <!-- Text content --> <li><dfn><a href=https://dom.spec.whatwg.org/#dom-node-textcontent>Text content</a></dfn>
    <!-- Text node --> <li><dfn><a href=https://dom.spec.whatwg.org/#text><code>Text</code> node</a></dfn>
+
   </ul>
 
  <dd><p>The following attributes are defined in
@@ -5058,15 +5059,14 @@ with a "<code>moz:</code>" prefix:
  run the following substeps:
 
 <ol>
- <li><p>If the <a>node</a>’s <a>ownerDocument</a> attribute
-  is not <var>other</var>, return true.
-
- <li><p>If the result of calling the <a>node</a>’s
-  <a>compareDocumentPosition</a> with <var>other</var> as argument
-  is <a>DOCUMENT_POSITION_DISCONNECTED</a> (1),
+ <li><p>If the <a>node</a>’s <a>node document</a>
+  is not <var>other</var>’s <a>node document</a>,
   return true.
 
- <li><p>Return false.
+ <li><p>Return true if the result of calling the <a>node</a>’s
+  <a>compareDocumentPosition</a> with <var>other</var> as argument
+  is <a>DOCUMENT_POSITION_DISCONNECTED</a> (1),
+  otherwise return false.
 </ol>
 
 <p>An <a><var>element</var></a>’s <dfn>container</dfn> is:


### PR DESCRIPTION
To avoid shadowing attributes set in the DOM, we should rely on the
algorithmic definitions of ownerDocument, which is node document, from
the DOM specificaiton.

This patch also removes the third step as the otherwise-clause needs to
be part of the same step as the if-condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1074)
<!-- Reviewable:end -->
