### PR TITLE
element clear: clear instead of resetting elements

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -306,6 +306,8 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- Color state --> <li><dfn><a href="https://html.spec.whatwg.org/#color-state-(type=color)"><code>color</code> state</a></dfn>
    <!-- Cookie-averse Document object --> <li><dfn><a href=https://html.spec.whatwg.org/#cookie-averse-document-object>Cookie-averse <code>Document</code> object</a></dfn>
    <!-- Current entry --> <li><dfn><a href=https://html.spec.whatwg.org/#current-entry>Current entry</a></dfn>
+   <!-- Dirty checkedness flag --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-input-checked-dirty-flag>Dirty checkedness flag</a></dfn>
+   <!-- Dirty value flag --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-dirty>Dirty value flag</a></dfn>
    <!-- Disabled --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-disabled>Disabled</a></dfn>
    <!-- Document address --> <li><dfn data-lt=address><a href=https://dom.spec.whatwg.org/#concept-document-url>Document address</a></dfn>
    <!-- Document readiness --> <li><dfn><a href=https://html.spec.whatwg.org/#current-document-readiness>Document readiness</a></dfn>
@@ -339,10 +341,11 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- Prepare to run a script --> <li><dfn><a href="https://html.spec.whatwg.org/#prepare-to-run-script">Prepare to run a script</a></dfn>
    <!-- Prompt to unload a document --> <li><dfn data-lt="prompting to unload"><a href=https://html.spec.whatwg.org/#prompt-to-unload-a-document>Prompt to unload a document</a></dfn>
    <!-- Radio button --> <li><dfn><a href="https://html.spec.whatwg.org/#radio-button-state-%28type=radio%29">Radio Button</a></dfn> state
+   <!-- Raw value --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-textarea-raw-value>Raw value</a></dfn>
    <!-- Refresh state pragma directive --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-meta-http-equiv-refresh>Refresh state pragma directive</a></dfn>
-   <!-- Reset algorithm --><li><dfn><a href=https://html.spec.whatwg.org/#concept-form-reset-control>Reset algorithm</a></dfn>
+   <!-- Reset algorithm --> <li><dfn data-lt="reset algorithms"><a href=https://html.spec.whatwg.org/#concept-form-reset-control>Reset algorithm</a></dfn>
    <!-- Reset Button --> <li><dfn><a href="https://html.spec.whatwg.org/#reset-button-state-%28type=reset%29">Reset Button</a></dfn> state
-   <!-- Resettable element --> <li><dfn><a href=https://html.spec.whatwg.org/#category-reset>Resettable</a></dfn> element
+   <!-- Resettable element --> <li><dfn data-lt="resettable elements"><a href=https://html.spec.whatwg.org/#category-reset>Resettable</a></dfn> element
    <!-- Run the animation frame callbacks --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks">Run the animation frame callbacks</a></dfn>
    <!-- Script execution environment --> <li><dfn><a href=https://html.spec.whatwg.org/#environment>Script execution environment</a></dfn>
    <!-- Script --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-script>Script</a></dfn>
@@ -361,6 +364,8 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- Unfocusing steps --><li><dfn><a href=https://html.spec.whatwg.org/#unfocusing-steps>unfocusing steps</a></dfn>
    <!-- User prompt --> <li><dfn data-lt="user prompts"><a href=https://html.spec.whatwg.org/#user-prompts>User prompt</a></dfn>
    <!-- Value --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-value>Value</a></dfn>
+   <!-- Value mode flag --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-output-mode>Value mode flag</a></dfn>
+   <!-- Value sanitization algorithm --> <li><dfn><a href=https://html.spec.whatwg.org/#value-sanitization-algorithm>Value sanitization algorithm</a></dfn>
    <!-- window.alert --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-alert><code>alert</code></a></dfn>
    <!-- window confirm --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-confirm><code>confirm</code></a></dfn>
    <!-- Window object --> <li><dfn><a href=https://html.spec.whatwg.org/#the-window-object><code>Window</code></a></dfn> object
