### PR TITLE
clarify where the 'scroll' property comes from in Take Element Screenshot

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -9267,8 +9267,8 @@ argument <var>value</var>:
 
 <ol>
  <li><p>Let <var>scroll</var> be the result
-  of <a>getting the property</a> <code>scroll</code>
-  if it is not <a>undefined</a>.
+  of <a>getting the property</a> <code>scroll</code> from
+  <var>parameters</var> if it is not <a>undefined</a>.
   Otherwise let it be true.
 
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,


### PR DESCRIPTION
Usually we talk about where we are getting properties from. Presumably it is from `parameters` here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1130)
<!-- Reviewable:end -->
