### PR TITLE
cookies: remove non-normative introductions

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6870,7 +6870,7 @@ must run the following steps:
 </section> <!-- /Add Cookie -->
 
 <section>
-<h3>Delete Cookie</h3>
+<h3><dfn>Delete Cookie</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -6882,13 +6882,6 @@ must run the following steps:
   <td>/session/{<var>session id</var>}/cookie/{<var>name</var>}</td>
   </tr>
 </table>
-
-<p>The <dfn>Delete Cookie</dfn> <a>command</a>
- allows you to delete either a single cookie by parameter
- <a>url variable</a> <var>name</var>
- or all the cookies associated with
- the <a>active document</a>’s <a>address</a>
- if <var>name</var> is <a>undefined</a>.
 
 <p>The <a>remote end steps</a> are:
 
@@ -6907,7 +6900,7 @@ must run the following steps:
 </section> <!-- /Delete Cookie -->
 
 <section>
-<h3>Delete All Cookies</h3>
+<h3><dfn>Delete All Cookies</dfn></h3>
 
 <table class=simple>
  <tr>
@@ -6919,10 +6912,6 @@ must run the following steps:
   <td>/session/{<var>session id</var>}/cookie
  </tr>
 </table>
-
-<p>The <dfn>Delete All Cookies</dfn> <a>command</a>
- allows deletion of all cookies associated with
- the <a>active document</a>’s <a>address</a>.
 
 <p>The <a>remote end steps</a> are:
 


### PR DESCRIPTION
Drops the non-normative introductions that can be confusing to
implementors from the Delete Cookie and Delete All Cookies commands.

Fixes: https://github.com/w3c/webdriver/issues/1147

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1149)
<!-- Reviewable:end -->