@@ -372,19 +377,20 @@ in the spec, as demonstrated in a (yet to be developed)
  <dd><p>The HTML specification also defines a number of elements
   which this specification has special-cased behavior for:
   <ul>
-   <!-- a element --> <li><a href=https://html.spec.whatwg.org/#the-a-element><dfn data-lt="a elements"><code>a</code> element</dfn></a>
-   <!-- area element --> <li><a href=https://html.spec.whatwg.org/#the-area-element><dfn><code>area</code> element</dfn></a>
-   <!-- frame element --> <li><a href=https://html.spec.whatwg.org/#frame><dfn><code>frame</code></dfn> element</a>
-   <!-- iframe element --> <li><a href=https://html.spec.whatwg.org/#the-iframe-element><dfn><code>iframe</code></dfn> element</a>
+   <!-- a element --> <li><dfn data-lt="a elements"><a href=https://html.spec.whatwg.org/#the-a-element><code>a</code> element</a></dfn>
+   <!-- area element --> <li><dfn data-lt=area><a href=https://html.spec.whatwg.org/#the-area-element><code>area</code> element</a></dfn>
    <!-- canvas element --> <li><dfn><a href=https://html.spec.whatwg.org/#the-canvas-element><code>canvas</code> element</a></dfn>
-   <!-- datalist element --> <li><a href=https://html.spec.whatwg.org/#the-datalist-element><dfn><code>datalist</code> element</dfn></a>
-   <!-- HTML Element --> <li><dfn><a href="https://html.spec.whatwg.org/#the-html-element"><code>html</code> element</a></dfn>
-   <!-- input element --> <li><a href=https://html.spec.whatwg.org/#the-input-element><dfn data-lt="input elements|input"><code>input</code> element</dfn></a>
+   <!-- datalist element --> <li><dfn data-lt=datalist><a href=https://html.spec.whatwg.org/#the-datalist-element><code>datalist</code> element</a></dfn>
+   <!-- frame element --> <li><dfn data-lt=frame><a href=https://html.spec.whatwg.org/#frame><code>frame</code> element</a></dfn>
+   <!-- HTML Element --> <li><dfn><a href=https://html.spec.whatwg.org/#the-html-element><code>html</code> element</a></dfn>
+   <!-- iframe element --> <li><dfn data-lt=iframe><a href=https://html.spec.whatwg.org/#the-iframe-element><code>iframe</code> element</a></dfn>
+   <!-- input element --> <li><dfn data-lt="input elements"><a href=https://html.spec.whatwg.org/#the-input-element><code>input</code> element</a></dfn>
    <!-- map element --> <li><a href=https://html.spec.whatwg.org/#the-map-element><dfn><code>map</code> element</dfn></a>
-   <!-- optgroup element --> <li><a href=https://html.spec.whatwg.org/#the-optgroup-element><dfn><code>optgroup</code> element</dfn></a>
-   <!-- option element --> <li><a href=https://html.spec.whatwg.org/#the-option-element><dfn data-lt="option elements|option"><code>option</code> element</dfn></a>
-   <!-- select element --> <li><a href=https://html.spec.whatwg.org/#the-select-element><dfn data-lt="code elements"><code>select</code> element</dfn></a>
-   <!-- textarea element --> <li><a href=https://html.spec.whatwg.org/#the-textarea-element><dfn><code>textarea</code> element</dfn></a>
+   <!-- optgroup element --> <li><dfn data-lt=optgroup><a href=https://html.spec.whatwg.org/#the-optgroup-element><code>optgroup</code> element</a></dfn>
+   <!-- option element --> <li><dfn data-lt="option elements|option"><a href=https://html.spec.whatwg.org/#the-option-element><code>option</code> element</a></dfn>
+   <!-- output element --> <li><dfn data-lt=output><a href=https://html.spec.whatwg.org/#the-output-element><code>output</code> element</a></dfn>
+   <!-- select element --> <li><dfn data-lt="code elements"><a href=https://html.spec.whatwg.org/#the-select-element><code>select</code> element</a></dfn>
+   <!-- textarea element --> <li><dfn data-lt="textarea elements|textarea"><a href=https://html.spec.whatwg.org/#the-textarea-element><code>textarea</code> element</a></dfn>
   </ul>
 
  <dd><p>The HTML specification also defines a range of different attributes:
