### PR TITLE
get current url: drop informational paragraph

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3307,11 +3307,10 @@ with a "<code>moz:</code>" prefix:
 
  <li><p>Return <a>success</a> with data <a>null</a>.
 </ol>
-
 </section> <!-- /Navigate To-->
 
 <section>
-<h3>Get Current URL</h3>
+<h3><dfn>Get Current URL</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -3323,9 +3322,6 @@ with a "<code>moz:</code>" prefix:
   <td>/session/{<var>session id</var>}/url</td>
  </tr>
 </table>
-
-<p>The <dfn>Get Current URL</dfn> <a>command</a>
- returns the <a>URL</a> of the <a>current top-level browsing context</a>.
 
 <p>The <a>remote end steps</a> are:
 


### PR DESCRIPTION
The first paragraph describing the Get Current URL command is
self-explanatory and can be surmised from the command's name.  To not
cause confusion about whether it is normative or informational,
it is removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1113)
<!-- Reviewable:end -->
