### PR TITLE
Change dispatch pointerUp's x, y handling

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -8419,10 +8419,10 @@ is also removed.
   does not contain <var>button</var>,
   return <a>success</a> with data <a>null</a>.
 
- <li><p>Let <var>x</var> be equal to <a>action object</a>'s
+ <li><p>Let <var>x</var> be equal to <a>input state</a>'s
   <code>x</code> property.
 
- <li><p>Let <var>y</var> be equal to <a>action object</a>'s
+ <li><p>Let <var>y</var> be equal to <a>input state</a>'s
   <code>y</code> property.
 
  <li><p>Remove <var>button</var> from the set corresponding


### PR DESCRIPTION
x and y should come from the input state and not the action object since passing in x and y values in the payload of a pointerUp doesn't really make sense :)

cc/ @jgraham 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1139)
<!-- Reviewable:end -->
