### PR TITLE
back: make description non-normative

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3344,7 +3344,7 @@ with a "<code>moz:</code>" prefix:
 </section>
 
 <section>
-<h3>Back</h3>
+<h3><dfn>Back</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -3357,13 +3357,11 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p>The <dfn>Back</dfn> <a>command</a>
- causes the browser to traverse one step backward
- in the <a>joint session history</a>
+<p class=note>This command causes the browser to traverse
+ one step backward in the <a>joint session history</a>
  of the <a>current top-level browsing context</a>.
- This is equivalent to pressing
- the back button in the browser chrome
- or calling <code>window.history.back</code>.
+ This is equivalent to pressing the back button in the browser chrome
+ or invoking <code>window.history.back</code>.
 
 <p>The <a>remote end steps</a> are:
 


### PR DESCRIPTION
The patch makes the first paragraph describing the semantics of
the command non-normative, because it could easily be mistaken for
a normative requirement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1114)
<!-- Reviewable:end -->
