### PR TITLE
element clear: drop intro

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5674,7 +5674,7 @@ argument <var>reference</var>, run the following steps:
 </section> <!-- /Element Click -->
 
 <section>
-<h3>Element Clear</h3>
+<h3><dfn>Element Clear</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5686,11 +5686,6 @@ argument <var>reference</var>, run the following steps:
   <td>/session/{<var>session id</var>}/element/{<var>element id</var>}/clear</td>
  </tr>
 </table>
-
-<p>The <dfn>Element Clear</dfn> <a>command</a>
- <a>scrolls into view</a> an <a>editable</a>
-  or <a>resettable</a> <a>element</a> and then attempts to clear
-  its <a>selected files</a> or <a>text content</a>.
 
 <p>The <a>remote end steps</a> are:
 
@@ -5754,8 +5749,6 @@ argument <var>reference</var>, run the following steps:
 
  <li><p>Run the <a>unfocusing steps</a> for the <var>element</var>.
 </ol> <!-- /clearing an editable element -->
-
-
 </section> <!-- /Element Clear -->
 
 <section>


### PR DESCRIPTION
Drop the non-normative introductions that can be confusing to
implementors from the Element Clear command.

Fixes: https://github.com/w3c/webdriver/issues/1147
Fixes: https://github.com/w3c/webdriver/issues/1129

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1152)
<!-- Reviewable:end -->
