### PR TITLE
Remove the ability to return a window or frame from execute script

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3537,32 +3537,6 @@ with a "<code>moz:</code>" prefix:
  identifies it. This must be a <a>String</a> and must not be
  "<code>current</code>".
 
-<p>The <dfn>web window identifier</dfn>
- is the string constant "<code>window-fcc6-11e5-b4f8-330a88ab9d7f</code>".
-
-<p>The <dfn>web frame identifier</dfn>
- is the string constant "<code>frame-075b-4da1-b6ba-e579c2d3230a</code>".
-
-<p>The <dfn>JSON serialization of the <code>WindowProxy</code> object</dfn>
- is the JSON <a>Object</a> obtained by applying the following algorithm
- to the given <a><code>WindowProxy</code></a> object <var>window</var>:
-
-<ol>
- <li><p>Let <var>identifier</var> be the <a>web window identifier</a>
-  if the associated <a>browsing context</a> of <var>window</var>
-  is a <a>top-level browsing context</a>.
-
-  <p>Otherwise let it be the <a>web frame identifier</a>.
-
- <li><p>Return a JSON <a>Object</a> initialised with the following properties:
-
-  <dl>
-   <dt><var>identifier</var>
-   <dd><p>Associated <a>window handle</a>
-    of the <var>window</var>’s <a>browsing context</a>.
-  </dl>
-</ol>
-
 <p class=note>In accordance with
  the <a href=https://html.spec.whatwg.org/multipage/interaction.html#focus>focus</a>
  section of the [[!HTML]] specification,
@@ -6224,16 +6198,6 @@ must run the following steps:
   <p>Otherwise, return <a>success</a>
    with the <a data-lt="JSON serialization of an element">serialization to JSON</a>
    of the <a>web element</a> <var>value</var>.
-
- <dt>a <a><code>WindowProxy</code></a> object
- <dd><p>If the associated <a>browsing context</a>
-  of the <a><code>WindowProxy</code></a> object
-  in <var>value</var> has been <a>discarded</a>,
-  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
-
-  <p>Otherwise return <a>success</a>
-   with the <a>JSON serialization of the <code>WindowProxy</code> object</a>
-   of <var>value</var>.
 
  <dt>instance of <a>NodeList</a>
  <dt>instance of <a>HTMLCollection</a>


### PR DESCRIPTION
This has not been implemented in any webdriver implementation
and so is being lifted to Level 2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1144)
<!-- Reviewable:end -->
