### PR TITLE
Use Web IDL's new-ish interface mixins concept

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -728,12 +728,11 @@ in the spec, as demonstrated in a (yet to be developed)
  the user agent must support <dfn>NavigatorAutomationInformation</dfn> interface:
 
  <pre class=idl>
- Navigator implements NavigatorAutomationInformation;
+ Navigator includes NavigatorAutomationInformation;
 </pre>
 
 <pre class=idl>
- [NoInterfaceObject, Exposed=(Window)]
- interface NavigatorAutomationInformation {
+ interface mixin NavigatorAutomationInformation {
  readonly attribute boolean webdriver; // always returns true
  };
 </pre>


### PR DESCRIPTION
WebIDL recently introduced dedicated syntax for mixins [1]. This
replaces the existing [NoInterfaceObject] and "implements" syntax with
"interface mixin" and "includes" in the appropriate places.

This fixes #1140 issue.

Test: https://github.com/w3c/web-platform-tests/pull/8770


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/webdriver/pull/1176.html" title="Last updated on Dec 21, 2017, 10:09 AM GMT (8008572)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1176/8d89e8f...romandev:8008572.html" title="Last updated on Dec 21, 2017, 10:09 AM GMT (8008572)">Diff</a>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1176)
<!-- Reviewable:end -->
