### PR TITLE
Refer to "CSS pixels" not "CSS reference pixels"

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -472,7 +472,7 @@ in the spec, as demonstrated in a (yet to be developed)
  <dd>The following terms are defined in
   the CSS Values and Units Module Level 3 specification: [[!CSS3-VALUES]]
   <ul>
-   <!-- CSS reference pixels --> <li><dfn><a href=https://www.w3.org/TR/css-values-3//#reference-pixel>CSS reference pixels</a></dfn>
+   <!-- CSS pixels --> <li><dfn><a href=https://www.w3.org/TR/css-values-3/#px>CSS pixels</a></dfn>
   </ul>
 
  <dd>The following properties are defined in
@@ -3921,13 +3921,13 @@ with a "<code>moz:</code>" prefix:
  <dd><p>Width of the <a>top-level browsing context</a>’s outer dimensions,
   including any browser chrome
   and externally drawn window decorations
-  in <a>CSS reference pixels</a>.
+  in <a>CSS pixels</a>.
 
  <dt>"<code>height</code>"
  <dd><p>Height of the <a>top-level browsing context</a>’s outer dimensions,
   including any browser chrome
   and externally drawn window decorations
-  in <a>CSS reference pixels</a>.
+  in <a>CSS pixels</a>.
 </dl>
 
 <p class="example">In some user agents the operating system’s
@@ -4070,13 +4070,13 @@ with a "<code>moz:</code>" prefix:
  <li><p>If <var>width</var> and <var>height</var> are not <a>null</a>:
 
   <ol>
-   <li><p>Set the width, in <a>CSS reference pixels</a>,
+   <li><p>Set the width, in <a>CSS pixels</a>,
     of the operating system window containing
     the <a>current top-level browsing context</a>,
     including any browser chrome and externally drawn window decorations
     to a value that is as close as possible to <var>width</var>.
 
-  <li><p>Set the height, in <a>CSS reference pixels</a>,
+  <li><p>Set the height, in <a>CSS pixels</a>,
    of the operating system window containing
    the <a>current top-level browsing context</a>,
    including any browser chrome and externally drawn window decorations
@@ -5403,20 +5403,20 @@ argument <var>reference</var>, run the following steps:
  <dt><dfn data-lt="elementrect-x">x</dfn>
  <dd>X axis position of the top-left corner of the <a>web element</a>
   relative to the <a>current browsing context</a>’s
-  <a>document element</a> in <a>CSS reference pixels</a>.
+  <a>document element</a> in <a>CSS pixels</a>.
 
  <dt><dfn data-lt="elementrect-y">y</dfn>
  <dd>Y axis position of the top-left corner of the <a>web element</a>
   relative to the <a>current browsing context</a>’s
-  <a>document element</a> in <a>CSS reference pixels</a>.
+  <a>document element</a> in <a>CSS pixels</a>.
 
  <dt><dfn data-lt="elementrect-height">height</dfn>
  <dd>Height of the <a>web element</a>’s
-  <a>bounding rectangle</a> in <a>CSS reference pixels</a>.
+  <a>bounding rectangle</a> in <a>CSS pixels</a>.
 
  <dt><dfn data-lt="elementrect-width">width</dfn>
  <dd>Width of the <a>web element</a>’s
-  <a>bounding rectangle</a> in <a>CSS reference pixels</a>.
+  <a>bounding rectangle</a> in <a>CSS pixels</a>.
 </dl>
 
 <p>The <a>remote end steps</a> are:
@@ -8486,12 +8486,12 @@ is also removed.
   </dl>
 
  <li><p>If <var>x</var> is less than 0 or greater than the width of
-  the viewport in <a>CSS reference pixels</a>, then
+  the viewport in <a>CSS pixels</a>, then
   return <a>error</a> with error code <a>move target out of
   bounds</a>.
 
  <li><p>If <var>y</var> is less than 0 or greater than the height of
-  the viewport in <a>CSS reference pixels</a>, then
+  the viewport in <a>CSS pixels</a>, then
   return <a>error</a> with error code <a>move target out of
   bounds</a>.
 
@@ -9108,7 +9108,7 @@ argument <var>value</var>:
 
 <ol>
  <li><p>If either the <a>initial viewport</a>’s width or height
-  is 0 <a>CSS reference pixels</a>,
+  is 0 <a>CSS pixels</a>,
   return <a>error</a> with <a>error code</a> <a>unable to capture screen</a>.
 
  <li><p>Let <var>paint width</var> be the <a>initial viewport</a>’s width –


### PR DESCRIPTION
There's two ways CSS implementations are allowed to define lengths: they can either make 1 CSS pixel equal to the CSS reference pixel or they can make 1 CSS cm equal to 1 SI cm. We shouldn't care which they do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1163)
<!-- Reviewable:end -->
