### PR TITLE
set timeouts: drop informational paragraph and small fixups

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2981,7 +2981,7 @@ with a "<code>moz:</code>" prefix:
 </section> <!-- /Get Timeouts -->
 
 <section>
-<h3>Set Timeouts</h3>
+<h3><dfn data-lt="timeouts|set timeout">Set Timeouts</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -2994,13 +2994,9 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p>The <dfn data-lt="timeouts|set timeout">Set Timeouts</dfn> <a>command</a>
- sets timeout durations associated with the <a>current session</a>.
- The timeouts that can be controlled are
- listed in the <a>table of session timeouts</a> below.
-
 <p>The following <dfn>table of session timeouts</dfn>
- enumerates the different timeout types that may be set.
+ enumerates the different timeout types that may be set
+ using the <a>Set Timeouts</a> command.
  The keywords given in the first column
  maps to the timeout type given in the second.
 
@@ -3008,7 +3004,7 @@ with a "<code>moz:</code>" prefix:
  <tr>
   <th>Keyword
   <th>Type
-  <th>Brief description
+  <th>Description
  </tr>
 
  <tr>
@@ -3066,7 +3062,8 @@ with a "<code>moz:</code>" prefix:
  <li><p>Return <a>success</a> with data <var>parameters</var>.
 </ol>
 
-<p>The <a>remote end steps</a> are:
+<p>The <a>remote end steps</a>
+ of the <a>Set Timeouts</a> <a>command</a> are:
 
 <ol>
  <li>Let <var>parameters</var> be the result of <a>trying</a>


### PR DESCRIPTION
This drops the informational paragraph describing the Set Timeouts
command because it can easily be mistaken for a normative requirement.

It also makes some other, minor editorial fixups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1111)
<!-- Reviewable:end -->