@@ -5516,6 +5522,33 @@ argument <var>reference</var>, run the following steps:
  they will implicitly <a data-lt="scroll into view">scroll elements into view</a>
  and check that it is an <a>interactable element</a>.
 
+<p>Some <a>resettable elements</a> define their own <dfn>clear algorithm</dfn>.
+ Unlike their associated <a>reset algorithms</a>,
+ changes made to form controls as part of these algorithms
+ <em>do</em> count as changes caused by the user
+ (and thus, e.g. do cause <a><code>input</code></a> events to fire).
+ When the <a>clear algorithm</a> is invoked
+ for an element that does not define its own <a>clear algorithm</a>,
+ its <a>reset algorithm</a> must be invoked instead.
+
+<p>The <a>clear algorithm</a> for <a><code>input</code></a> elements
+ is to set the <a>dirty value flag</a> and <a>dirty checkedness flag</a> back to false,
+ set the <a>value</a> of the element to an empty string,
+ set the <a>checkedness</a> of the element to true
+ if the element has a <a><code>checked</code></a> content attribute and false if it does not,
+ empty the list of <a>selected files</a>,
+ and then invoke the <a>value sanitization algorithm</a>,
+ if the <a><code>type</code></a> attribute’s current state defines one.
+
+<p>The <a>clear algorithm</a> for <a><code>textarea</code></a> elements
+ is to set the <a>dirty value flag</a> back to false,
+ and set the <a>raw value</a> of element to an empty string.
+
+<p>The <a>clear algorithm</a> for <a><code>output</code></a> elements
+ is set the element’s <a>value mode flag</a> to default
+ and then to set the element’s <code><a>textContent</a></code> IDL attribute
+ to an empty string (thus clearing the element’s child nodes).
+
 <section>
 <h3>Element Click</h3>
 
@@ -5713,7 +5746,7 @@ argument <var>reference</var>, run the following steps:
 
  <li><p>Invoke the <a>focusing steps</a> for <var>element</var>.
 
- <li><p>Invoke the <a>clear algorith</a> for <var>element</var>.
+ <li><p>Invoke the <a>clear algorithm</a> for <var>element</var>.
 
  <li><p>Invoke the <a>unfocusing steps</a> for the <var>element</var>.
 </ol>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -296,16 +296,14 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- Button --> <li><dfn><a href="https://html.spec.whatwg.org/#button-state-%28type=button%29">Button</a></dfn> state
    <!-- Buttons --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-button>Buttons</a></dfn>
    <!-- Canvas context mode --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-canvas-context-mode>Canvas context mode</a></dfn>
-   <!-- Color state --> <li><dfn><a href="https://html.spec.whatwg.org/#color-state-(type=color)"><code>color</code> state</a></dfn>
-   <!-- Multiple --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-multiple><code>multiple</code> attribute</a></dfn>
-   <!-- Mutable --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-mutable>Mutable</a></dfn>
    <!-- Checkbox --> <li><dfn><a href="https://html.spec.whatwg.org/#checkbox-state-%28type=checkbox%29">Checkbox</a></dfn> state
    <!-- Checkedness --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-checked>Checkedness</a></dfn>
    <!-- Child browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#child-browsing-context>Child browsing context</a></dfn>
-   <!-- Close a browsing context --> <li><dfn data-lt="close|closes"><a href=https://html.spec.whatwg.org/#close-a-browsing-context>Close a browsing context</a></dfn>
    <!-- Clean up after running a callback --> <li><dfn><a href="https://html.spec.whatwg.org/#clean-up-after-running-a-callback">Clean up after running a callback</a></dfn>
    <!-- Clean up after running a script --> <li><dfn><a href="https://html.spec.whatwg.org/#clean-up-after-running-script">Clean up after running a script</a></dfn>
