### PR TITLE
Define the correct rect for Take Screenshot

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -9218,8 +9218,34 @@ argument <var>value</var>:
 
  <li><p>When the user agent is next to <a>run the animation frame callbacks</a>:
   <ol>
-   <li><p>Let <var>root rect</var> be the <a>current top-level browsing context</a>’s
-    <a>document element</a>’s <a>rectangle</a>.
+   <li><p>Let <var>window</var> be the <a>associated window</a>
+     of the <a>current browsing context</a>’s <a>active document</a>.
+
+   <li><p>Let <var>x</var> be <var>window</var>'s
+    <a><code>scrollX</code></a> attribute.
+
+   <li><p>Let <var>y</var> be <var>window</var>'s
+    <a><code>scrollY</code></a> attribute.
+
+   <li><p>Let <var>y</var> be <var>window</var>'s
+    <a><code>scrollY</code></a> attribute.
+
+   <li><p>Let <var>width</var> be the width of the <a>top-level
+    browsing context</a>'s <a>viewport</a> excluding the width of the
+    scroll bar, if any.
+
+   <li><p>Let <var>height</var> be the height of the <a>top-level
+    browsing context</a>'s <a>viewport</a> excluding the height of the
+    scroll bar, if any.
+
+   <li><p>Let <var>root rect</var> be a <a><code>DOMRect</code></a>
+    whose
+     <code>x</code> member is <var>x</var>,
+     <code>y</code> member is <var>y</var>,
+     <code>width</code> member is the width of
+      the <a>viewport</a> excluding the width of the scroll bar, and
+     <code>height</code> member is the height of
+      the <a>viewport</a> excluding the height of the scroll bar.
 
    <li><p>Let <var>screenshot</var> be the result of <a>trying</a> to call
     <a>draw a bounding box from the framebuffer</a>,

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -9227,9 +9227,6 @@ argument <var>value</var>:
    <li><p>Let <var>y</var> be <var>window</var>'s
     <a><code>scrollY</code></a> attribute.
 
-   <li><p>Let <var>y</var> be <var>window</var>'s
-    <a><code>scrollY</code></a> attribute.
-
    <li><p>Let <var>width</var> be the width of the <a>top-level
     browsing context</a>'s <a>viewport</a> excluding the width of the
     scroll bar, if any.


### PR DESCRIPTION
@zcorpan is this the right way to do this with what we have defined in CSSOM View? (please wait for him or someone else who understands CSSOM View better to comment!)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gsnedders/webdriver/pull/1169.html" title="Last updated on Dec 21, 2017, 2:36 PM GMT (a35157e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1169/c9a1ddc...gsnedders:a35157e.html" title="Last updated on Dec 21, 2017, 2:36 PM GMT (a35157e)">Diff</a>