### PR TITLE
get timeouts: remove non-normative introduction

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2943,7 +2943,7 @@ with a "<code>moz:</code>" prefix:
 </section> <!-- /Status -->
 
 <section>
-<h3>Get Timeouts</h3>
+<h3><dfn>Get Timeouts</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -2955,9 +2955,6 @@ with a "<code>moz:</code>" prefix:
   <td>/session/{<var>session id</var>}/timeouts</td>
  </tr>
 </table>
-
-<p>The <dfn>Get Timeouts</dfn> <a>command</a>
- gets timeout durations associated with the <a>current session</a>.
 
 <p>The <a>remote end steps</a> are:
 


### PR DESCRIPTION
This paragraph does not really say anything not already obvious and
could be mistaken for a normative requirement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1110)
<!-- Reviewable:end -->
