### PR TITLE
clarify wording for Get Element Text algorithm

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4384,7 +4384,7 @@ argument <var>reference</var>, run the following steps:
 <ol>
  <li><p>Let <var>options</var> be
   the following <a><code>ScrollIntoViewOptions</code></a>:
-  
+
   <dl>
    <dt>"<code>behavior</code>"
    <dd>"<code>instant</code>"
@@ -5355,7 +5355,7 @@ argument <var>reference</var>, run the following steps:
   with argument <var>element id</var>.
 
  <li><p>Let <var>rendered text</var> be the result of performing
-  implementation-specific steps that are exactly analogous to the
+  implementation-specific steps whose result is exactly the same as the
   result of a <a>Call</a>(<a><code>bot.dom.getVisibleText</code></a>,
    <a>null</a>, <var>element</var>).
 


### PR DESCRIPTION
The way that I read this section, we are saying that the _result_ of this command should match the _result_ of `bot.dom.getVisibleText`, not that the _steps_ of the former should be analogous to the _result_ of the latter. But perhaps I am wrong!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1125)
<!-- Reviewable:end -->
