### PR TITLE
get active element: return error if activeElement is null

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5027,14 +5027,12 @@ argument <var>reference</var>, run the following steps:
  <li><p>Let <var>active element</var> be the <a>active element</a>
   of the <a>current browsing context</a>’s <a>document element</a>.
 
- <li><p>Let <var>active web element</var>
-  be the <a data-lt="JSON serialization of an element">JSON serialization</a>
-  of <var>active element</var>.
+ <li><p>If <var>active element</var> is a non-null <a>element</a>,
+  return <a>success</a> with its <a data-lt="JSON serialization of an element">JSON serialization</a>.
 
- <li><p>Return <a>success</a> with data <var>active web element</var>.
+  <p>Otherwise, return <a>error</a> with <a>error code</a> <a>no such element</a>.
 </ol>
 </section> <!-- /Get Active Element -->
-
 </section> <!-- /Element Retrieval -->
 
 <section>


### PR DESCRIPTION
It is not currently clear what WebDriver should do when
document.activeElement returns null, which may happen if the document
element is deleted.  This makes it clear that it will return a no
such element error in such a case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1157)
<!-- Reviewable:end -->
