### PR TITLE
mutable form control elements: simplify by saying they have to be mut…

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4437,7 +4437,8 @@ argument <var>reference</var>, run the following steps:
 <dl class=subcategories>
  <dt><dfn data-lt="mutable form control element">Mutable form control elements</dfn>
  <dd><p>Denotes <a><code>input</code> elements</a>
-  whose <a><code>type</code> attribute</a>
+  that are <a>mutable</a> (e.g. that are not <a>read only</a> or <a>disabled</a>)
+  and whose <a><code>type</code> attribute</a>
   is in one of the following states:
 
   <ul class=brief>
@@ -5855,13 +5856,7 @@ argument <var>reference</var>, run the following steps:
 
   <dl class=switch>
    <dt><var>element</var> is a <a>mutable form control element</a>
-   <dd>
-    <ol>
-     <li><p>If <var>element</var> is <a>disabled</a> or <a>read only</a>,
-      return <a>error</a> with <a>error code</a> <a>invalid element state</a>.
-
-     <li><p>Invoke the steps to <a>clear a resettable element</a>.
-    </ol>
+   <dd><p>Invoke the steps to <a>clear a resettable element</a>.
 
    <dt><var>element</var> is a <a>mutable element</a>
    <dd><p>Invoke the steps to <a>clear a content editable element</a>.


### PR DESCRIPTION
…able

To simplify the steps under the Element Clear command we can say
that the  mutable form control elements indeed share the mutable
definition from HTML.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1207.html" title="Last updated on Jan 24, 2018, 9:19 PM GMT (c4511af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1207/877030f...andreastt:c4511af.html" title="Last updated on Jan 24, 2018, 9:19 PM GMT (c4511af)">Diff</a>