### PR TITLE
Update HTML attributes to use quotes

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5,7 +5,7 @@
 <meta charset=utf-8>
 <title>WebDriver</title>
 
-<script src=https://www.w3.org/Tools/respec/respec-w3c-common async class=remove></script>
+<script src="https://www.w3.org/Tools/respec/respec-w3c-common" async class=remove></script>
 <script class=remove>
 var respecConfig = {
   specStatus: "CR",
@@ -49,11 +49,11 @@ var respecConfig = {
   noIDLSorting: true,
 };
 </script>
-<script src=selectionchange.js></script>
+<script src="selectionchange.js"></script>
 <script>selectionchange.start()</script>
-<script src=issue.js></script>
+<script src="issue.js"></script>
 
-<section id=abstract>
+<section id="abstract">
 <p>WebDriver is a remote control interface
  that enables introspection and control of user agents.
  It provides a platform- and language-neutral wire protocol
@@ -69,13 +69,13 @@ var respecConfig = {
  to control a — possibly separate — browser.
 
 <p>The standard forms part of the
- <a href=https://www.w3.org/testing/Activity>Web Testing Activity</a>
+ <a href="https://www.w3.org/testing/Activity">Web Testing Activity</a>
  that authors a larger set of tools commonly used for testing.
 
 </section>
 
 <!-- ReSpec complains if removed completely -->
-<section id=sotd>
+<section id="sotd">
 <p>
 This Candidate Recommendation will have met its <b>CR exit criteria</b>
 when there are at least two interoperable implementations of each feature
@@ -119,86 +119,86 @@ in the spec, as demonstrated in a (yet to be developed)
   in the Content Security Policy Level 3 specification: [[!CSP3]]
   <ul>
    <li><dfn><a href="https://www.w3.org/TR/CSP/#directives">Directives</a></dfn>
-   <li><dfn data-lt="blocked by content security policy"><a href=https://w3c.github.io/webappsec-csp/#should-block-navigation-response>Should block navigation response</a></dfn>
+   <li><dfn data-lt="blocked by content security policy"><a href="https://w3c.github.io/webappsec-csp/#should-block-navigation-response">Should block navigation response</a></dfn>
   </ul>
 
  <dt>DOM
  <dd><p>The following terms are defined
   in the Document Object Model specification: [[!DOM]]
   <ul>
-   <!-- Attribute --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-attribute>Attribute</a></dfn>
-   <!-- comapreDocumentPosition --> <li><dfn><a href=https://dom.spec.whatwg.org/#dom-node-comparedocumentposition>compareDocumentPosition</a></dfn>
-   <!-- connected --> <li><dfn><a href=https://dom.spec.whatwg.org/#connected>connected</a></dfn>
+   <!-- Attribute --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-attribute">Attribute</a></dfn>
+   <!-- comapreDocumentPosition --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-node-comparedocumentposition">compareDocumentPosition</a></dfn>
+   <!-- connected --> <li><dfn><a href="https://dom.spec.whatwg.org/#connected">connected</a></dfn>
    <!-- context object --><li><dfn><a href="https://dom.spec.whatwg.org/#context-object">context object</a></dfn>
-   <!-- Descendant --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-tree-descendant>Descendant</a></dfn>
-   <!-- Document element --> <li><dfn><a href=https://dom.spec.whatwg.org/#document-element>Document element</a></dfn>
-   <!-- Document --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-document>Document</a></dfn>
-   <!-- DOCUMENT_POSITION_DISCONNECTED --> <li><dfn><a href=https://dom.spec.whatwg.org/#dom-node-document_position_disconnected>DOCUMENT_POSITION_DISCONNECTED</a></dfn> (1)
-   <!-- Document type --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-document-type>Document type</a></dfn>
-   <!-- Document URL --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-document-url>Document URL</a></dfn>
-   <!-- Element --> <li><dfn data-lt=elements><a href=https://dom.spec.whatwg.org/#concept-element>Element</a></dfn>
-   <!-- Equals --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-node-equals>Equals</a></dfn>
-   <!-- Event --> <li><dfn><a href=https://dom.spec.whatwg.org/#event>Event</a></dfn>
-   <!-- Fire an event --> <li><dfn data-lt="fire|fires|fired|event fires|event fired|event firing"><a href=https://dom.spec.whatwg.org/#concept-event-fire>Fire an event</a></dfn>
-   <!-- Get an attribute by name --> <li><dfn data-lt="getting an attribute by name"><a href=https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name>Get an attribute by name</a></dfn>
-   <!-- getAttribute --> <li><dfn><a href=https://dom.spec.whatwg.org/#dom-element-getattribute>getAttribute</a></dfn>
+   <!-- Descendant --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-tree-descendant">Descendant</a></dfn>
+   <!-- Document element --> <li><dfn><a href="https://dom.spec.whatwg.org/#document-element">Document element</a></dfn>
+   <!-- Document --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-document">Document</a></dfn>
+   <!-- DOCUMENT_POSITION_DISCONNECTED --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-node-document_position_disconnected">DOCUMENT_POSITION_DISCONNECTED</a></dfn> (1)
+   <!-- Document type --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-document-type">Document type</a></dfn>
+   <!-- Document URL --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-document-url">Document URL</a></dfn>
+   <!-- Element --> <li><dfn data-lt="elements"><a href="https://dom.spec.whatwg.org/#concept-element">Element</a></dfn>
+   <!-- Equals --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-node-equals">Equals</a></dfn>
+   <!-- Event --> <li><dfn><a href="https://dom.spec.whatwg.org/#event">Event</a></dfn>
+   <!-- Fire an event --> <li><dfn data-lt="fire|fires|fired|event fires|event fired|event firing"><a href="https://dom.spec.whatwg.org/#concept-event-fire">Fire an event</a></dfn>
+   <!-- Get an attribute by name --> <li><dfn data-lt="getting an attribute by name"><a href="https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name">Get an attribute by name</a></dfn>
+   <!-- getAttribute --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-element-getattribute">getAttribute</a></dfn>
    <!-- getElementsByTagName --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-element-getelementsbytagname"><code>getElementsByTagName</code></a></dfn>
-   <!-- hasAttribute --> <li><dfn data-lt="has the attribute"><a href=https://dom.spec.whatwg.org/#dom-element-hasattribute>hasAttribute</a></dfn>
-   <!-- HTMLCollection --> <li><dfn><a href=https://dom.spec.whatwg.org/#htmlcollection><code>HTMLCollection</code></a></dfn>
-   <!-- Inclusive descendant --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant>Inclusive descendant</a></dfn>
-   <!-- isTrusted --> <li><dfn data-lt='is trusted'><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">isTrusted</a></dfn>
-   <!-- Node document --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-node-document>Node document</a></dfn>
+   <!-- hasAttribute --> <li><dfn data-lt="has the attribute"><a href="https://dom.spec.whatwg.org/#dom-element-hasattribute">hasAttribute</a></dfn>
+   <!-- HTMLCollection --> <li><dfn><a href="https://dom.spec.whatwg.org/#htmlcollection"><code>HTMLCollection</code></a></dfn>
+   <!-- Inclusive descendant --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant">Inclusive descendant</a></dfn>
+   <!-- isTrusted --> <li><dfn data-lt="is trusted"><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">isTrusted</a></dfn>
+   <!-- Node document --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-node-document">Node document</a></dfn>
    <!-- Node length --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-node-length">Node Length</a></dfn>
-   <!-- Node --> <li><dfn><a href=https://dom.spec.whatwg.org/#concept-node>Node</a></dfn>
-   <!-- NodeList --> <li><dfn><a href=https://dom.spec.whatwg.org/#nodelist><code>NodeList</code></a></dfn>
+   <!-- Node --> <li><dfn><a href="https://dom.spec.whatwg.org/#concept-node">Node</a></dfn>
+   <!-- NodeList --> <li><dfn><a href="https://dom.spec.whatwg.org/#nodelist"><code>NodeList</code></a></dfn>
    <!-- querySelectorAll --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall"><code>querySelectorAll</code></a></dfn>
    <!-- querySelector --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselector"><code>querySelector</code></a></dfn>
-   <!-- tagName --> <li><dfn><a href=https://dom.spec.whatwg.org/#dom-element-tagname>tagName</a></dfn>
-   <!-- Text node --> <li><dfn><a href=https://dom.spec.whatwg.org/#text><code>Text</code> node</a></dfn>
+   <!-- tagName --> <li><dfn><a href="https://dom.spec.whatwg.org/#dom-element-tagname">tagName</a></dfn>
+   <!-- Text node --> <li><dfn><a href="https://dom.spec.whatwg.org/#text"><code>Text</code> node</a></dfn>
   </ul>
 
  <dd><p>The following attributes are defined
   in the Document Object Model specification: [[!DOM]]
   <ul>
-   <!-- textContent attribute --> <li><dfn data-lt=textContent><a href=https://dom.spec.whatwg.org/#dom-node-textcontent><code>textContent</code> attribute</a></dfn>
+   <!-- textContent attribute --> <li><dfn data-lt="textContent"><a href="https://dom.spec.whatwg.org/#dom-node-textcontent"><code>textContent</code> attribute</a></dfn>
   </ul>
 
  <dd><p>The following attributes are defined in
   the DOM Parsing and Serialisation specification: [[!DOM-PARSING]]
   <ul>
-   <!-- innerHTML IDL Attribute--> <li><dfn><a href=https://w3c.github.io/DOM-Parsing/#dom-element-innerhtml><code>innerHTML</code> IDL attribute</a></dfn>
-   <!-- outerHTML IDL Attribute--> <li><dfn><a href=https://w3c.github.io/DOM-Parsing/#dom-element-outerhtml><code>outerHTML</code> IDL attribute</a></dfn>
-   <!-- serializeToString --> <li><dfn data-lt="serializing to string"><a href=https://w3c.github.io/DOM-Parsing/#dom-xmlserializer-serializetostring><code>serializeToString</code></a></dfn>
+   <!-- innerHTML IDL Attribute--> <li><dfn><a href="https://w3c.github.io/DOM-Parsing/#dom-element-innerhtml"><code>innerHTML</code> IDL attribute</a></dfn>
+   <!-- outerHTML IDL Attribute--> <li><dfn><a href="https://w3c.github.io/DOM-Parsing/#dom-element-outerhtml"><code>outerHTML</code> IDL attribute</a></dfn>
+   <!-- serializeToString --> <li><dfn data-lt="serializing to string"><a href="https://w3c.github.io/DOM-Parsing/#dom-xmlserializer-serializetostring"><code>serializeToString</code></a></dfn>
   </ul>
 
  <dd><p>The following attributes are defined
   in the UI Events specification: [[!UI-EVENTS]]
   <ul>
-   <!-- Activation trigger --> <li><dfn><a href=https://w3c.github.io/uievents/#activation-trigger>Activation trigger</a></dfn>
+   <!-- Activation trigger --> <li><dfn><a href="https://w3c.github.io/uievents/#activation-trigger">Activation trigger</a></dfn>
    <!-- click event --> <li><dfn><a href="https://w3c.github.io/uievents/#event-type-click">click event</a></dfn>
-   <!-- Keyboard Event --> <li><dfn><a href=https://w3c.github.io/uievents/#keyboardevent>Keyboard event</a></dfn>
-   <!-- Keyboard event order --> <li><dfn><a href=https://w3c.github.io/uievents/#events-keyboard-event-order>Keyboard event order</a></dfn>
-   <!-- keyDown event --> <li><dfn data-lt="keyDown-Event"><a href=https://w3c.github.io/uievents/#event-type-keydown>keyDown event</a></dfn>
-   <!-- keyPress event --> <li><dfn data-lt="keyPress-Event"><a href=https://w3c.github.io/uievents/#event-type-keypress>keyPress event</a></dfn>
-   <!-- keyUp event --> <li><dfn data-lt="keyUp-Event"><a href=https://w3c.github.io/uievents/#event-type-keyup>keyUp event</a></dfn>
-   <!-- mouseDown event --> <li><dfn><a href=https://w3c.github.io/uievents/#event-type-mousedown>mouseDown event</a></dfn>
-   <!-- Mouse event --> <li><dfn><a href=https://w3c.github.io/uievents/#mouseevent>Mouse event</a></dfn>
-   <!-- Mouse event order --> <li><dfn><a href=https://w3c.github.io/uievents/#events-mouseevent-event-order>Mouse event order</a></dfn>
+   <!-- Keyboard Event --> <li><dfn><a href="https://w3c.github.io/uievents/#keyboardevent">Keyboard event</a></dfn>
+   <!-- Keyboard event order --> <li><dfn><a href="https://w3c.github.io/uievents/#events-keyboard-event-order">Keyboard event order</a></dfn>
+   <!-- keyDown event --> <li><dfn data-lt="keyDown-Event"><a href="https://w3c.github.io/uievents/#event-type-keydown">keyDown event</a></dfn>
+   <!-- keyPress event --> <li><dfn data-lt="keyPress-Event"><a href="https://w3c.github.io/uievents/#event-type-keypress">keyPress event</a></dfn>
+   <!-- keyUp event --> <li><dfn data-lt="keyUp-Event"><a href="https://w3c.github.io/uievents/#event-type-keyup">keyUp event</a></dfn>
+   <!-- mouseDown event --> <li><dfn><a href="https://w3c.github.io/uievents/#event-type-mousedown">mouseDown event</a></dfn>
+   <!-- Mouse event --> <li><dfn><a href="https://w3c.github.io/uievents/#mouseevent">Mouse event</a></dfn>
+   <!-- Mouse event order --> <li><dfn><a href="https://w3c.github.io/uievents/#events-mouseevent-event-order">Mouse event order</a></dfn>
    <!-- mouseMove event --> <li><dfn><a href="https://w3c.github.io/uievents/#event-type-mousemove">mouseMove event</a></dfn>
    <!-- mouseOver event --> <li><dfn><a href="https://w3c.github.io/uievents/#event-type-mouseover">mouseOver event</a></dfn>
-   <!-- mouseUp event --> <li><dfn><a href=https://w3c.github.io/uievents/#event-type-mouseup>mouseUp event</a></dfn>
+   <!-- mouseUp event --> <li><dfn><a href="https://w3c.github.io/uievents/#event-type-mouseup">mouseUp event</a></dfn>
   </ul>
 
  <dd><p>The following attributes are defined
   in the UI Events Code specification: [[!UIEVENTS-CODE]]
   <ul>
-   <li><dfn data-lt="keyboard event code"><a href=https://www.w3.org/TR/uievents-code/#code-value-tables>Keyboard event code tables</a></dfn>
+   <li><dfn data-lt="keyboard event code"><a href="https://www.w3.org/TR/uievents-code/#code-value-tables">Keyboard event code tables</a></dfn>
   </ul>
 
  <dd><p>The following attributes are defined
   in the UI Events Code specification: [[!UIEVENTS-KEY]]
   <ul>
-   <li><dfn data-lt="modifier key"><a href=https://www.w3.org/TR/uievents-key/#keys-modifier>Keyboard modifier keys</a></dfn>
+   <li><dfn data-lt="modifier key"><a href="https://www.w3.org/TR/uievents-key/#keys-modifier">Keyboard modifier keys</a></dfn>
   </ul>
 
  <dt>DOM Parsing
@@ -212,62 +212,62 @@ in the spec, as demonstrated in a (yet to be developed)
  <dd><p>The following terms are defined in the ECMAScript Language Specification: [[!ECMA-262]]
   <ul>
    <!-- Abrupt Completion --> <li><dfn><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">Abrupt Completion</a></dfn>
-   <!-- Directive prologue --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-14.1>Directive prologue</a></dfn>
-   <!-- Early error --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-16>Early error</a></dfn>
-   <!-- Function --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.24>Function</a></dfn>
-   <!-- FunctionCreate --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-functioncreate>FunctionCreate</a></dfn>
-   <!-- FunctionBody --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-13>FunctionBody</a></dfn>
-   <!-- Global environment --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-10.2.3>Global environment</a></dfn>
-   <!-- Own property --> <li><dfn data-lt="own properties"><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.30>Own property</a></dfn>
-   <!-- parseFloat --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.3>parseFloat</a></dfn>
+   <!-- Directive prologue --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-14.1">Directive prologue</a></dfn>
+   <!-- Early error --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-16">Early error</a></dfn>
+   <!-- Function --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.24">Function</a></dfn>
+   <!-- FunctionCreate --> <li><dfn><a href="https://tc39.github.io/ecma262/#sec-functioncreate">FunctionCreate</a></dfn>
+   <!-- FunctionBody --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-13">FunctionBody</a></dfn>
+   <!-- Global environment --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-10.2.3">Global environment</a></dfn>
+   <!-- Own property --> <li><dfn data-lt="own properties"><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.30">Own property</a></dfn>
+   <!-- parseFloat --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.3">parseFloat</a></dfn>
    <!-- realm --> <li><dfn><a href="https://tc39.github.io/ecma262/#sec-code-realms">realm</a></dfn>
-   <!-- Use strict directive --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-14.1>Use strict directive</a></dfn>
+   <!-- Use strict directive --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-14.1">Use strict directive</a></dfn>
   </ul>
 
  <dd>This specification also presumes that you are able to call
-  some of the <dfn data-lt="internal method"><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2>internal methods</a></dfn>
+  some of the <dfn data-lt="internal method"><a href="https://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2">internal methods</a></dfn>
   from the ECMAScript Language Specification:
   <ul>
-   <!-- Call --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-13.2.1>Call</a></dfn>
-   <!-- Class --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2>[[\Class]]</a></dfn>
-   <!-- GetOwnProperty --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-8.12.1>[[\GetOwnProperty]]</a></dfn>
-   <!-- GetProperty --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-8.12.2>[[\GetProperty]]</a></dfn>
-   <!-- Index of --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-15.5.4.7>Index of</a></dfn>
-   <!-- Put --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-8.12.5>[[\Put]]</a></dfn>
-   <!-- Substring --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-15.5.4.15>Substring</a></dfn>
+   <!-- Call --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-13.2.1">Call</a></dfn>
+   <!-- Class --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-8.6.2">[[\Class]]</a></dfn>
+   <!-- GetOwnProperty --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-8.12.1">[[\GetOwnProperty]]</a></dfn>
+   <!-- GetProperty --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-8.12.2">[[\GetProperty]]</a></dfn>
+   <!-- Index of --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.5.4.7">Index of</a></dfn>
+   <!-- Put --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-8.12.5">[[\Put]]</a></dfn>
+   <!-- Substring --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.5.4.15">Substring</a></dfn>
   </ul>
 
  <dd>The ECMAScript Language Specification also defines the following
   types, values, and operations that are used throughout this
   specification:
   <ul>
-   <!-- Array --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-11.1.4>Array</a></dfn>
-   <!-- Boolean type --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.14>Boolean</a></dfn> type
-   <!-- List --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-8.8>List</a></dfn>
-   <!-- null --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.11>Null</a></dfn>
-   <!-- Number --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.19>Number</a></dfn>
-   <!-- Object --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.2.1>Object</a></dfn>
+   <!-- Array --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-11.1.4">Array</a></dfn>
+   <!-- Boolean type --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.14">Boolean</a></dfn> type
+   <!-- List --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-8.8">List</a></dfn>
+   <!-- null --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.11">Null</a></dfn>
+   <!-- Number --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.19">Number</a></dfn>
+   <!-- Object --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-4.2.1">Object</a></dfn>
    <!-- Parse --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.12.2">[[\Parse]]</a></dfn>
-   <!-- String --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.18>String</a></dfn>
+   <!-- String --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.18">String</a></dfn>
    <!-- Stringify --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.12.3">[[\Stringify]]</a></dfn>
-   <!-- ToInteger --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/6.0/#sec-tointeger>ToInteger</a></dfn>
-   <!-- undefined --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.9>Undefined</a></dfn>
+   <!-- ToInteger --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-tointeger">ToInteger</a></dfn>
+   <!-- undefined --> <li><dfn><a href="http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.9">Undefined</a></dfn>
   </ul>
 
  <dt>Fetch
  <dd><p>The following terms are defined in the WHATWG Fetch specification: [[!FETCH]]
   <ul>
-   <!-- Body --> <li><dfn><a href=https://fetch.spec.whatwg.org/#concept-request-body>Body</a></dfn>
+   <!-- Body --> <li><dfn><a href="https://fetch.spec.whatwg.org/#concept-request-body">Body</a></dfn>
    <!-- Header --> <li><dfn><a href="https://fetch.spec.whatwg.org/#concept-header">Header</a></dfn>
    <!-- Header Name --> <li><dfn><a href="https://fetch.spec.whatwg.org/#concept-header-name">Header Name</a></dfn>
    <!-- Header Value --> <li><dfn><a href="https://fetch.spec.whatwg.org/#concept-header-value">Header Value</a></dfn>
    <!-- Local Scheme --> <li><dfn><a href="https://fetch.spec.whatwg.org/#local-scheme">Local scheme</a></dfn>
-   <!-- Method --> <li><dfn><a href=https://fetch.spec.whatwg.org/#concept-request-method>Method</a></dfn>
-   <!-- Response --> <li><dfn data-lt="http response"><a href=https://fetch.spec.whatwg.org/#concept-response>Response</a></dfn>
-   <!-- Request --> <li><dfn data-lt="http request"><a href=https://fetch.spec.whatwg.org/#concept-request>Request</a></dfn>
+   <!-- Method --> <li><dfn><a href="https://fetch.spec.whatwg.org/#concept-request-method">Method</a></dfn>
+   <!-- Response --> <li><dfn data-lt="http response"><a href="https://fetch.spec.whatwg.org/#concept-response">Response</a></dfn>
+   <!-- Request --> <li><dfn data-lt="http request"><a href="https://fetch.spec.whatwg.org/#concept-request">Request</a></dfn>
    <!-- Set Header --> <li><dfn><a href="https://fetch.spec.whatwg.org/#concept-header-list-set">Set Header</a></dfn>
-   <!-- Status --> <li><dfn><a href=https://fetch.spec.whatwg.org/#concept-response-status>HTTP Status</a></dfn>
-   <!-- Status message --> <li><dfn><a href=https://fetch.spec.whatwg.org/#concept-response-status-message>Status message</a></dfn>
+   <!-- Status --> <li><dfn><a href="https://fetch.spec.whatwg.org/#concept-response-status">HTTP Status</a></dfn>
+   <!-- Status message --> <li><dfn><a href="https://fetch.spec.whatwg.org/#concept-response-status-message">Status message</a></dfn>
   </ul>
 
  <dt>Fullscreen
@@ -275,7 +275,7 @@ in the spec, as demonstrated in a (yet to be developed)
    <ul>
      <!-- Fullscreen element --> <li><dfn><a href="https://fullscreen.spec.whatwg.org/#fullscreen-element">Fullscreen element</a></dfn>
      <!-- Fullscreen an element --> <li><dfn><a href="https://fullscreen.spec.whatwg.org/#fullscreen-an-element">Fullscreen an element</a></dfn>
-     <!-- Fullscreen is supported --> <li><dfn  data-lt='support fullscreen'><a href="https://fullscreen.spec.whatwg.org/#fullscreen-is-supported">Fullscreen is supported</a></dfn>
+     <!-- Fullscreen is supported --> <li><dfn  data-lt="support fullscreen"><a href="https://fullscreen.spec.whatwg.org/#fullscreen-is-supported">Fullscreen is supported</a></dfn>
      <!-- Fully exit fullscreen --> <li><dfn><a href="https://fullscreen.spec.whatwg.org/#fully-exit-fullscreen">fully exit fullscreen</a></dfn>
      <!-- Unfullscreen a document --> <li><dfn><a href="https://fullscreen.spec.whatwg.org/#unfullscreen-a-document">unfullscreen a document</a></dfn>
    </ul>
@@ -283,138 +283,138 @@ in the spec, as demonstrated in a (yet to be developed)
  <dt>HTML
  <dd><p>The following terms are defined in the HTML specification: [[!HTML]]
   <ul>
-   <!-- 2D context creation algorithm --> <li><dfn><a href=https://html.spec.whatwg.org/#2d-context-creation-algorithm>2D context creation algorithm</a></dfn>
-   <!-- A browsing context is discarded --> <li><dfn data-lt=discarded><a href=https://html.spec.whatwg.org/#a-browsing-context-is-discarded>A browsing context is discarded</a></dfn>
-   <!-- Active document --> <li><dfn><a href=https://html.spec.whatwg.org/#active-document>Active document</a></dfn>
-   <!-- Active element --> <li><dfn>Active element</dfn> being the <a href=https://html.spec.whatwg.org/#dom-document-activeelement><code>activeElement</code></a> attribute on <a href=https://html.spec.whatwg.org/#document><code>Document</code></a>
+   <!-- 2D context creation algorithm --> <li><dfn><a href="https://html.spec.whatwg.org/#2d-context-creation-algorithm">2D context creation algorithm</a></dfn>
+   <!-- A browsing context is discarded --> <li><dfn data-lt="discarded"><a href="https://html.spec.whatwg.org/#a-browsing-context-is-discarded">A browsing context is discarded</a></dfn>
+   <!-- Active document --> <li><dfn><a href="https://html.spec.whatwg.org/#active-document">Active document</a></dfn>
+   <!-- Active element --> <li><dfn>Active element</dfn> being the <a href="https://html.spec.whatwg.org/#dom-document-activeelement"><code>activeElement</code></a> attribute on <a href="https://html.spec.whatwg.org/#document"><code>Document</code></a>
    <!-- API length --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-fe-api-value">API value</a></dfn>
-   <!-- A serialization of the bitmap as a file --> <li><dfn data-lt="a serialization of the canvas element’s bitmap as a file"><a href=https://html.spec.whatwg.org/#a-serialisation-of-the-bitmap-as-a-file>A serialization of the bitmap as a file</a></dfn>
-   <!-- Associated window --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-document-window>Associated window</a></dfn>
-   <!-- Body element --> <li><dfn><a href=https://html.spec.whatwg.org/#the-body-element><code>body</code> element</a></dfn>
-   <!-- Boolean attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#boolean-attribute>Boolean attribute</a></dfn>
-   <!-- Browsing context --> <li><dfn data-lt="browsing contexts"><a href=https://html.spec.whatwg.org/#browsing-context>Browsing context</a></dfn>
+   <!-- A serialization of the bitmap as a file --> <li><dfn data-lt="a serialization of the canvas element’s bitmap as a file"><a href="https://html.spec.whatwg.org/#a-serialisation-of-the-bitmap-as-a-file">A serialization of the bitmap as a file</a></dfn>
+   <!-- Associated window --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-document-window">Associated window</a></dfn>
+   <!-- Body element --> <li><dfn><a href="https://html.spec.whatwg.org/#the-body-element"><code>body</code> element</a></dfn>
+   <!-- Boolean attribute --> <li><dfn><a href="https://html.spec.whatwg.org/#boolean-attribute">Boolean attribute</a></dfn>
+   <!-- Browsing context --> <li><dfn data-lt="browsing contexts"><a href="https://html.spec.whatwg.org/#browsing-context">Browsing context</a></dfn>
    <!-- Button --> <li><dfn><a href="https://html.spec.whatwg.org/#button-state-%28type=button%29">Button</a></dfn> state
-   <!-- Buttons --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-button>Buttons</a></dfn>
-   <!-- Canvas context mode --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-canvas-context-mode>Canvas context mode</a></dfn>
+   <!-- Buttons --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-button">Buttons</a></dfn>
+   <!-- Canvas context mode --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-canvas-context-mode">Canvas context mode</a></dfn>
    <!-- Checkbox --> <li><dfn><a href="https://html.spec.whatwg.org/#checkbox-state-%28type=checkbox%29">Checkbox</a></dfn> state
-   <!-- Checkedness --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-checked>Checkedness</a></dfn>
-   <!-- Child browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#child-browsing-context>Child browsing context</a></dfn>
+   <!-- Checkedness --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-fe-checked">Checkedness</a></dfn>
+   <!-- Child browsing context --> <li><dfn><a href="https://html.spec.whatwg.org/#child-browsing-context">Child browsing context</a></dfn>
    <!-- Clean up after running a callback --> <li><dfn><a href="https://html.spec.whatwg.org/#clean-up-after-running-a-callback">Clean up after running a callback</a></dfn>
    <!-- Clean up after running a script --> <li><dfn><a href="https://html.spec.whatwg.org/#clean-up-after-running-script">Clean up after running a script</a></dfn>
-   <!-- Close a browsing context --> <li><dfn data-lt="close|closes"><a href=https://html.spec.whatwg.org/#close-a-browsing-context>Close a browsing context</a></dfn>
-   <!-- Code entry-point --> <li><dfn><a href=https://html.spec.whatwg.org/#code-entry-point>Code entry-point</a></dfn>
+   <!-- Close a browsing context --> <li><dfn data-lt="close|closes"><a href="https://html.spec.whatwg.org/#close-a-browsing-context">Close a browsing context</a></dfn>
+   <!-- Code entry-point --> <li><dfn><a href="https://html.spec.whatwg.org/#code-entry-point">Code entry-point</a></dfn>
    <!-- Color state --> <li><dfn><a href="https://html.spec.whatwg.org/#color-state-(type=color)"><code>color</code> state</a></dfn>
-   <!-- Cookie-averse Document object --> <li><dfn><a href=https://html.spec.whatwg.org/#cookie-averse-document-object>Cookie-averse <code>Document</code> object</a></dfn>
-   <!-- Current entry --> <li><dfn><a href=https://html.spec.whatwg.org/#current-entry>Current entry</a></dfn>
-   <!-- Dirty checkedness flag --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-input-checked-dirty-flag>Dirty checkedness flag</a></dfn>
-   <!-- Dirty value flag --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-dirty>Dirty value flag</a></dfn>
-   <!-- Disabled --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-disabled>Disabled</a></dfn>
-   <!-- Document address --> <li><dfn data-lt=address><a href=https://dom.spec.whatwg.org/#concept-document-url>Document address</a></dfn>
-   <!-- Document readiness --> <li><dfn><a href=https://html.spec.whatwg.org/#current-document-readiness>Document readiness</a></dfn>
-   <!-- Document title --> <li><dfn data-lt=title><a href=https://html.spec.whatwg.org/#document.title>Document title</a></dfn>
-   <!-- Element contexts --> <li><dfn data-lt="element context"><a href=https://html.spec.whatwg.org/#concept-element-contexts>Element contexts</a></dfn>
-   <!-- Enumerated attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#enumerated-attribute>Enumerated attribute</a></dfn>
-   <!-- Environment settings object --> <li><dfn><a href=https://html.spec.whatwg.org/#environment-settings-object>Environment settings object</a></dfn>
-   <!-- Event loop --> <li><dfn><a href=https://html.spec.whatwg.org/#event-loop>Event loop</a></dfn>
+   <!-- Cookie-averse Document object --> <li><dfn><a href="https://html.spec.whatwg.org/#cookie-averse-document-object">Cookie-averse <code>Document</code> object</a></dfn>
+   <!-- Current entry --> <li><dfn><a href="https://html.spec.whatwg.org/#current-entry">Current entry</a></dfn>
+   <!-- Dirty checkedness flag --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-input-checked-dirty-flag">Dirty checkedness flag</a></dfn>
+   <!-- Dirty value flag --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-fe-dirty">Dirty value flag</a></dfn>
+   <!-- Disabled --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-fe-disabled">Disabled</a></dfn>
+   <!-- Document address --> <li><dfn data-lt="address"><a href="https://dom.spec.whatwg.org/#concept-document-url">Document address</a></dfn>
+   <!-- Document readiness --> <li><dfn><a href="https://html.spec.whatwg.org/#current-document-readiness">Document readiness</a></dfn>
+   <!-- Document title --> <li><dfn data-lt="title"><a href="https://html.spec.whatwg.org/#document.title">Document title</a></dfn>
+   <!-- Element contexts --> <li><dfn data-lt="element context"><a href="https://html.spec.whatwg.org/#concept-element-contexts">Element contexts</a></dfn>
+   <!-- Enumerated attribute --> <li><dfn><a href="https://html.spec.whatwg.org/#enumerated-attribute">Enumerated attribute</a></dfn>
+   <!-- Environment settings object --> <li><dfn><a href="https://html.spec.whatwg.org/#environment-settings-object">Environment settings object</a></dfn>
+   <!-- Event loop --> <li><dfn><a href="https://html.spec.whatwg.org/#event-loop">Event loop</a></dfn>
    <!-- File --> <li><dfn><a href="https://html.spec.whatwg.org/#file-upload-state-%28type=file%29">File</a></dfn> state
    <!-- File upload state --> <li><dfn><a href="https://html.spec.whatwg.org/#file-upload-state-(type=file)">File upload state</a></dfn>
    <!-- Focusing steps --> <li><dfn><a href="https://html.spec.whatwg.org/#focusing-steps">Focusing steps</a></dfn>
-   <!-- Fousable area --><li><dfn><a href=https://html.spec.whatwg.org/#focusable-area>Focusable area</a></dfn>
-   <!-- GetOwnProperty of a Window object --> <li><dfn data-lt="window.[[\getOwnProperty]]"><a href=https://html.spec.whatwg.org/#windowproxy-getownproperty><code>[[\GetOwnProperty]]</code> of a <code>Window</code> object</a></dfn>
+   <!-- Fousable area --><li><dfn><a href="https://html.spec.whatwg.org/#focusable-area">Focusable area</a></dfn>
+   <!-- GetOwnProperty of a Window object --> <li><dfn data-lt="window.[[\getOwnProperty]]"><a href="https://html.spec.whatwg.org/#windowproxy-getownproperty"><code>[[\GetOwnProperty]]</code> of a <code>Window</code> object</a></dfn>
    <!-- Hidden --> <li><dfn><a href="https://html.spec.whatwg.org/#hidden-state-%28type=hidden%29">Hidden</a></dfn> state
    <!-- Image Button --> <li><dfn><a href="https://html.spec.whatwg.org/#image-button-state-%28type=image%29">Image Button</a></dfn> state
    <!-- In parallel --> <li><dfn><a href="https://html.spec.whatwg.org/#in-parallel">In parallel</a></dfn>
-   <!-- Input event applies --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-input-apply><code>input</code> event applies</a></dfn>
+   <!-- Input event applies --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-input-apply"><code>input</code> event applies</a></dfn>
    <!-- Input type file selected --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-input-type-file-selected">Selected Files</a></dfn>
-   <!-- Joint session history --> <li><dfn><a href=https://html.spec.whatwg.org/#joint-session-history>Joint session history</a></dfn>
-   <!-- Mature (navigation) --> <li><dfn data-lt="matured"><a href=https://html.spec.whatwg.org/#concept-navigate-mature>Mature</a></dfn> navigation.
-   <!-- Missing value default state --> <li><dfn><a href=https://html.spec.whatwg.org/#missing-value-default>Missing value default state</a></dfn>
-   <!-- Mutable --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-mutable>Mutable</a></dfn>
-   <!-- Navigate --> <li><dfn data-lt="navigating|navigation"><a href=https://html.spec.whatwg.org/#navigate>Navigate</a></dfn>
-   <!-- Navigator --> <li><dfn data-lt="navigator"><a href=https://html.spec.whatwg.org/#navigator>Navigator object</a></dfn>
-   <!-- Nested browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#nested-browsing-context>Nested browsing context</a></dfn>
-   <!-- Origin-clean --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-canvas-origin-clean>Origin-clean</a></dfn>
+   <!-- Joint session history --> <li><dfn><a href="https://html.spec.whatwg.org/#joint-session-history">Joint session history</a></dfn>
+   <!-- Mature (navigation) --> <li><dfn data-lt="matured"><a href="https://html.spec.whatwg.org/#concept-navigate-mature">Mature</a></dfn> navigation.
+   <!-- Missing value default state --> <li><dfn><a href="https://html.spec.whatwg.org/#missing-value-default">Missing value default state</a></dfn>
+   <!-- Mutable --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-fe-mutable">Mutable</a></dfn>
+   <!-- Navigate --> <li><dfn data-lt="navigating|navigation"><a href="https://html.spec.whatwg.org/#navigate">Navigate</a></dfn>
+   <!-- Navigator --> <li><dfn data-lt="navigator"><a href="https://html.spec.whatwg.org/#navigator">Navigator object</a></dfn>
+   <!-- Nested browsing context --> <li><dfn><a href="https://html.spec.whatwg.org/#nested-browsing-context">Nested browsing context</a></dfn>
+   <!-- Origin-clean --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-canvas-origin-clean">Origin-clean</a></dfn>
    <!-- Overridden reload --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/dom.html#an-overridden-reload">An overridden reload</a></dfn>
-   <!-- Parent browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#parent-browsing-context>Parent browsing context</a></dfn>
-   <!-- Pause --> <li><dfn data-lt=unpaused><a href=https://html.spec.whatwg.org/#pause>HTML Pause</a></dfn>
+   <!-- Parent browsing context --> <li><dfn><a href="https://html.spec.whatwg.org/#parent-browsing-context">Parent browsing context</a></dfn>
+   <!-- Pause --> <li><dfn data-lt="unpaused"><a href="https://html.spec.whatwg.org/#pause">HTML Pause</a></dfn>
    <!-- Prepare to run a callback --> <li><dfn><a href="https://html.spec.whatwg.org/#prepare-to-run-a-callback">Prepare to run a callback</a></dfn>
    <!-- Prepare to run a script --> <li><dfn><a href="https://html.spec.whatwg.org/#prepare-to-run-script">Prepare to run a script</a></dfn>
-   <!-- Prompt to unload a document --> <li><dfn data-lt="prompting to unload"><a href=https://html.spec.whatwg.org/#prompt-to-unload-a-document>Prompt to unload a document</a></dfn>
+   <!-- Prompt to unload a document --> <li><dfn data-lt="prompting to unload"><a href="https://html.spec.whatwg.org/#prompt-to-unload-a-document">Prompt to unload a document</a></dfn>
    <!-- Radio button --> <li><dfn><a href="https://html.spec.whatwg.org/#radio-button-state-%28type=radio%29">Radio Button</a></dfn> state
-   <!-- Raw value --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-textarea-raw-value>Raw value</a></dfn>
-   <!-- Refresh state pragma directive --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-meta-http-equiv-refresh>Refresh state pragma directive</a></dfn>
-   <!-- Reset algorithm --> <li><dfn data-lt="reset algorithms"><a href=https://html.spec.whatwg.org/#concept-form-reset-control>Reset algorithm</a></dfn>
+   <!-- Raw value --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-textarea-raw-value">Raw value</a></dfn>
+   <!-- Refresh state pragma directive --> <li><dfn><a href="https://html.spec.whatwg.org/#attr-meta-http-equiv-refresh">Refresh state pragma directive</a></dfn>
+   <!-- Reset algorithm --> <li><dfn data-lt="reset algorithms"><a href="https://html.spec.whatwg.org/#concept-form-reset-control">Reset algorithm</a></dfn>
    <!-- Reset Button --> <li><dfn><a href="https://html.spec.whatwg.org/#reset-button-state-%28type=reset%29">Reset Button</a></dfn> state
-   <!-- Resettable element --> <li><dfn data-lt="resettable elements"><a href=https://html.spec.whatwg.org/#category-reset>Resettable</a></dfn> element
+   <!-- Resettable element --> <li><dfn data-lt="resettable elements"><a href="https://html.spec.whatwg.org/#category-reset">Resettable</a></dfn> element
    <!-- Run the animation frame callbacks --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks">Run the animation frame callbacks</a></dfn>
-   <!-- Script execution environment --> <li><dfn><a href=https://html.spec.whatwg.org/#environment>Script execution environment</a></dfn>
-   <!-- Script --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-script>Script</a></dfn>
-   <!-- Selectedness --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-option-selectedness>Selectedness</a></dfn>
-   <!-- Session history --> <li><dfn><a href=https://html.spec.whatwg.org/#session-history>Session history</a></dfn>
-   <!-- setSelectionRange --> <li><dfn data-lt="set selection range"><a href=https://html.spec.whatwg.org/#dom-textarea/input-setselectionrange><code>setSelectionRange</code></a></dfn>
-   <!-- Settings object --> <li><dfn><a href=https://html.spec.whatwg.org/#settings-object>Settings object</a></dfn>
-   <!-- Simple dialogs --> <li><dfn data-lt="simple dialog"><a href=https://html.spec.whatwg.org/#simple-dialogs>Simple dialogs</a></dfn>
+   <!-- Script execution environment --> <li><dfn><a href="https://html.spec.whatwg.org/#environment">Script execution environment</a></dfn>
+   <!-- Script --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-script">Script</a></dfn>
+   <!-- Selectedness --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-option-selectedness">Selectedness</a></dfn>
+   <!-- Session history --> <li><dfn><a href="https://html.spec.whatwg.org/#session-history">Session history</a></dfn>
+   <!-- setSelectionRange --> <li><dfn data-lt="set selection range"><a href="https://html.spec.whatwg.org/#dom-textarea/input-setselectionrange"><code>setSelectionRange</code></a></dfn>
+   <!-- Settings object --> <li><dfn><a href="https://html.spec.whatwg.org/#settings-object">Settings object</a></dfn>
+   <!-- Simple dialogs --> <li><dfn data-lt="simple dialog"><a href="https://html.spec.whatwg.org/#simple-dialogs">Simple dialogs</a></dfn>
    <!-- Submit Button --> <li><dfn><a href="https://html.spec.whatwg.org/#submit-button-state-%28type=submit%29">Submit Button</a></dfn> state
-   <!-- Submittable elements --> <li><dfn data-lt="submittable element"><a href=https://html.spec.whatwg.org/#category-submit>Submittable elements</a></dfn>
-   <!-- Suffering from bad input --> <li><dfn><a href=https://html.spec.whatwg.org/#suffering-from-bad-input>Suffering from bad input</a></dfn>
-   <!-- Top-level browsing context --> <li><dfn data-lt="top-level browsing contexts"><a href=https://html.spec.whatwg.org/#top-level-browsing-context>Top-level browsing context</a></dfn>
-   <!-- Traverse the history by a delta --> <li><dfn><a href=https://html.spec.whatwg.org/#traverse-the-history-by-a-delta>Traverse the history by a delta</a></dfn>
-   <!-- Traverse the history --> <li><dfn data-lt="traversing the history"><a href=https://html.spec.whatwg.org/#traverse-the-history>Traverse the history</a></dfn>
-   <!-- Tree order --> <li><dfn><a href=https://html.spec.whatwg.org/#tree-order>Tree order</a></dfn>
-   <!-- Unfocusing steps --><li><dfn><a href=https://html.spec.whatwg.org/#unfocusing-steps>unfocusing steps</a></dfn>
-   <!-- User prompt --> <li><dfn data-lt="user prompts"><a href=https://html.spec.whatwg.org/#user-prompts>User prompt</a></dfn>
-   <!-- Value --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-value>Value</a></dfn>
-   <!-- Value mode flag --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-output-mode>Value mode flag</a></dfn>
-   <!-- Value sanitization algorithm --> <li><dfn><a href=https://html.spec.whatwg.org/#value-sanitization-algorithm>Value sanitization algorithm</a></dfn>
-   <!-- window.alert --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-alert><code>alert</code></a></dfn>
-   <!-- window confirm --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-confirm><code>confirm</code></a></dfn>
-   <!-- Window object --> <li><dfn><a href=https://html.spec.whatwg.org/#the-window-object><code>Window</code></a></dfn> object
-   <!-- window.prompt --> <li><dfn>window.<a href=https://html.spec.whatwg.org/#dom-prompt><code>prompt</code></a></dfn>
-   <!-- WindowProxy exotic object --> <li><dfn><a href=https://html.spec.whatwg.org/#windowproxy><code>WindowProxy</code></a></dfn> exotic object
-   <!-- WorkerNavigator --> <li><dfn data-lt="workernavigator"><a href=https://html.spec.whatwg.org/#workernavigator>WorkerNavigator object</a></dfn>
+   <!-- Submittable elements --> <li><dfn data-lt="submittable element"><a href="https://html.spec.whatwg.org/#category-submit">Submittable elements</a></dfn>
+   <!-- Suffering from bad input --> <li><dfn><a href="https://html.spec.whatwg.org/#suffering-from-bad-input">Suffering from bad input</a></dfn>
+   <!-- Top-level browsing context --> <li><dfn data-lt="top-level browsing contexts"><a href="https://html.spec.whatwg.org/#top-level-browsing-context">Top-level browsing context</a></dfn>
+   <!-- Traverse the history by a delta --> <li><dfn><a href="https://html.spec.whatwg.org/#traverse-the-history-by-a-delta">Traverse the history by a delta</a></dfn>
+   <!-- Traverse the history --> <li><dfn data-lt="traversing the history"><a href="https://html.spec.whatwg.org/#traverse-the-history">Traverse the history</a></dfn>
+   <!-- Tree order --> <li><dfn><a href="https://html.spec.whatwg.org/#tree-order">Tree order</a></dfn>
+   <!-- Unfocusing steps --><li><dfn><a href="https://html.spec.whatwg.org/#unfocusing-steps">unfocusing steps</a></dfn>
+   <!-- User prompt --> <li><dfn data-lt="user prompts"><a href="https://html.spec.whatwg.org/#user-prompts">User prompt</a></dfn>
+   <!-- Value --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-fe-value">Value</a></dfn>
+   <!-- Value mode flag --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-output-mode">Value mode flag</a></dfn>
+   <!-- Value sanitization algorithm --> <li><dfn><a href="https://html.spec.whatwg.org/#value-sanitization-algorithm">Value sanitization algorithm</a></dfn>
+   <!-- window.alert --> <li><dfn>window.<a href="https://html.spec.whatwg.org/#dom-alert"><code>alert</code></a></dfn>
+   <!-- window confirm --> <li><dfn>window.<a href="https://html.spec.whatwg.org/#dom-confirm"><code>confirm</code></a></dfn>
+   <!-- Window object --> <li><dfn><a href="https://html.spec.whatwg.org/#the-window-object"><code>Window</code></a></dfn> object
+   <!-- window.prompt --> <li><dfn>window.<a href="https://html.spec.whatwg.org/#dom-prompt"><code>prompt</code></a></dfn>
+   <!-- WindowProxy exotic object --> <li><dfn><a href="https://html.spec.whatwg.org/#windowproxy"><code>WindowProxy</code></a></dfn> exotic object
+   <!-- WorkerNavigator --> <li><dfn data-lt="workernavigator"><a href="https://html.spec.whatwg.org/#workernavigator">WorkerNavigator object</a></dfn>
   </ul>
 
  <dd><p>The HTML specification also defines a number of elements
   which this specification has special-cased behavior for:
   <ul>
-   <!-- a element --> <li><dfn data-lt="a elements"><a href=https://html.spec.whatwg.org/#the-a-element><code>a</code> element</a></dfn>
-   <!-- area element --> <li><dfn data-lt=area><a href=https://html.spec.whatwg.org/#the-area-element><code>area</code> element</a></dfn>
-   <!-- canvas element --> <li><dfn><a href=https://html.spec.whatwg.org/#the-canvas-element><code>canvas</code> element</a></dfn>
-   <!-- datalist element --> <li><dfn data-lt=datalist><a href=https://html.spec.whatwg.org/#the-datalist-element><code>datalist</code> element</a></dfn>
-   <!-- frame element --> <li><dfn data-lt=frame><a href=https://html.spec.whatwg.org/#frame><code>frame</code> element</a></dfn>
-   <!-- HTML Element --> <li><dfn><a href=https://html.spec.whatwg.org/#the-html-element><code>html</code> element</a></dfn>
-   <!-- iframe element --> <li><dfn data-lt=iframe><a href=https://html.spec.whatwg.org/#the-iframe-element><code>iframe</code> element</a></dfn>
-   <!-- input element --> <li><dfn data-lt="input elements"><a href=https://html.spec.whatwg.org/#the-input-element><code>input</code> element</a></dfn>
-   <!-- map element --> <li><a href=https://html.spec.whatwg.org/#the-map-element><dfn><code>map</code> element</dfn></a>
-   <!-- optgroup element --> <li><dfn data-lt=optgroup><a href=https://html.spec.whatwg.org/#the-optgroup-element><code>optgroup</code> element</a></dfn>
-   <!-- option element --> <li><dfn data-lt="option elements|option"><a href=https://html.spec.whatwg.org/#the-option-element><code>option</code> element</a></dfn>
-   <!-- output element --> <li><dfn data-lt=output><a href=https://html.spec.whatwg.org/#the-output-element><code>output</code> element</a></dfn>
-   <!-- select element --> <li><dfn data-lt="code elements"><a href=https://html.spec.whatwg.org/#the-select-element><code>select</code> element</a></dfn>
-   <!-- textarea element --> <li><dfn data-lt="textarea elements|textarea"><a href=https://html.spec.whatwg.org/#the-textarea-element><code>textarea</code> element</a></dfn>
+   <!-- a element --> <li><dfn data-lt="a elements"><a href="https://html.spec.whatwg.org/#the-a-element"><code>a</code> element</a></dfn>
+   <!-- area element --> <li><dfn data-lt="area"><a href="https://html.spec.whatwg.org/#the-area-element"><code>area</code> element</a></dfn>
+   <!-- canvas element --> <li><dfn><a href="https://html.spec.whatwg.org/#the-canvas-element"><code>canvas</code> element</a></dfn>
+   <!-- datalist element --> <li><dfn data-lt="datalist"><a href="https://html.spec.whatwg.org/#the-datalist-element"><code>datalist</code> element</a></dfn>
+   <!-- frame element --> <li><dfn data-lt="frame"><a href="https://html.spec.whatwg.org/#frame"><code>frame</code> element</a></dfn>
+   <!-- HTML Element --> <li><dfn><a href="https://html.spec.whatwg.org/#the-html-element"><code>html</code> element</a></dfn>
+   <!-- iframe element --> <li><dfn data-lt="iframe"><a href="https://html.spec.whatwg.org/#the-iframe-element"><code>iframe</code> element</a></dfn>
+   <!-- input element --> <li><dfn data-lt="input elements"><a href="https://html.spec.whatwg.org/#the-input-element"><code>input</code> element</a></dfn>
+   <!-- map element --> <li><a href="https://html.spec.whatwg.org/#the-map-element"><dfn><code>map</code> element</dfn></a>
+   <!-- optgroup element --> <li><dfn data-lt="optgroup"><a href="https://html.spec.whatwg.org/#the-optgroup-element"><code>optgroup</code> element</a></dfn>
+   <!-- option element --> <li><dfn data-lt="option elements|option"><a href="https://html.spec.whatwg.org/#the-option-element"><code>option</code> element</a></dfn>
+   <!-- output element --> <li><dfn data-lt="output"><a href="https://html.spec.whatwg.org/#the-output-element"><code>output</code> element</a></dfn>
+   <!-- select element --> <li><dfn data-lt="code elements"><a href="https://html.spec.whatwg.org/#the-select-element"><code>select</code> element</a></dfn>
+   <!-- textarea element --> <li><dfn data-lt="textarea elements|textarea"><a href="https://html.spec.whatwg.org/#the-textarea-element"><code>textarea</code> element</a></dfn>
   </ul>
 
  <dd><p>The HTML specification also defines a range of different attributes:
   <ul>
-   <!-- Canvas height attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-canvas-height><code>canvas</code>’s height attribute</a></dfn>
-   <!-- Canvas width attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-canvas-width><code>canvas</code>’ width attribute</a></dfn>
-   <!-- Checked content attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-checked>Checked</a></dfn>
-   <!-- Multiple attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-multiple><code>multiple</code> attribute</a></dfn>
-   <!-- readOnly attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#the-readonly-attribute><code>readOnly</code> attribute</a></dfn>
-   <!-- Type attribute --> <li><dfn data-lt=type><a href=https://html.spec.whatwg.org/#attr-input-type><code>type</code> attribute</a></dfn>
-   <!-- Value attribute --><li><dfn><a href=https://html.spec.whatwg.org/#dom-input-value><code>value</code> attribute</a></dfn>
+   <!-- Canvas height attribute --> <li><dfn><a href="https://html.spec.whatwg.org/#attr-canvas-height"><code>canvas</code>’s height attribute</a></dfn>
+   <!-- Canvas width attribute --> <li><dfn><a href="https://html.spec.whatwg.org/#attr-canvas-width"><code>canvas</code>’ width attribute</a></dfn>
+   <!-- Checked content attribute --> <li><dfn><a href="https://html.spec.whatwg.org/#attr-input-checked">Checked</a></dfn>
+   <!-- Multiple attribute --> <li><dfn><a href="https://html.spec.whatwg.org/#attr-input-multiple"><code>multiple</code> attribute</a></dfn>
+   <!-- readOnly attribute --> <li><dfn><a href="https://html.spec.whatwg.org/#the-readonly-attribute"><code>readOnly</code> attribute</a></dfn>
+   <!-- Type attribute --> <li><dfn data-lt="type"><a href="https://html.spec.whatwg.org/#attr-input-type"><code>type</code> attribute</a></dfn>
+   <!-- Value attribute --><li><dfn><a href="https://html.spec.whatwg.org/#dom-input-value"><code>value</code> attribute</a></dfn>
   </ul>
 
  <dd><p>The HTML Editing APIs specification defines the following terms: [[!EDITING]]
   <ul>
-   <!-- Content Editable --> <li><dfn><a href=https://w3c.github.io/editing/contentEditable.html>Content editable</a></dfn></li>
+   <!-- Content Editable --> <li><dfn><a href="https://w3c.github.io/editing/contentEditable.html">Content editable</a></dfn></li>
   </ul>
 
  <dd><p>The following events are also defined in the HTML specification:
   <ul>
-   <!-- beforeunload --> <li><dfn><a href=https://html.spec.whatwg.org/#event-beforeunload><code>beforeunload</code></a></dfn>
+   <!-- beforeunload --> <li><dfn><a href="https://html.spec.whatwg.org/#event-beforeunload"><code>beforeunload</code></a></dfn>
    <!-- change --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/indices.html#event-change"><code>change</code></a></dfn>
-   <!-- DOMContentLoaded --> <li><dfn><a href=https://html.spec.whatwg.org/#event-domcontentloaded><code>DOMContentLoaded</code></a></dfn>
-   <!-- input --> <li><dfn><a href=https://html.spec.whatwg.org/#event-input><code>input</code></a></dfn>
+   <!-- DOMContentLoaded --> <li><dfn><a href="https://html.spec.whatwg.org/#event-domcontentloaded"><code>DOMContentLoaded</code></a></dfn>
+   <!-- input --> <li><dfn><a href="https://html.spec.whatwg.org/#event-input"><code>input</code></a></dfn>
    <!-- load --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/indices.html#event-load"><code>load</code></a></dfn>
    <!-- PageHide --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/indices.html#event-pagehide"><code>pageHide</code></a></dfn>
    <!-- PageShow --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/indices.html#event-pageshow"><code>pageShow</code></a></dfn>
@@ -422,7 +422,7 @@ in the spec, as demonstrated in a (yet to be developed)
 
  <dd><p>The “data” URL scheme specification defines the following terms: [[!RFC2397]]
   <ul>
-   <!-- data: url --> <li><dfn><a href=https://tools.ietf.org/html/rfc2397#section-2><code>data:</code> URL</a></dfn>
+   <!-- data: url --> <li><dfn><a href="https://tools.ietf.org/html/rfc2397#section-2"><code>data:</code> URL</a></dfn>
   </ul>
 
  <dt>HTTP and related specifications
@@ -432,22 +432,22 @@ in the spec, as demonstrated in a (yet to be developed)
 
  <dd><p>The following terms are defined in the Cookie specification: [[!RFC6265]]
   <ul>
-   <!-- Compute cookie-string --> <li><dfn><a href=https://tools.ietf.org/html/rfc6265#section-5.4>Compute <code>cookie-string</code></a></dfn>
-   <!-- Cookie --> <li><dfn data-lt=cookies><a href=https://tools.ietf.org/html/rfc6265#section-5.3>Cookie</a></dfn>
-   <!-- Cookie store --> <li><dfn><a href=https://tools.ietf.org/html/rfc6265#section-5.3>Cookie store</a></dfn>
-   <!-- Receives a cookie --> <li><dfn data-lt="receiving a cookie"><a href=https://tools.ietf.org/html/rfc6265#section-5.3>Receives a cookie</a></dfn>
+   <!-- Compute cookie-string --> <li><dfn><a href="https://tools.ietf.org/html/rfc6265#section-5.4">Compute <code>cookie-string</code></a></dfn>
+   <!-- Cookie --> <li><dfn data-lt="cookies"><a href="https://tools.ietf.org/html/rfc6265#section-5.3">Cookie</a></dfn>
+   <!-- Cookie store --> <li><dfn><a href="https://tools.ietf.org/html/rfc6265#section-5.3">Cookie store</a></dfn>
+   <!-- Receives a cookie --> <li><dfn data-lt="receiving a cookie"><a href="https://tools.ietf.org/html/rfc6265#section-5.3">Receives a cookie</a></dfn>
   </ul>
 
  <dd><p>The following terms are defined in
   the Hypertext Transfer Protocol (HTTP) Status Code Registry:
   <ul>
-   <!-- Status code registry --> <li><dfn><a href=http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml>Status code registry</a></dfn>
+   <!-- Status code registry --> <li><dfn><a href="http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml">Status code registry</a></dfn>
   </ul>
 
  <dd>The following terms are defined in
   the Netscape Navigator Proxy Auto-Config File Format:
   <ul>
-   <!-- Proxy autoconfiguration --> <li><dfn><a href=https://web.archive.org/web/20070602031929/http://wp.netscape.com/eng/mozilla/2.0/relnotes/demo/proxy-live.html>Proxy autoconfiguration</a></dfn>
+   <!-- Proxy autoconfiguration --> <li><dfn><a href="https://web.archive.org/web/20070602031929/http://wp.netscape.com/eng/mozilla/2.0/relnotes/demo/proxy-live.html">Proxy autoconfiguration</a></dfn>
   </ul>
 
   <dd><p>The specification uses
@@ -457,9 +457,9 @@ in the spec, as demonstrated in a (yet to be developed)
  <dd>The following terms are defined
   in the Infra standard: [[!INFRA]]
    <ul>
-    <!-- ASCII lowercase --> <li><dfn data-lt="lowercase"><a href=https://infra.spec.whatwg.org/#ascii-lowercase>ASCII lowercase</a></dfn>
+    <!-- ASCII lowercase --> <li><dfn data-lt="lowercase"><a href="https://infra.spec.whatwg.org/#ascii-lowercase">ASCII lowercase</a></dfn>
     <!-- Javascript String's length --> <li><dfn><a href="https://infra.spec.whatwg.org/#javascript-string-length">JavaScript string's length</a></dfn>
-    <!-- queue --> <li><dfn><a href=https://infra.spec.whatwg.org/#queues>queue</a></dfn>
+    <!-- queue --> <li><dfn><a href="https://infra.spec.whatwg.org/#queues">queue</a></dfn>
    </ul>
 
  <dt>Interaction
@@ -482,48 +482,48 @@ in the spec, as demonstrated in a (yet to be developed)
  <dd>The following terms are defined in
   the CSS Values and Units Module Level 3 specification: [[!CSS3-VALUES]]
   <ul>
-   <!-- CSS pixels --> <li><dfn><a href=https://www.w3.org/TR/css-values-3/#px>CSS pixels</a></dfn>
+   <!-- CSS pixels --> <li><dfn><a href="https://www.w3.org/TR/css-values-3/#px">CSS pixels</a></dfn>
   </ul>
 
  <dd>The following properties are defined in
   the CSS Basic Box Model Level 3 specification: [[!CSS3-BOX]]
    <ul>
-    <!-- Visibility property --> <li>The <dfn><a href=https://drafts.csswg.org/css-box/#visibility-prop><code>visibility</code></a></dfn> property
+    <!-- Visibility property --> <li>The <dfn><a href="https://drafts.csswg.org/css-box/#visibility-prop"><code>visibility</code></a></dfn> property
    </ul>
 
  <dd>The following terms are defined in
   the CSS Device Adaptation Module Level 1 specification: [[!CSS-DEVICE-ADAPT]]
    <ul>
-    <!-- Initial viewport --><li><dfn data-lt=viewport><a href=https://drafts.csswg.org/css-device-adapt/#initial-viewport>Initial viewport</a></dfn>,
+    <!-- Initial viewport --><li><dfn data-lt="viewport"><a href="https://drafts.csswg.org/css-device-adapt/#initial-viewport">Initial viewport</a></dfn>,
      sometimes here referred to as the <i>viewport</i>.
    </ul>
 
  <dd>The following properties are defined in
   the CSS Display Module Level 3 specification: [[!CSS3-DISPLAY]]
   <ul>
-   <!-- Display property --> <li>The <dfn><a href=https://drafts.csswg.org/css-display/#the-display-properties><code>display</code></a></dfn> property
+   <!-- Display property --> <li>The <dfn><a href="https://drafts.csswg.org/css-display/#the-display-properties"><code>display</code></a></dfn> property
   </ul>
 
  <dd>The following terms are defined in
   the Geometry Interfaces Module Level 1 specification: [[!GEOMETRY-1]]
   <ul>
    <!-- DOMRect --> <li><a href="https://www.w3.org/TR/geometry-1/#dom-domrect"><dfn><code>DOMRect</code></dfn></a>
-   <!-- Rectangle --> <li><dfn data-lt="bounding rectangle"><a href=https://drafts.fxtf.org/geometry/#rectangle>Rectangle</a></dfn>
-   <!-- Rectangle height dimension --> <li><dfn data-lt="height dimension"><a href=https://drafts.fxtf.org/geometry/#rectangle-height-dimension>Rectangle height dimension</a></dfn>
-   <!-- Rectangle width dimension --> <li><dfn data-lt="width dimension"><a href=https://drafts.fxtf.org/geometry/#rectangle-width-dimension>Rectangle width dimension</a></dfn>
-   <!-- Rectangle x coordinate --> <li><dfn data-lt="x coordinate"><a href=https://drafts.fxtf.org/geometry/#rectangle-x-coordinate>Rectangle x coordinate</a></dfn>
-   <!-- Rectangle y coordinate --> <li><dfn data-lt="y coordinate"><a href=https://drafts.fxtf.org/geometry/#rectangle-y-coordinate>Rectangle y coordinate</a></dfn>
+   <!-- Rectangle --> <li><dfn data-lt="bounding rectangle"><a href="https://drafts.fxtf.org/geometry/#rectangle">Rectangle</a></dfn>
+   <!-- Rectangle height dimension --> <li><dfn data-lt="height dimension"><a href="https://drafts.fxtf.org/geometry/#rectangle-height-dimension">Rectangle height dimension</a></dfn>
+   <!-- Rectangle width dimension --> <li><dfn data-lt="width dimension"><a href="https://drafts.fxtf.org/geometry/#rectangle-width-dimension">Rectangle width dimension</a></dfn>
+   <!-- Rectangle x coordinate --> <li><dfn data-lt="x coordinate"><a href="https://drafts.fxtf.org/geometry/#rectangle-x-coordinate">Rectangle x coordinate</a></dfn>
+   <!-- Rectangle y coordinate --> <li><dfn data-lt="y coordinate"><a href="https://drafts.fxtf.org/geometry/#rectangle-y-coordinate">Rectangle y coordinate</a></dfn>
   </ul>
 
  <dd>The following terms are defined in
   the CSS Cascading and Inheritance Level 4 specification: [[!CSS-CASCADE-4]]
   <ul>
-   <!-- Computed Value --> <li><dfn><a href=https://drafts.csswg.org/css-cascade-4/#computed-value>Computed value</a></dfn>
+   <!-- Computed Value --> <li><dfn><a href="https://drafts.csswg.org/css-cascade-4/#computed-value">Computed value</a></dfn>
   </ul>
 
  <dd>The following terms are defined in the CSS Object Model: [[!CSSOM]]:
   <ul>
-   <!-- Resolved value --> <li><dfn><a href=https://drafts.csswg.org/cssom/#resolved-value>Resolved value</a></dfn>
+   <!-- Resolved value --> <li><dfn><a href="https://drafts.csswg.org/cssom/#resolved-value">Resolved value</a></dfn>
   </ul>
 
  <dd>The following functions are defined in
@@ -531,56 +531,56 @@ in the spec, as demonstrated in a (yet to be developed)
   <ul>
    <!-- getBoundingClientRect() --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect">getBoundingClientRect</a></dfn>
    <!-- elementFromPoint --> <li><dfn>Element from point</dfn> as <a href="https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint">elementFromPoint()</a>
-   <!-- elementsFromPoint --> <li><dfn data-lt="paint order|paint tree">Elements from point</dfn> as <a href=https://drafts.csswg.org/cssom-view/#dom-document-elementsfrompoint>elementsFromPoint()</a>
-   <!-- getClientRects --> <li><dfn data-lt="DOM client rectangle"><a href=https://drafts.csswg.org/cssom-view/#dom-range-getclientrects>getClientRects</a></dfn>
-   <!-- innerHeight --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-innerheight>innerHeight</a></dfn>
-   <!-- innerWidth --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-innerwidth>innerWidth</a></dfn>
-   <!-- moveTo --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-moveto>moveTo(x, y)</a></dfn>
-   <!-- offsetLeft --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetleft>offsetLeft</a></dfn>
-   <!-- offsetParent --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent>offsetParent</a></dfn>
-   <!-- offsetTop --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsettop>offsetTop</a></dfn>
-   <!-- outerHeight --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-outerheight>outerHeight</a></dfn>
-   <!-- outerWidth --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-outerwidth>outerWidth</a></dfn>
-   <!-- screenX --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-screenx>screenX</a></dfn>
-   <!-- screenY --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-window-screeny>screenY</a></dfn>
+   <!-- elementsFromPoint --> <li><dfn data-lt="paint order|paint tree">Elements from point</dfn> as <a href="https://drafts.csswg.org/cssom-view/#dom-document-elementsfrompoint">elementsFromPoint()</a>
+   <!-- getClientRects --> <li><dfn data-lt="DOM client rectangle"><a href="https://drafts.csswg.org/cssom-view/#dom-range-getclientrects">getClientRects</a></dfn>
+   <!-- innerHeight --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-window-innerheight">innerHeight</a></dfn>
+   <!-- innerWidth --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-window-innerwidth">innerWidth</a></dfn>
+   <!-- moveTo --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-window-moveto">moveTo(x, y)</a></dfn>
+   <!-- offsetLeft --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetleft">offsetLeft</a></dfn>
+   <!-- offsetParent --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent">offsetParent</a></dfn>
+   <!-- offsetTop --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsettop">offsetTop</a></dfn>
+   <!-- outerHeight --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-window-outerheight">outerHeight</a></dfn>
+   <!-- outerWidth --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-window-outerwidth">outerWidth</a></dfn>
+   <!-- screenX --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-window-screenx">screenX</a></dfn>
+   <!-- screenY --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-window-screeny">screenY</a></dfn>
    <!-- scrollX --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-window-scrollx">scrollX</a></dfn>
    <!-- scrollY --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-window-scrolly">scrollY</a></dfn>
-   <!-- scrollIntoView --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview>scrollIntoView</a></dfn>
-   <!-- ScrollIntoViewOptions --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dictdef-scrollintoviewoptions><code>ScrollIntoViewOptions</code></a></dfn>
-   <!-- ScrollIntoViewOptions block --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-scrollintoviewoptions-block>Logical scroll position "<code>block</code>"</a></dfn>
-   <!-- ScrollIntoViewOptions inline --> <li><dfn><a href=https://drafts.csswg.org/cssom-view/#dom-scrollintoviewoptions-inline>Logical scroll position "<code>inline</code>"</a></dfn>
+   <!-- scrollIntoView --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">scrollIntoView</a></dfn>
+   <!-- ScrollIntoViewOptions --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dictdef-scrollintoviewoptions"><code>ScrollIntoViewOptions</code></a></dfn>
+   <!-- ScrollIntoViewOptions block --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-scrollintoviewoptions-block">Logical scroll position "<code>block</code>"</a></dfn>
+   <!-- ScrollIntoViewOptions inline --> <li><dfn><a href="https://drafts.csswg.org/cssom-view/#dom-scrollintoviewoptions-inline">Logical scroll position "<code>inline</code>"</a></dfn>
   </ul>
 
  <dt>SOCKS Proxy and related specification:
  <dd><p>To be <dfn>SOCKS Proxy</dfn>
-  and <dfn data-lt=authenticating>SOCKS authentication</dfn> compliant,
+  and <dfn data-lt="authenticating">SOCKS authentication</dfn> compliant,
   it is supposed that the implementation supports the relevant subsets of
   [[!RFC1928]] and [[!RFC1929]].
 
  <dt>Unicode
  <dd>The following terms are defined in the  standard: [[!Unicode]]
   <ul>
-   <!-- Code point --> <li><dfn data-lt="unicode code point"><a href=http://www.unicode.org/versions/Unicode9.0.0/ch03.pdf#G2212>Code Point</a></dfn>
-   <!-- Extended grapheme cluster --> <li><dfn data-lt="grapheme cluster"><a href=http://www.unicode.org/versions/Unicode9.0.0/ch03.pdf#G2213>Extended grapheme cluster</a></dfn>
+   <!-- Code point --> <li><dfn data-lt="unicode code point"><a href="http://www.unicode.org/versions/Unicode9.0.0/ch03.pdf#G2212">Code Point</a></dfn>
+   <!-- Extended grapheme cluster --> <li><dfn data-lt="grapheme cluster"><a href="http://www.unicode.org/versions/Unicode9.0.0/ch03.pdf#G2213">Extended grapheme cluster</a></dfn>
   </ul>
 
  <dt>Unicode Standard Annex #29
  <dd>The following terms are defined in the standard: [[!UAX29]]
   <ul>
-   <!-- Breaking text into extended grapheme clusters --><li><dfn data-lt="breaking text into extended grapheme clusters"><a href=http://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries>Grapheme cluster boundaries</a></dfn>
+   <!-- Breaking text into extended grapheme clusters --><li><dfn data-lt="breaking text into extended grapheme clusters"><a href="http://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries">Grapheme cluster boundaries</a></dfn>
   </ul>
 
  <dt>Unicode Standard Annex #44
  <dd>The following terms are defined in the standard: [[!UAX44]]
   <ul>
-   <!-- Unicode character property --> <li><dfn><a href=http://unicode.org/reports/tr44/#Properties>Unicode character property</a></dfn>
+   <!-- Unicode character property --> <li><dfn><a href="http://unicode.org/reports/tr44/#Properties">Unicode character property</a></dfn>
   </ul>
 
  <dt>URLs
  <dd>The following terms are defined in the WHATWG URL standard: [[!URL]]
   <ul>
-   <!-- Absolute URL --> <li><dfn><a href=https://url.spec.whatwg.org/#syntax-url-absolute>Absolute URL</a></dfn>
-   <!-- Absolute URL with fragment --> <li><dfn><a href=https://url.spec.whatwg.org/#syntax-url-absolute-with-fragment>Absolute URL with fragment</a></dfn>
+   <!-- Absolute URL --> <li><dfn><a href="https://url.spec.whatwg.org/#syntax-url-absolute">Absolute URL</a></dfn>
+   <!-- Absolute URL with fragment --> <li><dfn><a href="https://url.spec.whatwg.org/#syntax-url-absolute-with-fragment">Absolute URL with fragment</a></dfn>
    <!-- Default port --> <li><dfn><a href="https://url.spec.whatwg.org/#default-port">Default port</a></dfn>
    <!-- Domain --><li><dfn data-lt="domains"><a href="https://url.spec.whatwg.org/#concept-domain">Domain</a></dfn>
    <!-- Host --> <li><dfn><a href="https://url.spec.whatwg.org/#concept-host">Host</a></dfn>
@@ -588,11 +588,11 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- IPv4 address --> <li><dfn data-lt="ipv4 addresses"><a href="https://url.spec.whatwg.org/#concept-ipv4">IPv4 address</a></dfn>
    <!-- IPv6 address --> <li><dfn data-lt="ipv6 addresses"><a href="https://url.spec.whatwg.org/#concept-ipv6">IPv6 address</a></dfn>
    <!-- Is Special --> <li><dfn><a href="https://url.spec.whatwg.org/#is-special">Is special</a></dfn>
-   <!-- Path-absolute URL --> <li><dfn><a href=https://url.spec.whatwg.org/#syntax-url-path-absolute>Path-absolute URL</a></dfn>
-   <!-- Path --> <li><dfn><a href=https://url.spec.whatwg.org/#concept-url-path>Path</a></dfn>
+   <!-- Path-absolute URL --> <li><dfn><a href="https://url.spec.whatwg.org/#syntax-url-path-absolute">Path-absolute URL</a></dfn>
+   <!-- Path --> <li><dfn><a href="https://url.spec.whatwg.org/#concept-url-path">Path</a></dfn>
    <!-- Port --> <li><dfn><a href="https://url.spec.whatwg.org/#concept-url-port">Port</a></dfn>
-   <!-- URL --> <li><dfn><a href=https://url.spec.whatwg.org/#concept-url>URL</a></dfn>
-   <!-- URL serializer --> <li><dfn><a href=https://url.spec.whatwg.org/#concept-url-serializer>URL serializer</a></dfn>
+   <!-- URL --> <li><dfn><a href="https://url.spec.whatwg.org/#concept-url">URL</a></dfn>
+   <!-- URL serializer --> <li><dfn><a href="https://url.spec.whatwg.org/#concept-url-serializer">URL serializer</a></dfn>
   </ul>
 
  <dt>Web IDL
@@ -602,7 +602,7 @@ in the spec, as demonstrated in a (yet to be developed)
   <ul>
    <!-- DOMException --> <li><a href="https://heycam.github.io/webidl/#dfn-DOMException"><dfn><code>DOMException</code></dfn></a>
    <!-- Sequence --> <li><a href="https://heycam.github.io/webidl/#idl-sequence"><dfn>Sequence</dfn></a>
-   <!-- Supported property indices --> <li><dfn data-lt="supported property index"><a href=https://heycam.github.io/webidl/#dfn-supported-property-indices>Supported property indices</a></dfn>
+   <!-- Supported property indices --> <li><dfn data-lt="supported property index"><a href="https://heycam.github.io/webidl/#dfn-supported-property-indices">Supported property indices</a></dfn>
    <!-- SyntaxError --> <li><dfn><a href="https://heycam.github.io/webidl/#syntaxerror"><code>SyntaxError</code></a></dfn></li>
 
   </ul>
@@ -611,7 +611,7 @@ in the spec, as demonstrated in a (yet to be developed)
   <dd><p>The following terms are defined in the Promises Guide. [[!PROMISES-GUIDE]]
     <ul>
       <!-- a new promise --> <li><dfn><a href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise">A new promise</a></dfn>
-      <!-- Promise calling --> <li><dfn data-lt='promise-call'><a href="https://www.w3.org/2001/tag/doc/promises-guide#promise-calling">Promise-calling</a></dfn>
+      <!-- Promise calling --> <li><dfn data-lt="promise-call"><a href="https://www.w3.org/2001/tag/doc/promises-guide#promise-calling">Promise-calling</a></dfn>
       <!-- Reject --> <li><dfn><a href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a></dfn>
       <!-- Resolve --> <li><dfn><a href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">resolve</a></dfn>
     </ul>
@@ -646,7 +646,7 @@ in the spec, as demonstrated in a (yet to be developed)
 <h3>Compatibility</h3>
 
 <p>This specification is derived from the popular
- <a href=http://www.seleniumhq.org>Selenium WebDriver</a> browser automation framework.
+ <a href="http://www.seleniumhq.org">Selenium WebDriver</a> browser automation framework.
  Selenium is a long-lived project,
  and due to its age and breadth of use
  it has a wide range of expected functionality.
@@ -673,7 +673,7 @@ in the spec, as demonstrated in a (yet to be developed)
 
 <p>WebDriver provides a mechanism for others to define extensions to the protocol
  for the purposes of automating functionality that cannot be implemented entirely
- in <a href=https://tc39.github.io/ecma262/>ECMAScript</a>. This allows other
+ in <a href="https://tc39.github.io/ecma262/">ECMAScript</a>. This allows other
  web standards to support the automation of new platform features. It also
  allows vendors to expose functionality that is specific to their browser.
 </section>
@@ -695,7 +695,7 @@ in the spec, as demonstrated in a (yet to be developed)
  <dfn>max</dfn>(<var>value</var>, <var>value</var>[, <var>value</var>])
  returns the largest item of two or more values.
 
-<p>A <dfn data-lt=uuid>Universally Unique IDentifier (UUID)</dfn> is
+<p>A <dfn data-lt="uuid">Universally Unique IDentifier (UUID)</dfn> is
  a 128 bits long URN that requires no central registration process. [[!RFC4122]].
  <dfn>Generating a UUID</dfn> means Creating a
  <a>UUID</a> From Truly Random or Pseudo-Random Numbers [[!RFC4122]],
@@ -705,7 +705,7 @@ in the spec, as demonstrated in a (yet to be developed)
  is a value that approximates the number of seconds
  that have elapsed since the Epoch,
  as described by The Open Group Base Specifications Issue 7
- <a href=http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_15>section 4.15</a> (IEEE Std 1003.1).
+ <a href="http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_15">section 4.15</a> (IEEE Std 1003.1).
 
 <p> An <dfn>integer</dfn> is a <a>Number</a> that is unchanged
  under the <a>ToInteger</a> operation.
@@ -739,11 +739,11 @@ in the spec, as demonstrated in a (yet to be developed)
 <p>If the <dfn>webdriver-active flag</dfn> is true,
  the user agent must support <dfn>NavigatorAutomationInformation</dfn> interface:
 
- <pre class=idl>
+ <pre class="idl">
  Navigator includes NavigatorAutomationInformation;
 </pre>
 
-<pre class=idl>
+<pre class="idl">
  interface mixin NavigatorAutomationInformation {
  readonly attribute boolean webdriver; // always returns true
  };
@@ -770,12 +770,12 @@ in the spec, as demonstrated in a (yet to be developed)
  <dt><dfn data-lt="local ends|local">Local end</dfn>
  <dd><p>The local end represents the client side of the protocol,
   which is usually in the form of language-specific libraries
-  providing an API on top of the WebDriver <a href=#protocol>protocol</a>.
+  providing an API on top of the WebDriver <a href="#protocol">protocol</a>.
   This specification does not place any restrictions on the details of those libraries
   above the level of the wire protocol.
 
  <dt><dfn data-lt="remote ends|remote">Remote end</dfn>
- <dd>The remote end hosts the server side of the <a href=#protocol>protocol</a>.
+ <dd>The remote end hosts the server side of the <a href="#protocol">protocol</a>.
   Defining the behavior of a remote end in response to the WebDriver protocol
   forms the largest part of this specification.
 </dl>
@@ -787,7 +787,7 @@ in the spec, as demonstrated in a (yet to be developed)
  <dt><dfn data-lt="intermediary nodes">Intermediary node</dfn>
  <dd>Intermediary nodes are those that act as proxies, implementing
   both the <a>local end</a> and <a>remote end</a> of
-  the <a href=#protocol>protocol</a>.  However they are not expected
+  the <a href="#protocol">protocol</a>.  However they are not expected
   to implement <a>remote end steps</a> directly. All nodes between a
   specific <a>intermediary node</a> and a <a>local end</a> are said to
   be <dfn data-lt="downstream node">downstream</dfn> of that
@@ -809,7 +809,7 @@ in the spec, as demonstrated in a (yet to be developed)
 <p>A <a>remote end</a>’s <dfn>readiness state</dfn> is the value corresponding
  to the first matching statement:
 
-<dl class=switch>
+<dl class="switch">
  <dt>the maximum <a>active sessions</a> is equal to the length of the list of
   <a>active sessions</a>
  <dt>the node is an <a>intermediary node</a> and is known to be in a state in
@@ -820,7 +820,7 @@ in the spec, as demonstrated in a (yet to be developed)
  <dd><p>True
 </dl>
 
-<p class=example>If the <a>intermediary node</a>
+<p class="example">If the <a>intermediary node</a>
  is a multiplexer that manages
  multiple <a data-lt="endpoint node">endpoint nodes</a>,
  this might indicate its ability to purvey more <a>sessions</a>,
@@ -852,7 +852,7 @@ in the spec, as demonstrated in a (yet to be developed)
 
 <p>Where algorithms that return values are fallible,
  they are written in terms of returning either
- <dfn>success</dfn> or <dfn data-lt=errors>error</dfn>.
+ <dfn>success</dfn> or <dfn data-lt="errors">error</dfn>.
  A <a>success</a> value has an associated <var>data</var> field
  which encapsulates the value returned,
  whereas an <a>error</a> response has an associated <a>error code</a>.
@@ -874,7 +874,7 @@ in the spec, as demonstrated in a (yet to be developed)
  defined as being the same as the result of calling
  <a>Object</a>.<a>[[\GetOwnProperty]]</a>(<var>name</var>).
 
-<p><dfn data-lt='set a property'>Setting a property</dfn> with
+<p><dfn data-lt="set a property">Setting a property</dfn> with
  arguments <var>name</var> and <var>value</var> is defined as being
  the same as calling
  <a>Object</a>.<a>[[\Put]]</a>(<var>name</var>, <var>value</var>).
@@ -883,7 +883,7 @@ in the spec, as demonstrated in a (yet to be developed)
   of type JSON <a>Object</a> is defined as the result of
   calling <code>JSON.</code><a>[[\Stringify]]</a>(<var>object</var>).
 
-<p>The result of <dfn data-lt='parsing as json'>JSON deserialization</dfn> with <var>text</var> is defined as
+<p>The result of <dfn data-lt="parsing as json">JSON deserialization</dfn> with <var>text</var> is defined as
   the result of calling <code>JSON.</code><a>[[\Parse]]</a>(<var>text</var>).
 </section> <!-- /Algorithms -->
 
@@ -943,7 +943,7 @@ in the spec, as demonstrated in a (yet to be developed)
 
   <li><p>If <var>session id</var> is among the variables defined by <var>command parameters</var>:
 
-   <p class=note>This condition is intended to exclude the <a>New Session</a> and <a>Status</a>
+   <p class="note">This condition is intended to exclude the <a>New Session</a> and <a>Status</a>
     <a>commands</a> and any <a>extension commands</a> which do not operate on a particular <a>session</a>.
 
   <ol>
@@ -1107,7 +1107,7 @@ in the spec, as demonstrated in a (yet to be developed)
  which is used as a prefix on all WebDriver-defined URLs on that <a>remote end</a>.
  This must either be <a>undefined</a> or a <a>path-absolute URL</a>.
 
-<aside class=example>
+<aside class="example">
  <p>For example a <a>remote end</a> wishing
   to run alongside other services on <code>example.com</code>
   might set its <a>URL prefix</a> to <code>/wd</code>
@@ -1155,12 +1155,12 @@ in the spec, as demonstrated in a (yet to be developed)
 <section>
 <h3>List of Endpoints</h3>
 
-<p>The following <dfn data-lt=endpoints>table of endpoints</dfn> lists
+<p>The following <dfn data-lt="endpoints">table of endpoints</dfn> lists
  the <a>method</a> and <a>URI template</a> for each <a>endpoint
  node</a> <a>command</a>. <a>Extension commands</a> are implicitly
  appended to this table.
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>Method</th>
   <th>URI Template</th>
@@ -1512,7 +1512,7 @@ in the spec, as demonstrated in a (yet to be developed)
    with additional <a>error data</a> helpful in diagnosing the error.
  </ul>
 
-<aside class=example>
+<aside class="example">
  <p>A <code>GET</code> request to <code>/session/1234/url</code>,
  where <code>1234</code> is not the <a>session id</a> of a <a>current session</a>
  would return an <a>HTTP response</a> with the status 404 and a body of the form:
@@ -1552,7 +1552,7 @@ in the spec, as demonstrated in a (yet to be developed)
  is the values of the <i>HTTP Status</i>
  and <i>JSON Error Code</i> columns for the row corresponding to that <a>error code</a>.
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>Error Code
   <th>HTTP Status
@@ -1816,17 +1816,17 @@ in the spec, as demonstrated in a (yet to be developed)
  or more path segments which uniquely identifies the vendor and UA.
  It is suggested that vendors use their vendor prefixes
  without additional characters as outlined in [[CSS21]],
- notably in <a href=https://www.w3.org/TR/CSS21/syndata.html#vendor-keywords>section 4.1.2.2 on <i>vendor keywords</i></a>,
+ notably in <a href="https://www.w3.org/TR/CSS21/syndata.html#vendor-keywords">section 4.1.2.2 on <i>vendor keywords</i></a>,
  as the name for this path element,
  and include a vendor-chosen UA identifier.
 
-<aside class=note>
+<aside class="note">
  If the <a>extension command URI Template</a> includes a variable named
  <var>session id</var>, the value of this variable will be used to define the
  <a>current session</a> during command processing.
 </aside>
 
-<aside class=example>
+<aside class="example">
  <p>This might lead to a URL of the form
   <code>/session/5d376174-36f0-11e5-9b9a-6bdf200a3f7f/<var>ms</var>/<var>edge</var>/<var>context</var></code>,
   where <code>session/{<var>session id</var>}</code> associates the request
@@ -1851,11 +1851,11 @@ in the spec, as demonstrated in a (yet to be developed)
 <p>As with <a>extension commands</a>,
  it is suggested that the key used to denote
  the <a>extension capability</a> namespace
- is based on the <a href=https://www.w3.org/TR/CSS21/syndata.html#vendor-keywords>vendor keywords</a>
+ is based on the <a href="https://www.w3.org/TR/CSS21/syndata.html#vendor-keywords">vendor keywords</a>
  listed in [[!CSS21]]
  and precedes the first "<code>:</code>" character in the string.
 
-<aside class=example>
+<aside class="example">
  <p><a>Extension capabilities</a> are typically used
   to provide UA or <a>intermediary node</a> specific configuration
   that is not handled by the <a>table of standard capabilities</a>.
@@ -1905,7 +1905,7 @@ with a "<code>moz:</code>" prefix:
 }</pre>
 </aside>
 
-<table class=simple>
+<table class="simple">
  <thead>
    <tr>
     <th>Capability
@@ -1941,7 +1941,7 @@ with a "<code>moz:</code>" prefix:
   <td>"<code>acceptInsecureCerts</code>"
   <td>boolean
   <td>Indicates whether untrusted and self-signed TLS certificates
-   are implicitly trusted on <a data-lt=go>navigation</a>
+   are implicitly trusted on <a data-lt="go">navigation</a>
    for the duration of the <a>session</a>.
  </tr>
 
@@ -1964,7 +1964,7 @@ with a "<code>moz:</code>" prefix:
   <td>"<code>setWindowRect</code>"
   <td>boolean
    <td>Indicates whether the remote end supports all of the <a>commands</a> in
-   <a href=#h-resizing-and-positioning-windows>Resizing and Positioning Windows</a>.
+   <a href="#h-resizing-and-positioning-windows">Resizing and Positioning Windows</a>.
  </tr>
 
  <tr>
@@ -1991,7 +1991,7 @@ with a "<code>moz:</code>" prefix:
  Implementations may define additional proxy configuration options,
  but they must not alter the semantics of those listed below.
 
-<table class=simple>
+<table class="simple">
  <thead>
   <tr>
    <th>Key
@@ -2240,7 +2240,7 @@ with a "<code>moz:</code>" prefix:
     property</a> named <var>name</var> from <var>capability</var>.
 
    <li><p>Run the substeps of the first matching condition:
-    <dl class=switch>
+    <dl class="switch">
      <dt><var>value</var> is <a>null</a>
      <dd><p>Let <var>deserialized</var> be set to <a>null</a>.
 
@@ -2337,7 +2337,7 @@ with a "<code>moz:</code>" prefix:
  <li><p>Return <var>result</var>.
 </ol>
 
-<aside class=note>
+<aside class="note">
  <p>The algorithm outlined in <a>matching capabilities</a>
   blithely ignores real-world problems
   that make implementation less than perfectly straightforward,
@@ -2370,11 +2370,11 @@ with a "<code>moz:</code>" prefix:
    <dt>"<code>acceptInsecureCerts</code>"
    <dd><a>Boolean</a> initially set to <code>false</code>,
     indicating the session will not implicitly trust untrusted
-    or self-signed TLS certificates on <a data-lt=go>navigation</a>.
+    or self-signed TLS certificates on <a data-lt="go">navigation</a>.
 
    <dt>"<code>setWindowRect</code>"
    <dd>Boolean indicating whether the <a>remote end</a> supports all of the
-    <a>commands</a> in <a href=#h-resizing-and-positioning-windows>Resizing and Positioning Windows</a>.
+    <a>commands</a> in <a href="#h-resizing-and-positioning-windows">Resizing and Positioning Windows</a>.
   </dl>
 
  <li><p>Optionally add <a>extension capabilities</a> as entries
@@ -2382,7 +2382,7 @@ with a "<code>moz:</code>" prefix:
   ellided, and there is no requirement that all
   <a>extension capabilities</a> be added.
 
-  <aside class=note>
+  <aside class="note">
   <p>
    This allows a <a>remote end</a> to add information that might be
    useful to a <a>local end</a> without unnecessarily bloating the
@@ -2401,14 +2401,14 @@ with a "<code>moz:</code>" prefix:
   <ol>
    <li><p>Run the substeps of the first matching <var>name</var>:
 
-    <dl class=switch>
+    <dl class="switch">
      <dt>"<code>browserName</code>"
      <dd><p>If <var>value</var> is not a string equal to
        the "<code>browserName</code>" entry in
        <var>matched capabilities</var>, return <a>success</a>
        with data <a>null</a>.
 
-     <p class=note>There is a chance the <a>remote end</a> will need
+     <p class="note">There is a chance the <a>remote end</a> will need
       to start a browser process to correctly determine
       the <code>browserName</code>. Lightweight checks are preferred
       before this is done.
@@ -2425,12 +2425,12 @@ with a "<code>moz:</code>" prefix:
       <p>If the two values do not match,
        return <a>success</a> with data <a>null</a>.
 
-      <p class=note>Version comparison is left as an implementation detail
+      <p class="note">Version comparison is left as an implementation detail
        since each user agent will likely have conflicting methods
        of encoding the user agent version,
        and standardizing these schemes is beyond the scope of this standard.
 
-     <p class=note>There is a chance the <a>remote end</a> will need
+     <p class="note">There is a chance the <a>remote end</a> will need
       to start a browser process to correctly determine
       the <code>browserVersion</code>. Lightweight checks are preferred
       before this is done.
@@ -2440,14 +2440,14 @@ with a "<code>moz:</code>" prefix:
        to the "<code>platformName</code>" entry in <var>matched capabilities</var>,
        return <a>success</a> with data <a>null</a>.
 
-      <div class=note>
+      <div class="note">
        <p>The following platform names are in common usage with
         well-understood semantics and, when <a>matching
         capabilities</a>, greatest interoperability can be achieved by
         honoring them as valid synonyms for well-known Operating
         Systems:
 
-        <table class=simple>
+        <table class="simple">
          <tr>
           <th>Key
           <th>System
@@ -2471,7 +2471,7 @@ with a "<code>moz:</code>" prefix:
        and the <a>endpoint node</a> does not support <a>insecure TLS certificates</a>,
        return <a>success</a> with data <a>null</a>.
 
-       <p class=note>If the <a>endpoint node</a> does not
+       <p class="note">If the <a>endpoint node</a> does not
         support <a>insecure TLS certificates</a> and this is the reason
         no match is ultimately made, it is useful to provide this
         information to the <a>local end</a>.
@@ -2483,7 +2483,7 @@ with a "<code>moz:</code>" prefix:
       node</a>'s implementation-specific validity checks,
       return <a>success</a> with data <a>null</a>.
 
-      <p class=note>A <a>local end</a> would only send this capability
+      <p class="note">A <a>local end</a> would only send this capability
        if it expected it to be honored and the configured proxy
        used. The intent is that if this is not possible a new session
        will not be established.
@@ -2583,9 +2583,9 @@ with a "<code>moz:</code>" prefix:
 <p>A <a>session</a> has an associated <dfn>session implicit wait
  timeout</dfn> that specifies a time to wait in milliseconds for
  the <a>element location strategy</a>
- when <a href=#element-retrieval>retreiving elements</a> and when
+ when <a href="#element-retrieval">retreiving elements</a> and when
  waiting for an <a>element</a> to become <a>interactable</a> when
- performing <a href=#element-interaction>element interaction</a> .
+ performing <a href="#element-interaction">element interaction</a> .
  Unless stated otherwise it is zero milliseconds.
 
 <p>A <a>session</a> has an associated <dfn>page loading strategy</dfn>,
@@ -2596,7 +2596,7 @@ with a "<code>moz:</code>" prefix:
  that indicates whether untrusted or self-signed TLS certificates
  should be trusted for the duration of the WebDriver session.
  If it is unset, this indicates that certificate- or TLS errors
- that occur upon <a data-lt=go>navigation</a> should be suppressed.
+ that occur upon <a data-lt="go">navigation</a> should be suppressed.
  The state can be unset by providing
  an "<code>acceptInsecureCerts</code>" <a>capability</a> with the value true.
  Unless stated otherwise, it is set.
@@ -2611,7 +2611,7 @@ with a "<code>moz:</code>" prefix:
 <p>A <a>session</a> has an associated <a>input cancel list</a>.
 
 <p>A <a>session</a> has an associated <dfn>request queue</dfn> which is a
- <a>queue</a> of <a data-lt=request>requests</a> that are currently awaiting
+ <a>queue</a> of <a data-lt="request">requests</a> that are currently awaiting
  processing.
 
 <p>When asked to <dfn>close the session</dfn>,
@@ -2620,7 +2620,7 @@ with a "<code>moz:</code>" prefix:
 <ol>
  <li><p>Perform the following substeps based on the <a>remote end</a>'s
   type:
-  <dl class=switch>
+  <dl class="switch">
    <dt><a>Remote end</a> is an <a>endpoint node</a>
    <dd>
     <ol>
@@ -2686,7 +2686,7 @@ with a "<code>moz:</code>" prefix:
  An <a>intermediary node</a> MUST forward custom,
  top-level parameters (i.e. non-<a>capabilities</a>) to subsequent <a>remote end</a> nodes.
 
-<aside class=example>
+<aside class="example">
  <p>An <a>intermediary node</a> might require authentication
   on <a>creating a new session</a>.
   This authentication is an argument to the <a>New Session</a> command
@@ -2748,7 +2748,7 @@ with a "<code>moz:</code>" prefix:
   commands may be forwarded to this <a>associated session</a> on
   subsequent commands.
 
-  <p class=note>How this is done is entirely up to the implementation,
+  <p class="note">How this is done is entirely up to the implementation,
    but typically the <code>sessionId</code>, and <a>URL</a> and
    <a>URL prefix</a> of the <a>upstream</a> <a>remote end</a> will need
    to be tracked.
@@ -2799,7 +2799,7 @@ with a "<code>moz:</code>" prefix:
     "<code>proxy</code>" from <var>capabilities</var> and run the
     substeps of the first matching statement:
 
-       <dl class=switch>
+       <dl class="switch">
          <dt><var>proxy</var> is a <a>proxy configuration</a> object</dt>
          <dd><p>Take implementation-defined steps to set the user agent proxy
              using the extracted <var>proxy</var> configuration.  If the
@@ -2914,7 +2914,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<aside class=note>
+<aside class="note">
  <p><a>Status</a> returns information
   about whether a <a>remote end</a>
   is in a state in which it can create <a data-lt="new session">new sessions</a>,
@@ -3009,7 +3009,7 @@ with a "<code>moz:</code>" prefix:
  The keywords given in the first column
  maps to the timeout type given in the second.
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>Keyword
   <th>Type
@@ -3020,21 +3020,21 @@ with a "<code>moz:</code>" prefix:
   <td>"<code>script</code>"
   <td><a>session script timeout</a>
   <td>Determines when to interrupt a script that is being
-   <a href=#executing-script>evaluated</a>.
+   <a href="#executing-script">evaluated</a>.
  </tr>
 
  <tr>
   <td>"<code>pageLoad</code>"
   <td><a>session page load timeout</a>
   <td>Provides the timeout limit used to interrupt
-  <a data-lt=navigate>navigation</a> of the <a>browsing context</a>.
+  <a data-lt="navigate">navigation</a> of the <a>browsing context</a>.
  </tr>
 
  <tr>
   <td>"<code>implicit</code>"
   <td><a>session implicit wait timeout</a>
   <td>Gives the timeout of when to abort
-   <a href=#element-retrieval>locating an element</a>.
+   <a href="#element-retrieval">locating an element</a>.
  </tr>
 </table>
 
@@ -3123,7 +3123,7 @@ with a "<code>moz:</code>" prefix:
  and shows which <a>document readiness</a> state
  that corresponds to it:
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>Keyword
   <th>Page load strategy state
@@ -3206,7 +3206,7 @@ with a "<code>moz:</code>" prefix:
 <p>When asked to run the <dfn>post-navigation checks</dfn>,
  run the substeps of the first matching statement:
 
-<dl class=switch>
+<dl class="switch">
  <dt><a>response</a> is a network error
  <dd><p>Return <a>error</a> with <a>error code</a> <a>unknown error</a>.
   <p class="note">A &quot;network error&quot; in this case is not an
@@ -3240,11 +3240,11 @@ with a "<code>moz:</code>" prefix:
  </tr>
  <tr>
   <td>POST</td>
-  <td id=post-url>/session/{<var>session id</var>}/url</td>
+  <td id="post-url">/session/{<var>session id</var>}/url</td>
  </tr>
 </table>
 
-<p class=note>The command causes the user agent
+<p class="note">The command causes the user agent
  to <a>navigate</a> the <a>current top-level browsing context</a> to a new location.
 
 <p>If the <a>session</a> is not in a <a>secure TLS</a> state,
@@ -3252,7 +3252,7 @@ with a "<code>moz:</code>" prefix:
  cause the user agent to abort and show a security warning
  are to hinder navigation to the requested address.
 
-<aside class=example>
+<aside class="example">
  <p>To navigate the <a>current top-level browsing context</a>
   of the <a>session</a> with ID <i>1</i> to <code>https://example.com</code>,
   the <a>local end</a> would POST to <i>/session/1/url</i> with the body:
@@ -3358,7 +3358,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>This command causes the browser to traverse
+<p class="note">This command causes the browser to traverse
  one step backward in the <a>joint session history</a>
  of the <a>current top-level browsing context</a>.
  This is equivalent to pressing the back button in the browser chrome
@@ -3403,7 +3403,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>This command causes the browser
+<p class="note">This command causes the browser
  to traverse one step forwards in the <a>joint session history</a>
  of the <a>current top-level browsing context</a>.
 
@@ -3446,7 +3446,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>This command causes the browser
+<p class="note">This command causes the browser
  to reload the page in the <a>current top-level browsing context</a>.
 
 <p>The <a>remote end steps</a> are:
@@ -3489,7 +3489,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>This command returns the <a>document title</a>
+<p class="note">This command returns the <a>document title</a>
  of the <a>current top-level browsing context</a>,
  equivalent to calling <code>document.title</code>.
 
@@ -3522,7 +3522,7 @@ with a "<code>moz:</code>" prefix:
  a specific <a>browsing context</a> can be selected
  using the <a>Switch to Frame</a> command.
 
-<p class=note>The use of the term “window” to
+<p class="note">The use of the term “window” to
  refer to a <a>top-level browsing context</a>
  is legacy and doesn’t correspond with either
  the operating system notion of a “window”
@@ -3562,8 +3562,8 @@ with a "<code>moz:</code>" prefix:
   </dl>
 </ol>
 
-<p class=note>In accordance with
- the <a href=https://html.spec.whatwg.org/multipage/interaction.html#focus>focus</a>
+<p class="note">In accordance with
+ the <a href="https://html.spec.whatwg.org/multipage/interaction.html#focus">focus</a>
  section of the [[!HTML]] specification,
  commands are unaffected by whether
  the operating system window has focus or not.
@@ -3582,7 +3582,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>This command returns the <a>window handle</a>
+<p class="note">This command returns the <a>window handle</a>
  for the <a>current top-level browsing context</a>.
  It can be used as an argument to <a>Switch To Window</a>.
 
@@ -3643,7 +3643,7 @@ with a "<code>moz:</code>" prefix:
   </tr>
 </table>
 
-<p class=note>This command is used
+<p class="note">This command is used
  to select the <a>current top-level browsing context</a>
  for the current <a>session</a>,
  i.e. the one that will be used for processing <a>commands</a>.
@@ -3694,7 +3694,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>This command returns a list of <a>window handles</a>
+<p class="note">This command returns a list of <a>window handles</a>
  for every open <a>top-level browsing context</a>.
 
 <p>The order in which the window handles are returned is arbitrary.
@@ -3732,7 +3732,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>The <a>Switch To Frame</a> command is used to select
+<p class="note">The <a>Switch To Frame</a> command is used to select
  the <a>current top-level browsing context</a> or a <a>child browsing context</a>
  of the <a>current browsing context</a> to use as the <a>current browsing context</a>
  for subsequent <a>commands</a>.
@@ -3757,7 +3757,7 @@ with a "<code>moz:</code>" prefix:
 
  <li><p>Run the substeps of the first matching condition:
 
-  <dl class=switch>
+  <dl class="switch">
    <dt><var>id</var> is <a>null</a>
    <dd>
     <ol>
@@ -3781,7 +3781,7 @@ with a "<code>moz:</code>" prefix:
      <li><p>Let <var>child window</var> be
       the <a><code>WindowProxy</code></a> object obtained by
       calling
-      <var>window</var>.<a data-lt='window.[[\getOwnProperty]]'><code>[[\GetOwnProperty]]</code></a>
+      <var>window</var>.<a data-lt="window.[[\getOwnProperty]]"><code>[[\GetOwnProperty]]</code></a>
       (<var>id</var>).
 
      <li><p>Set the <a>current browsing context</a> to
@@ -3814,7 +3814,7 @@ with a "<code>moz:</code>" prefix:
  <li><p>Return <a>success</a> with data <a>null</a>.
 </ol>
 
-<p class=note>WebDriver is not bound by the same origin policy,
+<p class="note">WebDriver is not bound by the same origin policy,
  so it is always possible to switch into child browsing contexts,
  even if they are different origin to the current browsing context.
 </section> <!-- /Switch To Frame -->
@@ -3833,7 +3833,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>The <a>Switch to Parent Frame</a> <a>command</a>
+<p class="note">The <a>Switch to Parent Frame</a> <a>command</a>
  sets the <a>current browsing context</a> for future <a>commands</a>
  to the parent of the <a>current browsing context</a>.
 
@@ -3876,7 +3876,7 @@ with a "<code>moz:</code>" prefix:
  which describes what visibility state its OS widget window is in.
  It can be in one of the following states:
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>State
   <th>Keyword
@@ -3992,7 +3992,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>The <a>Get Window Rect</a> <a>command</a>
+<p class="note">The <a>Get Window Rect</a> <a>command</a>
  returns the size and position on the screen
  of the operating system window corresponding
  to the <a>current top-level browsing context</a>.
@@ -4026,7 +4026,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=ntoe>The <a>Set Window Rect</a> <a>command</a>
+<p class="note">The <a>Set Window Rect</a> <a>command</a>
  alters the size and the position of the operating system window
  corresponding to the <a>current top-level browsing context</a>.
 
@@ -4086,7 +4086,7 @@ with a "<code>moz:</code>" prefix:
    including any browser chrome and externally drawn window decorations
    to a value that is as close as possible to <var>height</var>.
 
-   <aside class=note>
+   <aside class="note">
     <p>The specification does not guarantee
      that the resulting window size will exactly match that which was requested.
      In particular the implementation is expected to clamp values
@@ -4114,14 +4114,14 @@ with a "<code>moz:</code>" prefix:
     containing the <a>current top-level browsing context</a>
     to the position given by the <var>x</var> and <var>y</var> coordinates.
 
-    <aside class=note>
+    <aside class="note">
      <p>Note that this step is similar
       to calling the <a>moveTo(x, y)</a> method
       on the <a><code>WindowProxy</code></a> object
       associated with the <a>current top-level browsing context</a>,
-      but without the <a href=https://developer.mozilla.org/en-US/docs/Web/API/Window/moveTo>security restrictions</a> that you
+      but without the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/moveTo">security restrictions</a> that you
 
-     <ol type=a>
+     <ol type="a">
       <li>cannot move a window or tab
        that was not created by <code>window.open</code>.
 
@@ -4151,7 +4151,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>The <a>Maximize Window</a> command
+<p class="note">The <a>Maximize Window</a> command
  invokes the window manager-specific “maximize” operation, if any,
  on the window containing the <a>current top-level browsing context</a>.
  This typically increases the window to the maximum available size
@@ -4198,7 +4198,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>The <a>Minimize Window</a> command
+<p class="note">The <a>Minimize Window</a> command
  invokes the window manager-specific “minimize” operation, if any,
  on the window containing the <a>current top-level browsing context</a>.
  This typically hides the window in the system tray.
@@ -4241,7 +4241,7 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>The <a>Fullscreen Window</a> command
+<p class="note">The <a>Fullscreen Window</a> command
  invokes the window manager-specific “full screen” operation, if any,
  on the window containing the <a>current top-level browsing context</a>.
  This typically increases the window to the size of the physical display
@@ -4427,7 +4427,7 @@ argument <var>reference</var>, run the following steps:
  WebDriver performs hit-testing to find
  if the interaction will be able to reach the requested element.
 
-<p>An <dfn data-lt=interactable>interactable element</dfn>
+<p>An <dfn data-lt="interactable">interactable element</dfn>
  is an <a>element</a> which is either
  <a>pointer-interactable</a> or <a>keyboard-interactable</a>.
 
@@ -4484,13 +4484,13 @@ argument <var>reference</var>, run the following steps:
  if it is a member of its own <a>pointer-interactable paint tree</a>,
  given the pretense that its <a>pointer events are not disabled</a>.
 
-<p>An <a>element</a> is <dfn data-lt=obscuring>obscured</dfn>
+<p>An <a>element</a> is <dfn data-lt="obscuring">obscured</dfn>
  if the <a>pointer-interactable paint tree</a>
  at its <a>center point</a> is empty,
  or the first element in this tree
  is not an <a>inclusive descendant</a> of itself.
 
-<aside class=example>
+<aside class="example">
  <p>This ascertains if the <a>element</a>’s <a>in-view center point</a>
   would be possible to <a data-lt="element click">interact</a> with.
 
@@ -4611,14 +4611,14 @@ argument <var>reference</var>, run the following steps:
 <section>
 <h3>Locator Strategies</h3>
 
-<p>An <dfn data-lt=strategy>element location strategy</dfn>
+<p>An <dfn data-lt="strategy">element location strategy</dfn>
  is an <a>enumerated attribute</a>
  deciding what technique should be used
  to search for <a>elements</a> in the <a>current browsing context</a>.
  The following <dfn>table of location strategies</dfn> lists the keywords and
  states defined for this attribute:
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>State
   <th>Keyword
@@ -4769,7 +4769,7 @@ argument <var>reference</var>, run the following steps:
   <a>ORDERED_NODE_SNAPSHOT_TYPE</a>,
   and <a>null</a>.
 
-  <p class=note>A snapshot is used to promote operation atomicity.
+  <p class="note">A snapshot is used to promote operation atomicity.
 
  <li><p>Let <var>index</var> be 0.
 
@@ -5023,9 +5023,9 @@ argument <var>reference</var>, run the following steps:
 </table>
 
 <p><dfn>Get Active Element</dfn> returns
- the <a href=https://html.spec.whatwg.org/#dom-document-activeelement>active element</a>
+ the <a href="https://html.spec.whatwg.org/#dom-document-activeelement">active element</a>
  of the <a>current browsing context</a>’s
- <a href=https://dom.spec.whatwg.org/#concept-element>document element</a>.
+ <a href="https://dom.spec.whatwg.org/#concept-element">document element</a>.
 
 <p>The <a>remote end steps</a> are:
 
@@ -5087,7 +5087,7 @@ argument <var>reference</var>, run the following steps:
 
 <p>An <a><var>element</var></a>’s <dfn>container</dfn> is:
 
-<dl class=switch>
+<dl class="switch">
  <dt><a><code>option</code> element</a> in a valid <a>element context</a>
  <dt><a><code>optgroup</code> element</a> in a valid <a>element context</a>
  <dd><p>The <a><var>element</var></a>'s <a>element context</a>,
@@ -5151,7 +5151,7 @@ argument <var>reference</var>, run the following steps:
  <li><p>Let <var>selected</var> be the value
   corresponding to the first matching statement:
 
-  <dl class=switch>
+  <dl class="switch">
    <dt><var>element</var> is an <a><code>input</code> element</a>
     with a <a><code>type</code> attribute</a>
     in the <a>Checkbox</a>- or <a>Radio Button</a> state
@@ -5200,7 +5200,7 @@ argument <var>reference</var>, run the following steps:
 
  <li>Let <var>result</var> be the result of the first matching condition:
 
-   <dl class=switch>
+   <dl class="switch">
     <dt>If <var>name</var> is a <a>boolean attribute</a>
     <dd><p>"<code>true</code>" (string)
      if the <var>element</var> <a>has the attribute</a>,
@@ -5327,7 +5327,7 @@ argument <var>reference</var>, run the following steps:
  text is also used for locating <a><code>a</code> elements</a> by
  their <a>link text</a> and <a>partial link text</a>.
 
-<p class=note>One of the major inputs to this specification was the
+<p class="note">One of the major inputs to this specification was the
  Open Source <a href="http://www.seleniumhq.org">Selenium</a>
  project. This was in wide-spread use before this specification
  written, and so had set user expectations of how the <a>Get Element
@@ -5603,7 +5603,7 @@ argument <var>reference</var>, run the following steps:
 
  <li><p>Matching on <var>element</var>:
 
-  <dl class=switch>
+  <dl class="switch">
    <dt><a><code>option</code> element</a>
    <dd>
      <ol>
@@ -5902,8 +5902,8 @@ sending composition events in accordance with the requirements of
 properties.
 
 <ul>
- <li><a href=https://www.w3.org/TR/uievents/#events-compositionevents><code>composition event</code></a> with properties:
-  <table class=simple>
+ <li><a href="https://www.w3.org/TR/uievents/#events-compositionevents"><code>composition event</code></a> with properties:
+  <table class="simple">
    <tr>
     <th>Attribute</th>
     <th>Value</th>
@@ -6194,7 +6194,7 @@ must run the following steps:
 
  <li><p>Matching on <var>value</var>:
 
-  <dl class=switch>
+  <dl class="switch">
    <dt><a>undefined</a>
    <dt><a>null</a>
    <dt>type <a>Boolean</a>
@@ -6223,7 +6223,7 @@ must run the following steps:
  a <a>remote end</a> must return the value
  of the first matching statement, matching on <var>value</var>:
 
-<dl class=switch>
+<dl class="switch">
  <dt><a>undefined</a>
  <dt><a>null</a>
  <dd><p><a>Success</a> with data <a>null</a>.
@@ -6291,7 +6291,7 @@ must run the following steps:
  <li><p>Let <var>result</var> be the value of the first matching statement,
   matching on <var>value</var>:
 
-  <dl class=switch>
+  <dl class="switch">
    <dt>instance of <a>NodeList</a>
    <dt>instance of <a>HTMLCollection</a>
    <dt>instance of <a>Array</a>
@@ -6601,7 +6601,7 @@ must run the following steps:
  and a brief non-normative description of the field
  and the expected input type of its associated value.
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>Concept
   <th>RFC 6265 Field
@@ -6703,7 +6703,7 @@ must run the following steps:
 <p>When the <a>remote end</a> is instructed
  to <dfn data-lt="creating a cookie">create a cookie</dfn>,
  this is synonymous to carrying out the steps described in [[!RFC6265]]
- <a href=https://tools.ietf.org/html/rfc6265#section-5.3>section 5.3</a>,
+ <a href="https://tools.ietf.org/html/rfc6265#section-5.3">section 5.3</a>,
  under <a>receiving a cookie</a>,
  except the user agent may not ignore the received cookie in its entirety
  (disregard step 1).
@@ -6716,7 +6716,7 @@ must run the following steps:
   the <a>current browsing context</a>’s <a>active document</a>,
   run the substeps of the first matching condition:
 
-  <dl class=switch>
+  <dl class="switch">
    <dt><var>name</var> is <a>undefined</a>
    <dt><var>name</var> is equal to <a>cookie name</a>
    <dd><p>Set the <a>cookie expiry time</a>
@@ -6925,7 +6925,7 @@ must run the following steps:
 <section>
 <h3><dfn>Delete All Cookies</dfn></h3>
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>HTTP Method</th>
   <th>URI Template</th>
@@ -6987,7 +6987,7 @@ must run the following steps:
  <p>The diagram below displays when each action gets executed.
   "Source 1" is the first finger, and "source 2" is the second.
 
- <p><img src=graphics/note1actions.svg alt="">
+ <p><img src="graphics/note1actions.svg" alt="">
 
  <p>There is no limit to the number of <a>input sources</a>,
   and there is no restriction regarding the length of each input's action list.
@@ -7002,7 +7002,7 @@ must run the following steps:
 
  <p>And the execution of each action will be done as follows:
 
- <p><img src=graphics/note4actions.svg alt="">
+ <p><img src="graphics/note4actions.svg" alt="">
 
  <p>Specific timing for the actions can also be expressed.
   The <a>pause</a> action can be used to either
@@ -7013,7 +7013,7 @@ must run the following steps:
   must wait for the longest pause to complete.
   For example, in this diagram:
 
- <p><img src=graphics/note2actions.svg alt="">
+ <p><img src="graphics/note2actions.svg" alt="">
 
  <p>The <a>remote end</a> will dispatch
   the <a>pointerDown</a> action in the first <a>tick</a>.
@@ -7030,7 +7030,7 @@ must run the following steps:
   then the <a>input source</a> will not have any actions executed in the containing <a>tick</a>.
   As an example:
 
- <p><img src=graphics/note3actions.svg alt="">
+ <p><img src="graphics/note3actions.svg" alt="">
 
  <p>During <a>tick</a> 2, source 1 will have its <a>pointerMove</a> action dispatched,
   while source 2 will do nothing.
@@ -7052,7 +7052,7 @@ must run the following steps:
  not associated with a specific physical device. A <a>null input source</a>
  supports the following actions:
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>Action
   <th>Non-normative Description
@@ -7070,7 +7070,7 @@ must run the following steps:
  A <a>key input source</a> supports the same <a>pause</a> action
  as a <a>null input source</a> plus the following actions:
 
- <table class=simple>
+ <table class="simple">
   <tr>
    <th>Action
    <th>Non-normative Description
@@ -7092,7 +7092,7 @@ must run the following steps:
  supports the same <a>pause</a> action as a <a>null input source</a>
  plus the following actions:
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>Action
   <th>Non-normative Description
@@ -7163,7 +7163,7 @@ is also removed.
 
  <!-- todo: define generating DOM events from an input somewhere -->
 
-<aside class=note>
+<aside class="note">
  <p>An <a>activation trigger</a>
   generated by the WebDriver API user
   needs to be indistinguishable from those generated
@@ -7192,7 +7192,7 @@ is also removed.
 <section>
 <h2>Input Source State</h2>
 
-<p class=note>The objects and properties defined in this section
+<p class="note">The objects and properties defined in this section
  are spec-internal constructs
  and do not correspond to ECMAScript objects.
  For convenience the same terminology is used for their manipulation.
@@ -7203,7 +7203,7 @@ is also removed.
 <p>The <dfn>corresponding <a>input source state</a> type</dfn>
  for a label <var>action type</var> is given by the following table:
 
-<table class=simple>
+<table class="simple">
  <thead>
   <tr>
    <th><var>Action type</var>
@@ -7429,7 +7429,7 @@ is also removed.
    <li>Let <var>source</var> be a new <a>input source</a> created from
     the first match against <var>type</var>:
 
-    <dl class=switch>
+    <dl class="switch">
      <dt>"<code>none</code>"
      <dd>Create a new <a>null input source</a>.
 
@@ -7850,7 +7850,7 @@ is also removed.
     <var>source type</var> and the <var>action object</var>'s
     <code>subtype</code> property, to a dispatch action algorithm.
 
-    <table class=simple>
+    <table class="simple">
      <tr>
       <th><var>source type</var>
       <th><code>subtype</code> property
@@ -7931,7 +7931,7 @@ is also removed.
  the second column on the row containing <var>key</var>'s <a>unicode
  code point</a> in the first column, otherwise it is <var>key</var>.
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th><var>key</var>'s codepoint
   <th>Normalised key value
@@ -8022,7 +8022,7 @@ is also removed.
 <!-- TODO This should perhaps return undefined when the shift key
  doesn't match the requirement for producing the character? -->
 
-<table class=simple>
+<table class="simple">
  <tr>
    <th>Key
    <th>Alternate Key
@@ -8136,7 +8136,7 @@ is also removed.
  in the first column, if such a row exists, otherwise it
  is <code>0</code>.
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th><var>key</var>'s codepoint
   <th>Description
@@ -8237,7 +8237,7 @@ is also removed.
   <ul>
    <li><a href="https://w3c.github.io/uievents/#keydown"><code>keyDown</code></a>
     with properties:
-    <table class=simple>
+    <table class="simple">
      <tr>
       <th>Attribute</th>
       <th>Value</th>
@@ -8258,7 +8258,7 @@ is also removed.
 
    <li><a href="https://w3c.github.io/uievents/#keypress"><code>keyPress</code></a>
     with properties:
-    <table class=simple>
+    <table class="simple">
      <tr>
       <th>Attribute</th>
       <th>Value</th>
@@ -8281,7 +8281,7 @@ is also removed.
  <li><p>Return <a>success</a> with data <a>null</a>.
 </ol>
 
-<aside class=note>
+<aside class="note">
  <p>A single <a>keyDown</a> action produces a single key input,
   irrespective of how long the key is held down; there is no implicit
   key repetition.
@@ -8338,7 +8338,7 @@ is also removed.
   <ul>
    <li><a href="https://w3c.github.io/uievents/#keyup"><code>keyup</code></a>,
     with properties:
-    <table class=simple>
+    <table class="simple">
      <tr>
       <th>Attribute</th>
       <th>Value</th>
@@ -8759,7 +8759,7 @@ is also removed.
 
 <p><a>User prompts</a> that are spawned
  from <a><code>beforeunload</code></a> event handlers,
- are <a>dismissed</a> implicitly upon <a data-lt=go>navigation</a> or
+ are <a>dismissed</a> implicitly upon <a data-lt="go">navigation</a> or
  or <a>close window</a>,
  regardless of the defined <a>user prompt handler</a>.
 
@@ -8772,7 +8772,7 @@ is also removed.
  along with the <a>commands</a> that are allowed to interact with it
  as a non-normative reference:
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>Definition
   <th>Dialog
@@ -8826,7 +8826,7 @@ is also removed.
  following <dfn>known prompt handling approaches table</dfn> lists the
  keywords and states for the attribute:
 
-<table class=simple>
+<table class="simple">
  <tr>
   <th>Keyword
   <th>State
@@ -8901,7 +8901,7 @@ argument <var>value</var>:
  <li><p>Perform the following substeps based on the <a>current session</a>'s
   <a>user prompt handler</a>:
 
-  <dl class=switch>
+  <dl class="switch">
    <dt><a>dismiss state</a>
    <dd><p><a>Dismiss</a> the <a>current user prompt</a>.
 
@@ -8937,7 +8937,7 @@ argument <var>value</var>:
  <li><p>Return <a>success</a>.
 </ol>
 
-<aside class=example>
+<aside class="example">
  <p>When returning an <a>error</a> with <a>unexpected alert open</a>,
   a <a>remote end</a> may choose to return the <a>user prompt message</a>
   as part of an additional "<code>data</code>" <a>Object</a>
@@ -9095,7 +9095,7 @@ argument <var>value</var>:
  <li><p>Run the substeps of the first matching
   <a>current user prompt</a>:
 
-  <dl class=switch>
+  <dl class="switch">
    <dt><a>alert</a>
    <dt><a>confirm</a>
    <dd><p>Return <a>error</a> with
@@ -9223,8 +9223,8 @@ argument <var>value</var>:
 
 <p>The <dfn>Take Screenshot</dfn> <a>command</a>
  takes a screenshot of the
- <a href=#>top-level browsing context</a>’s
- <a href=#>viewport</a>.
+ <a href="#">top-level browsing context</a>’s
+ <a href="#">viewport</a>.
 
 <p>The <a>remote end steps</a> are:
 
@@ -9296,7 +9296,7 @@ argument <var>value</var>:
  <li><p>When the user agent is next to <a>run the animation frame callbacks</a>:
   <ol>
    <li><p>Let <var>element rect</var> be <var>element</var>’s
-    <a href=https://drafts.fxtf.org/geometry/#rectangle>rectangle</a>.
+    <a href="https://drafts.fxtf.org/geometry/#rectangle">rectangle</a>.
 
    <li><p>Let <var>screenshot result</var> be the result
     of <a>trying</a> to call
@@ -9317,7 +9317,7 @@ argument <var>value</var>:
 </section> <!-- /Take Element Screenshot -->
 </section> <!-- /Screen Capture -->
 
-<section class=appendix>
+<section class="appendix">
 <h2>Privacy Considerations</h2>
 
 <p>It is advisable that <a>remote ends</a>
@@ -9328,7 +9328,7 @@ argument <var>value</var>:
  and preventing state from bleeding through to the next session.
 </section>
 
-<section class=appendix>
+<section class="appendix">
 <h2>Security Considerations</h2>
 
 <p>A user agent can rely on a command-line flag
@@ -9369,7 +9369,7 @@ argument <var>value</var>:
  so that it easy to identify automation windows.
 </section>
 
-<section class=appendix>
+<section class="appendix">
 <h2>Element Displayedness</h2>
 
 <p>Although WebDriver does not define a primitive
@@ -9409,14 +9409,14 @@ argument <var>value</var>:
  <code>/session/{session id}/element/{element id}/displayed</code>.
 </section> <!-- /Element Displayedness -->
 
-<section class=appendix>
+<section class="appendix">
 <h2>Acknowledgements</h2>
 
 <p>There have been a lot of people that have helped make
- <a href=#h-abstract>browser automation</a> possible over the years
+ <a href="#h-abstract">browser automation</a> possible over the years
  and thereby furthered the goals of this standard.
  In particular, thanks goes to the
- <a href=http://www.seleniumhq.org/>Selenium</a> Open Source community,
+ <a href="http://www.seleniumhq.org/">Selenium</a> Open Source community,
  without which this standard would never have been possible.
 
 <p>This standard is authored by
@@ -9424,11 +9424,11 @@ argument <var>value</var>:
  <!-- ~~~ run sort(1) on this ~~~ -->
 
  <!-- Aleksey Chemakin --> Aleksey Chemakin,
- <!-- Andreas Tolfsen --> <a href=https://sny.no>Andreas Tolfsen</a>,
+ <!-- Andreas Tolfsen --> <a href="https://sny.no">Andreas Tolfsen</a>,
  <!-- Andrey Botalov --> Andrey Botalov,
  <!-- Clayton Martin --> Clayton Martin,
  <!-- Daniel Wagner-Hall --> Daniel Wagner-Hall,
- <!-- David Burns --> <a href=http://www.theautomatedtester.co.uk/>David Burns</a>,
+ <!-- David Burns --> <a href="http://www.theautomatedtester.co.uk/">David Burns</a>,
  <!-- Eran Messeri --> Eran Messeri,
  <!-- Erik Wilde --> Erik Wilde,
  <!-- Gábor Csárdi --> Gábor Csárdi,
@@ -9439,22 +9439,22 @@ argument <var>value</var>:
  <!-- Jim Evans --> Jim Evans,
  <!-- John Jansen --> John Jansen,
  <!-- Luke Inman-Semerau --> Luke Inman-Semerau,
- <!-- Maja Frydrychowicz --> <a href=http://www.erranderr.com/>Maja Frydrychowicz</a>,
+ <!-- Maja Frydrychowicz --> <a href="http://www.erranderr.com/">Maja Frydrychowicz</a>,
  <!-- Malini Das --> Malini Das,
  <!-- Marc Fisher --> Marc Fisher,
  <!-- Mike Pennisi --> Mike Pennisi,
  <!-- Ondřej Machulda --> Ondřej Machulda,
  <!-- Randall Kent --> Randall Kent,
  <!-- Seva Lotoshnikov --> Seva Lotoshnikov,
- <!-- Simon Stewart --> <a href=http://www.rocketpoweredjetpants.com/>Simon Stewart</a>,
+ <!-- Simon Stewart --> <a href="http://www.rocketpoweredjetpants.com/">Simon Stewart</a>,
  <!-- Titus Fortner --> Titus Fortner,
  <!-- Vangelis Katsikaros --> and Vangelis Katsikaros.
 
  <!-- ~~~ end sort ~~~ -->
 
  The work is coordinated and edited by
- <a href=http://www.theautomatedtester.co.uk/>David Burns</a>
- and <a href=http://www.rocketpoweredjetpants.com/>Simon Stewart</a>.
+ <a href="http://www.theautomatedtester.co.uk/">David Burns</a>
+ and <a href="http://www.rocketpoweredjetpants.com/">Simon Stewart</a>.
 
 <p>Thanks to
  Berge Schwebs Bjørlo,


### PR DESCRIPTION
Added quotes to all HTML attributes to improve editor tooling.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/InstyleVII/webdriver/pull/1186.html" title="Last updated on Jan 8, 2018, 8:48 PM GMT (39de95d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1186/e9d00b7...InstyleVII:39de95d.html" title="Last updated on Jan 8, 2018, 8:48 PM GMT (39de95d)">Diff</a>