+   <!-- Close a browsing context --> <li><dfn data-lt="close|closes"><a href=https://html.spec.whatwg.org/#close-a-browsing-context>Close a browsing context</a></dfn>
    <!-- Code entry-point --> <li><dfn><a href=https://html.spec.whatwg.org/#code-entry-point>Code entry-point</a></dfn>
+   <!-- Color state --> <li><dfn><a href="https://html.spec.whatwg.org/#color-state-(type=color)"><code>color</code> state</a></dfn>
    <!-- Cookie-averse Document object --> <li><dfn><a href=https://html.spec.whatwg.org/#cookie-averse-document-object>Cookie-averse <code>Document</code> object</a></dfn>
    <!-- Current entry --> <li><dfn><a href=https://html.spec.whatwg.org/#current-entry>Current entry</a></dfn>
    <!-- Disabled --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-disabled>Disabled</a></dfn>
@@ -329,6 +327,7 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- Joint session history --> <li><dfn><a href=https://html.spec.whatwg.org/#joint-session-history>Joint session history</a></dfn>
    <!-- Mature (navigation) --> <li><dfn data-lt="matured"><a href=https://html.spec.whatwg.org/#concept-navigate-mature>Mature</a></dfn> navigation.
    <!-- Missing value default state --> <li><dfn><a href=https://html.spec.whatwg.org/#missing-value-default>Missing value default state</a></dfn>
+   <!-- Mutable --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-mutable>Mutable</a></dfn>
    <!-- Navigate --> <li><dfn data-lt="navigating|navigation"><a href=https://html.spec.whatwg.org/#navigate>Navigate</a></dfn>
    <!-- Navigator --> <li><dfn data-lt="navigator"><a href=https://html.spec.whatwg.org/#navigator>Navigator object</a></dfn>
    <!-- Nested browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#nested-browsing-context>Nested browsing context</a></dfn>
@@ -336,9 +335,9 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- Overridden reload --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/dom.html#an-overridden-reload">An overridden reload</a></dfn>
    <!-- Parent browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#parent-browsing-context>Parent browsing context</a></dfn>
    <!-- Pause --> <li><dfn data-lt=unpaused><a href=https://html.spec.whatwg.org/#pause>HTML Pause</a></dfn>
-   <!-- Prompt to unload a document --> <li><dfn data-lt="prompting to unload"><a href=https://html.spec.whatwg.org/#prompt-to-unload-a-document>Prompt to unload a document</a></dfn>
    <!-- Prepare to run a callback --> <li><dfn><a href="https://html.spec.whatwg.org/#prepare-to-run-a-callback">Prepare to run a callback</a></dfn>
    <!-- Prepare to run a script --> <li><dfn><a href="https://html.spec.whatwg.org/#prepare-to-run-script">Prepare to run a script</a></dfn>
+   <!-- Prompt to unload a document --> <li><dfn data-lt="prompting to unload"><a href=https://html.spec.whatwg.org/#prompt-to-unload-a-document>Prompt to unload a document</a></dfn>
    <!-- Radio button --> <li><dfn><a href="https://html.spec.whatwg.org/#radio-button-state-%28type=radio%29">Radio Button</a></dfn> state
    <!-- Refresh state pragma directive --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-meta-http-equiv-refresh>Refresh state pragma directive</a></dfn>
    <!-- Reset algorithm --><li><dfn><a href=https://html.spec.whatwg.org/#concept-form-reset-control>Reset algorithm</a></dfn>
@@ -353,8 +352,8 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- Settings object --> <li><dfn><a href=https://html.spec.whatwg.org/#settings-object>Settings object</a></dfn>
    <!-- Simple dialogs --> <li><dfn data-lt="simple dialog"><a href=https://html.spec.whatwg.org/#simple-dialogs>Simple dialogs</a></dfn>
    <!-- Submit Button --> <li><dfn><a href="https://html.spec.whatwg.org/#submit-button-state-%28type=submit%29">Submit Button</a></dfn> state
