### PR TITLE
delete session: remove inaccurate non-normative paragraph

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2862,7 +2862,7 @@ with a "<code>moz:</code>" prefix:
 </section> <!-- /New Session -->
 
 <section>
-<h3>Delete Session</h3>
+<h3><dfn>Delete Session</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -2874,11 +2874,6 @@ with a "<code>moz:</code>" prefix:
   <td>/session/{<var>session id</var>}</td>
  </tr>
 </table>
-
-<p>The <dfn>Delete Session</dfn> <a>command</a> <a>closes</a>
- any <a>top-level browsing contexts</a> associated with the <a>current session</a>,
- terminates the <a>connection</a>,
- and finally <a data-lt="close the session">closes</a> the <a>current session</a>.
 
 <p>The <a>remote end steps</a> are:
 


### PR DESCRIPTION
It does not make any sense to say that the connection is being
terminated as the wire protocol is implemented over HTTP.

It also mentions that the top-level browsing contexts associated
with the current session should be closed, which is not the case with
all drivers.

The whole paragraph, overall, is informative and could easily be
mistaken for a normative paragraph.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1107)
<!-- Reviewable:end -->
