### PR TITLE
'Get Window Handles' returns window handles ordered by timestamp of creation

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3698,7 +3698,8 @@ with a "<code>moz:</code>" prefix:
 <p>The <dfn>Get Window Handles</dfn> <a>command</a>
  returns a list of <a>window handles</a>
  for every open <a>top-level browsing context</a>.
- The order in which the window handles are returned is arbitrary.
+ The window handles must be returned in ascending order, sorted by the 
+ timestamp of the creation of their associated <a>top-level browsing context</a>.
 
 <p>The <a>remote end steps</a> are:
 


### PR DESCRIPTION
I suggest, that the Get Window handles command returns the window handles in ascending order, sorted by the timestamp of the creation of their associated top-level browsing context.
By doing this, testers can rely on the fact, that the first window handle in the list represents the window, with which the test was started and the last window handle in the list represents the most recently opened window.

There also is a StackOverflow question [[0]] with ~200k views from which the accepted answer suggests to just switch to the last window handle when one wants to switch to the most recently opened browsing context. While researching I also found other humans (examples: [[1]][[2]]) wrongly asserting that behaviour of the command.

I think, this improvement would be really helpful .

What do you think?

[0]: https://stackoverflow.com/a/9597714/4099380
[1]: https://sqa.stackexchange.com/a/4993
[2]: https://stackoverflow.com/a/19116017/4099380