-   <!-- Suffering from bad input --> <li><dfn><a href=https://html.spec.whatwg.org/#suffering-from-bad-input>Suffering from bad input</a></dfn>
    <!-- Submittable elements --> <li><dfn data-lt="submittable element"><a href=https://html.spec.whatwg.org/#category-submit>Submittable elements</a></dfn>
+   <!-- Suffering from bad input --> <li><dfn><a href=https://html.spec.whatwg.org/#suffering-from-bad-input>Suffering from bad input</a></dfn>
    <!-- Top-level browsing context --> <li><dfn data-lt="top-level browsing contexts"><a href=https://html.spec.whatwg.org/#top-level-browsing-context>Top-level browsing context</a></dfn>
    <!-- Traverse the history by a delta --> <li><dfn><a href=https://html.spec.whatwg.org/#traverse-the-history-by-a-delta>Traverse the history by a delta</a></dfn>
    <!-- Traverse the history --> <li><dfn data-lt="traversing the history"><a href=https://html.spec.whatwg.org/#traverse-the-history>Traverse the history</a></dfn>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -299,7 +299,6 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- Color state --> <li><dfn><a href="https://html.spec.whatwg.org/#color-state-(type=color)"><code>color</code> state</a></dfn>
    <!-- Multiple --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-multiple><code>multiple</code> attribute</a></dfn>
    <!-- Mutable --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-mutable>Mutable</a></dfn>
-   <!-- Change event --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/indices.html#event-change"><code>change</code> event</a></dfn>
    <!-- Checkbox --> <li><dfn><a href="https://html.spec.whatwg.org/#checkbox-state-%28type=checkbox%29">Checkbox</a></dfn> state
    <!-- Checkedness --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-checked>Checkedness</a></dfn>
    <!-- Child browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#child-browsing-context>Child browsing context</a></dfn>
@@ -326,7 +325,6 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- Image Button --> <li><dfn><a href="https://html.spec.whatwg.org/#image-button-state-%28type=image%29">Image Button</a></dfn> state
    <!-- In parallel --> <li><dfn><a href="https://html.spec.whatwg.org/#in-parallel">In parallel</a></dfn>
    <!-- Input event applies --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-input-apply><code>input</code> event applies</a></dfn>
-   <!-- Input event --> <li><dfn><a href=https://html.spec.whatwg.org/#event-input><code>input</code></a> event</dfn>
    <!-- Input type file selected --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-input-type-file-selected">Selected Files</a></dfn>
    <!-- Joint session history --> <li><dfn><a href=https://html.spec.whatwg.org/#joint-session-history>Joint session history</a></dfn>
    <!-- Mature (navigation) --> <li><dfn data-lt="matured"><a href=https://html.spec.whatwg.org/#concept-navigate-mature>Mature</a></dfn> navigation.
@@ -363,8 +361,12 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- Tree order --> <li><dfn><a href=https://html.spec.whatwg.org/#tree-order>Tree order</a></dfn>
    <!-- Unfocusing steps --><li><dfn><a href=https://html.spec.whatwg.org/#unfocusing-steps>unfocusing steps</a></dfn>
    <!-- User prompt --> <li><dfn data-lt="user prompts"><a href=https://html.spec.whatwg.org/#user-prompts>User prompt</a></dfn>
-   <!-- Value attribute --><li><dfn><a href=https://html.spec.whatwg.org/#dom-input-value><code>value</code> attribute</a></dfn>
    <!-- Value --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-value>Value</a></dfn>
+   <!-- window.alert --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-alert><code>alert</code></a></dfn>
+   <!-- window confirm --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-confirm><code>confirm</code></a></dfn>
+   <!-- Window object --> <li><dfn><a href=https://html.spec.whatwg.org/#the-window-object><code>Window</code></a></dfn> object
+   <!-- window.prompt --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-prompt><code>prompt</code></a></dfn>
+   <!-- WindowProxy exotic object --> <li><dfn><a href=https://html.spec.whatwg.org/#windowproxy><code>WindowProxy</code></a></dfn> exotic object
    <!-- WorkerNavigator --> <li><dfn data-lt="workernavigator"><a href=https://html.spec.whatwg.org/#workernavigator>WorkerNavigator object</a></dfn>
   </ul>
 
