### PR TITLE
Fix link to current HTML results

### DIFF
--- a/implementation-report.md
+++ b/implementation-report.md
@@ -3,7 +3,7 @@
 Currently tests are being tracked on [http://wpt.fyi/webdriver](http://wpt.fyi/webdriver).
 
 A cached result of tests from multiple different vendors is stored
-[results/html/all.html](here).
+[here](https://w3c.github.io/webdriver/results/html/all.html).
 
 ## Status Documents from Vendors
 


### PR DESCRIPTION
Who knows which order the `[]` and `()` need to be in markdown? Also point at the living spec results, since otherwise the implementation report points at a raw HTML blob.