### PR TITLE
set window rect: restrict to signed 32-bit integer input

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4063,11 +4063,11 @@ with a "<code>moz:</code>" prefix:
   else let it be <a>null</a>.
 
  <li><p>If <var>width</var> or <var>height</var> is neither <a>null</a>
-  nor a <a>Number</a> from 0 to 2<sup>64</sup> − 1,
+  nor a <a>Number</a> from 0 to 2<sup>31</sup> − 1,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>If <var>x</var> or <var>y</var> is neither <a>null</a>
-  nor a <a>Number</a> from −(2<sup>63</sup>) to 2<sup>63</sup> − 1,
+  nor a <a>Number</a> from −(2<sup>31</sup>) to 2<sup>31</sup> − 1,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>If the <a>remote end</a> does not support


### PR DESCRIPTION
The screenX/screenY/outeWidth/outerHeight attributes on the Window
interface should according to CSSOM-VIEW be longs.  WebIDL defines longs
as platform-independent signed 32-bit integers, which means the bitness
of the platform does not come into effect.

We don't want the input to WindowProxy.moveTo or resizeTo to be larger
than the supported numbers it can take.  This patch reduces the allowed
sizes to i32s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1084)
<!-- Reviewable:end -->