@@ -386,18 +388,15 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- textarea element --> <li><a href=https://html.spec.whatwg.org/#the-textarea-element><dfn><code>textarea</code> element</dfn></a>
   </ul>
 
- <dd><p>The following types are also defined in the HTML specification,
-  and referenced here:
+ <dd><p>The HTML specification also defines a range of different attributes:
   <ul>
-   <!-- Canvas height atribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-canvas-height><code>canvas</code>’s height attribute</a></dfn>
+   <!-- Canvas height attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-canvas-height><code>canvas</code>’s height attribute</a></dfn>
    <!-- Canvas width attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-canvas-width><code>canvas</code>’ width attribute</a></dfn>
-   <!-- Window object --> <li><dfn><a href=https://html.spec.whatwg.org/#the-window-object><code>Window</code></a></dfn> object
-   <!-- WindowProxy exotic object --> <li><dfn><a href=https://html.spec.whatwg.org/#windowproxy><code>WindowProxy</code></a></dfn> exotic object
+   <!-- Checked content attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-checked>Checked</a></dfn>
+   <!-- Multiple attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-multiple><code>multiple</code> attribute</a></dfn>
    <!-- readOnly attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#the-readonly-attribute><code>readOnly</code> attribute</a></dfn>
-   <!-- type attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-type><code>type</code> attribute</a></dfn>
-   <!-- window confirm --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-confirm><code>confirm</code></a></dfn>
-   <!-- window.alert --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-alert><code>alert</code></a></dfn>
-   <!-- window.prompt --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-prompt><code>prompt</code></a></dfn>
+   <!-- Type attribute --> <li><dfn data-lt=type><a href=https://html.spec.whatwg.org/#attr-input-type><code>type</code> attribute</a></dfn>
+   <!-- Value attribute --><li><dfn><a href=https://html.spec.whatwg.org/#dom-input-value><code>value</code> attribute</a></dfn>
   </ul>
 
  <dd><p>The HTML Editing APIs specification defines the following terms: [[!EDITING]]
@@ -408,7 +407,9 @@ in the spec, as demonstrated in a (yet to be developed)
  <dd><p>The following events are also defined in the HTML specification:
   <ul>
    <!-- beforeunload --> <li><dfn><a href=https://html.spec.whatwg.org/#event-beforeunload><code>beforeunload</code></a></dfn>
+   <!-- change --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/indices.html#event-change"><code>change</code></a></dfn>
    <!-- DOMContentLoaded --> <li><dfn><a href=https://html.spec.whatwg.org/#event-domcontentloaded><code>DOMContentLoaded</code></a></dfn>
+   <!-- input --> <li><dfn><a href=https://html.spec.whatwg.org/#event-input><code>input</code></a></dfn>
    <!-- load --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/indices.html#event-load"><code>load</code></a></dfn>
    <!-- PageHide --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/indices.html#event-pagehide"><code>pageHide</code></a></dfn>
    <!-- PageShow --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/indices.html#event-pageshow"><code>pageShow</code></a></dfn>
@@ -5578,7 +5579,7 @@ argument <var>reference</var>, run the following steps:
 
        <li><p>Run the <a>focusing steps</a> on <var>parent node</var>.
 
-       <li><p><a>Fire</a> an <a><code>input</code> event</a> at <var>parent node</var>.
+       <li><p><a>Fire</a> an <a><code>input</code></a> event at <var>parent node</var>.
 
        <li><p>Let <var>previous selectedness</var> be equal to <var>element</var>
          <a>selectedness</a>.
@@ -5593,7 +5594,7 @@ argument <var>reference</var>, run the following steps:
 
        <li><p>If <var>previous selectedness</var> is false:
          <ol>
