### PR TITLE
user prompts: drop mention of window.print

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -393,7 +393,6 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- type attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-type><code>type</code> attribute</a></dfn>
    <!-- window confirm --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-confirm><code>confirm</code></a></dfn>
    <!-- window.alert --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-alert><code>alert</code></a></dfn>
-   <!-- window.print --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-print><code>print</code></a></dfn>
    <!-- window.prompt --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-prompt><code>prompt</code></a></dfn>
   </ul>
 
@@ -8798,8 +8797,7 @@ is also removed.
 </table>
 
 <p>The <dfn>current user prompt</dfn> is said to be the active <a>user prompt</a>,
- which can be one of the entries on the <a>table of simple dialogs</a>, or
- the <a>window.<code>print</code></a> dialog.
+ which can be one of the entries on the <a>table of simple dialogs</a>.
 
 <p>To <dfn data-lt="dismissed|dismisses">dismiss</dfn>
  the <a>current user prompt</a>,


### PR DESCRIPTION
window.print creates an OS level dialogue that no drivers should be
allowed to interact with.

Fixes: https://github.com/w3c/webdriver/issues/1090

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1091)
<!-- Reviewable:end -->
