### PR TITLE
take element screenshot: deserialise input before other steps

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -9237,10 +9237,13 @@ argument <var>value</var>:
 <p>The <a>remote end steps</a> are:
 
 <ol>
+ <li><p>Let <var>scroll</var> be the result
+  of <a>getting the property</a> <code>scroll</code>
+  if it is not <a>undefined</a>.
+  Otherwise let it be true.
+
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
-
- <li><p>Let <var>scroll</var> be true if it is <a><code>undefined</code></a>.
 
  <li><p>Let <var>element</var> be the result of
   <a>trying</a> to <a>get a known element</a>


### PR DESCRIPTION
As we agreed last week, deserialisation steps must come before the
remaining endpoint node steps.

This patch also fixes a bug where "scroll" came out of nowhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1076)
<!-- Reviewable:end -->