-          <li><p><a>Fire</a> a <a><code>change</code> event</a> at <var>parent node</var>.
+          <li><p><a>Fire</a> a <a><code>change</code></a> event at <var>parent node</var>.
          </ol>
 
        <li><p><a>Fire</a> a <a>mouseUp event</a> at <var>parent node</var>.
@@ -6033,7 +6034,7 @@ must run the following steps:
       If <var>multiple</var> is <code>true</code>
       <var>files</var> are be appended to <var>element</var>’s <a>selected files</a>.
 
-     <li><p><a>Fire</a> an <a><code>input</code> event</a>.
+     <li><p><a>Fire</a> an <a><code>input</code></a> event.
 
      <li><p>Return <a>success</a> with data <a>null</a>.
     </ol>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5707,11 +5707,11 @@ argument <var>reference</var>, run the following steps:
  <li><p>If <var>element</var>'s <a>value</a> is an empty string
   do nothing and return.
 
- <li><p>Run the <a>focusing steps</a> for <var>element</var>.
+ <li><p>Invoke the <a>focusing steps</a> for <var>element</var>.
 
- <li><p>Run <var>element</var>’s <a>reset algorithm</a>.
+ <li><p>Invoke the <a>clear algorith</a> for <var>element</var>.
 
- <li><p>Run the <a>unfocusing steps</a> for the <var>element</var>.
+ <li><p>Invoke the <a>unfocusing steps</a> for the <var>element</var>.
 </ol>
 
 <p>The <a>remote end steps</a> for <a>Element Clear</a> are:
@@ -5730,9 +5730,9 @@ argument <var>reference</var>, run the following steps:
 
  <li><p><a>Scroll into view</a> the <var>element</var>.
 
- <li><p>Wait in an implementation-specific way up to the <a>session
-  implicit wait timeout</a> for <var>element</var> to
-  become <a>interactable</a>.
+ <li><p>Wait in an implementation-specific way
+  up to the <a>session implicit wait timeout</a>
+  for <var>element</var> to become <a>interactable</a>.
 
  <li><p>If <var>element</var> is not <a>interactable</a>,
   return <a>error</a> with <a>error code</a> <a>element not interactable</a>.
@@ -5741,9 +5741,9 @@ argument <var>reference</var>, run the following steps:
   <a>read only</a>, or has <a>pointer events disabled</a>,
   return <a>error</a> with <a>error code</a> <a>invalid element state</a>.
 
- <li>If <var>element</var> is <a>content editable</a> follow the steps
-  required to <a>clear a content editable element</a>. Otherwise,
-  follow the steps required to <a>clear a resettable element</a>.
+ <li>If <var>element</var> is <a>content editable</a>
+  follow the steps to <a>clear a content editable element</a>.
+  Otherwise, follow the steps required to <a>clear a resettable element</a>.
 
  <li><p>Return <a>success</a> with data <a>null</a>.
 </ol>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5674,7 +5674,7 @@ argument <var>reference</var>, run the following steps:
 </section> <!-- /Element Click -->
 
 <section>
-<h3>Element Clear</h3>
+<h3><dfn>Element Clear</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5686,11 +5686,6 @@ argument <var>reference</var>, run the following steps:
   <td>/session/{<var>session id</var>}/element/{<var>element id</var>}/clear</td>
  </tr>
 </table>
-
-<p>The <dfn>Element Clear</dfn> <a>command</a>
- <a>scrolls into view</a> an <a>editable</a>
-  or <a>resettable</a> <a>element</a> and then attempts to clear
-  its <a>selected files</a> or <a>text content</a>.
 
 <p>The <a>remote end steps</a> are:
 
@@ -5754,8 +5749,6 @@ argument <var>reference</var>, run the following steps:
 
  <li><p>Run the <a>unfocusing steps</a> for the <var>element</var>.
 </ol> <!-- /clearing an editable element -->
