### PR TITLE
Fix minor typo

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6954,7 +6954,7 @@ must run the following steps:
  the first containing a <a>keyDown</a> action,
  and the second a <a>keyUp</a> action,
  whereas a pinch-zoom input is represented
- by an action sequence consisting of a three <a>ticks</a>
+ by an action sequence consisting of three <a>ticks</a>
  and two pointer input devices of type touch,
  each performing a sequence of actions <a>pointerDown</a>,
  followed by <a>pointerMove</a>, and then <a>pointerUp</a>.


### PR DESCRIPTION
Remove unnecessary 'a' in  'consisting of a three ticks'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1094)
<!-- Reviewable:end -->
