### PR TITLE
Limit timeout and cookie expiry time values to the maximum safe integer

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -258,6 +258,7 @@ in the spec, as demonstrated in a (yet to be developed)
    <!-- Array --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-11.1.4>Array</a></dfn>
    <!-- Boolean type --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.14>Boolean</a></dfn> type
    <!-- List --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-8.8>List</a></dfn>
+   <!-- Max Safe Integer --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer>maximum safe integer</a></dfn>
    <!-- null --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.11>Null</a></dfn>
    <!-- Number --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.19>Number</a></dfn>
    <!-- Object --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.2.1>Object</a></dfn>
@@ -3106,7 +3107,7 @@ with a "<code>moz:</code>" prefix:
      return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
    <li><p>If <var>value</var> is not an <a>integer</a>,
-    or it is less than 0 or greater than 2<sup>64</sup> – 1,
+    or it is less than 0 or greater than the <a>maximum safe integer</a>,
     return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
    </ol>
 
@@ -6946,7 +6947,7 @@ must run the following steps:
   the <a>current browsing context</a>’s <a>active document</a>’s <a>domain</a>,
   <a>cookie secure only</a> or <a>cookie HTTP only</a> are not boolean types,
   or <a>cookie expiry time</a> is not an integer type,
-  or it less than 0 or greater than 2<sup>64</sup> – 1,
+  or it less than 0 or greater than the <a>maximum safe integer</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p><a>Create a cookie</a> in


### PR DESCRIPTION
Defined in ECMA:
https://www.ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer

Closes #1202


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/carlosgcampos/webdriver/pull/1210.html" title="Last updated on Jan 25, 2018, 2:57 PM GMT (2be6e8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1210/980cbaf...carlosgcampos:2be6e8b.html" title="Last updated on Jan 25, 2018, 2:57 PM GMT (2be6e8b)">Diff</a>