-
-
 </section> <!-- /Element Clear -->
 
 <section>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5687,7 +5687,34 @@ argument <var>reference</var>, run the following steps:
  </tr>
 </table>
 
-<p>The <a>remote end steps</a> are:
+<p>To <dfn>clear a content editable element</dfn>:
+
+<ol>
+ <li><p>If <var>element</var>’s <a><code>innerHTML</code> IDL attribute</a>
+  is an empty string do nothing and return.
+
+ <li><p>Run the <a>focusing steps</a> for <var>element</var>.
+
+ <li><p>Set <var>element</var>’s <a><code>innerHTML</code> IDL attribute</a>
+  to an empty string.
+
+ <li><p>Run the <a>unfocusing steps</a> for the <var>element</var>.
+</ol>
+
+<p>To <dfn>clear a resettable element</dfn>:
+
+<ol>
+ <li><p>If <var>element</var>'s <a>value</a> is an empty string
+  do nothing and return.
+
+ <li><p>Run the <a>focusing steps</a> for <var>element</var>.
+
+ <li><p>Run <var>element</var>’s <a>reset algorithm</a>.
+
+ <li><p>Run the <a>unfocusing steps</a> for the <var>element</var>.
+</ol>
+
+<p>The <a>remote end steps</a> for <a>Element Clear</a> are:
 
 <ol>
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
@@ -5720,35 +5747,6 @@ argument <var>reference</var>, run the following steps:
 
  <li><p>Return <a>success</a> with data <a>null</a>.
 </ol>
-
-<p>When required to <dfn>clear a content editable element</dfn>
- a <a>remote end</a> must run the following steps:
-
-<ol>
- <li><p>If <var>element</var>'s <a><code>innerHTML</code> IDL
-  attribute</a> is an empty string do nothing and return.
-
- <li><p>Run the <a>focusing steps</a> for <var>element</var>.
-
- <li><p>Set <var>element</var>'s <a><code>innerHTML</code> IDL
-  attribute</a> to an empty string.
-
- <li><p>Run the <a>unfocusing steps</a> for the <var>element</var>.
-</ol> <!-- /clearing a content editable element -->
-
-<p>When required to <dfn>clear a resettable element</dfn> a <a>remote
- end</a> must run the following steps:
-
-<ol>
- <li><p>If <var>element</var>'s <a>value</a> is an empty string do
- nothing and return.
-
- <li><p>Run the <a>focusing steps</a> for <var>element</var>.
-
- <li><p>Run <var>element</var>'s <a>reset algorithm</a>.
-
- <li><p>Run the <a>unfocusing steps</a> for the <var>element</var>.
-</ol> <!-- /clearing an editable element -->
 </section> <!-- /Element Clear -->
 
 <section>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -154,9 +154,13 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- querySelectorAll --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall"><code>querySelectorAll</code></a></dfn>
    <!-- querySelector --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselector"><code>querySelector</code></a></dfn>
    <!-- tagName --> <li><dfn><a href=https://dom.spec.whatwg.org/#dom-element-tagname>tagName</a></dfn>
-   <!-- Text content --> <li><dfn><a href=https://dom.spec.whatwg.org/#dom-node-textcontent>Text content</a></dfn>
    <!-- Text node --> <li><dfn><a href=https://dom.spec.whatwg.org/#text><code>Text</code> node</a></dfn>
+  </ul>
 
+ <dd><p>The following attributes are defined
+  in the Document Object Model specification: [[!DOM]]
+  <ul>
+   <!-- textContent attribute --> <li><dfn data-lt=textContent><a href=https://dom.spec.whatwg.org/#dom-node-textcontent><code>textContent</code> attribute</a></dfn>
   </ul>
 
  <dd><p>The following attributes are defined in


### PR DESCRIPTION
The Element Clear command currently _resets_ interactable elements to their default value, e.g. what was defined in the `value` IDL attribute in the case of `<input>`. The intention of this command is to _clear_ the value entirely. These patches fixes the problem, but unfortunately had to reorganise dependencies a bit to make it happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1156)
<!-- Reviewable:end -->
