### PR TITLE
Try to merge capabilities before selecting them.

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2236,17 +2236,25 @@ with a "<code>moz:</code>" prefix:
     <var>validated first match capabilities</var>.
   </ol>
 
+  <li><p>Let <var>merged capabilites</var> be an empty <a>List</a>.
+
   <li><p>For each <var>first match capabilities</var> corresponding
    to an indexed property in <var>validated first match capabilities</var>:
    <ol>
-    <li><p>Let <var>merged capabilities</var> be the result of
+    <li><p>Let <var>merged</var> be the result of
      <a>trying</a> to <a data-lt="merging capabilities">merge
      capabilities</a> with <var>required capabilities</var>
      and <var>first match capabilities</var> as arguments.
 
+    <li><p>Append <var>merged</var> to <var>merged capabilites</var>.
+   </ol>
+
+  <li><p>For each <var>capabilities</var> corresponding
+   to an indexed property in <var>merged capabilities</var>:
+   <ol>
     <li><p>Let <var>matched capabilities</var> be the result of
      <a>trying</a> to <a data-lt="matching capabilities">match
-     capabilities</a> with <var>merged capabilities</var> as an
+     capabilities</a> with <var>capabilities</var> as an
      argument.
 
     <li><p>If <var>matched capabilities</var> is not <a>null</a>,


### PR DESCRIPTION
This means that the session will fail if any capabilities can't be
merged, rather than failing only if the capabilities that can't be merged
are before the ones that are selected. The early failure is consistent
with the early failure for other kinds of validation errors elsewhere.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1204.html" title="Last updated on Jan 23, 2018, 2:00 PM GMT (fa4d3d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1204/877030f...fa4d3d1.html" title="Last updated on Jan 23, 2018, 2:00 PM GMT (fa4d3d1)">Diff</a>