### PR TITLE
add definition of 'script' variable

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4384,7 +4384,7 @@ argument <var>reference</var>, run the following steps:
 <ol>
  <li><p>Let <var>options</var> be
   the following <a><code>ScrollIntoViewOptions</code></a>:
-  
+
   <dl>
    <dt>"<code>behavior</code>"
    <dd>"<code>instant</code>"
@@ -6315,6 +6315,10 @@ must run the following steps:
  request</dfn> with argument <var>parameters</var> the implementation must:
 
 <ol>
+ <li><p>Let <var>script</var> be the result of
+  <a>getting a property</a> named <code>script</code>
+  from the <var>parameters</var>.
+
  <li><p>If <var>script</var> is not a <a>String</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 


### PR DESCRIPTION
In the definition for [extracting the script arguments from a request](https://w3c.github.io/webdriver/webdriver-spec.html#dfn-extract-the-script-arguments-from-a-request) for Execute Script, we refer to a `script` variable, but it has not been defined. Presumably it is meant to match a `script`  property in the parameters?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1127)
<!-- Reviewable:end -->
