### PR TITLE
interface: expose navigator.webdriver unconditionally

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -768,32 +768,48 @@ in the spec, as demonstrated in a (yet to be developed)
 </section> <!-- /Terminology -->
 
 <section>
+<h2>Interface</h2>
 
-<h2 data-dfn-for="NavigatorAutomationInformation">Interface</h2>
-
-<p>If the <dfn>webdriver-active flag</dfn> is true,
- the user agent must support <dfn>NavigatorAutomationInformation</dfn> interface:
-
- <pre class=idl>
- Navigator includes NavigatorAutomationInformation;
-</pre>
+<p>
+The <dfn>webdriver-active flag</dfn>
+is set to true when the user agent is under remote control.
+It is initially false.
 
 <pre class=idl>
- interface mixin NavigatorAutomationInformation {
- readonly attribute boolean webdriver; // always returns true
- };
+<a>Navigator</a> includes <a>NavigatorAutomationInformation</a>;
 </pre>
 
-<p data-dfn-for="NavigatorAutomationInformation">Note that the <dfn>webdriver</dfn>
- property should not be exposed on <code><a>WorkerNavigator</a></code>, and it must be
- a getter that always returns true.
+<p>
+Note that the <a><code>NavigatorAutomationInformation</code></a> interface
+should not be exposed on <a><code>WorkerNavigator</code></a>.
 
-<p>This property defines a standard way for a co-operating user agent to inform a website
-  that it is controlled by WebDriver.
+<pre class=idl>
+interface mixin <dfn>NavigatorAutomationInformation</dfn> {
+	readonly attribute boolean <a>webdriver</a>;
+};
+</pre>
 
-<p class="note" style="display: none">It is acknowledged that this is
- complementary to the Evil Bit [[!RFC3514]].
+<dl>
+<dt><dfn data-lt=navigator-webdriver><code>webdriver</code></dfn>
+<dd><p>Returns true if <a>webdriver-active flag</a> is true,
+false otherwise.
+</dl>
 
+<aside class=example>
+<p>
+For web authors (non-normative):
+
+<dl>
+<dt><code>navigator</code>.<a><code>webdriver</code></a>
+<dd><p>
+Defines a standard way for co-operating user agents
+to inform the document that it is controlled by WebDriver,
+for example so that alternate code paths can be triggered during automation.
+</dl>
+</aside>
+
+<p style="display: none">
+It is acknowledged that this is complementary to the Evil Bit [[!RFC3514]].
 </section>
 
 <section>


### PR DESCRIPTION
The navigator.webdriver WebIDL attribute is currently only meant
to be exposed when the webdriver-active flag is true.  Safari and
Edge expose the attribute unconditionally, and Gecko plans to follow
suit.

Making the attribute selectively present, which is unlike any other
web features are implemented, forces web authors to detect automation
in the following way:

	var underAutomation = ("webdriver" in navigator) ? navigator.webdriver : false;

Following this patch, web authors can do this:

	var underAutomation = navigator.webdriver;

Fixes: https://github.com/w3c/webdriver/issues/1214


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1219.html" title="Last updated on Feb 2, 2018, 8:00 PM GMT (c9a12ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1219/320745c...andreastt:c9a12ed.html" title="Last updated on Feb 2, 2018, 8:00 PM GMT (c9a12ed)">Diff</a>