### PR TITLE
interface: webdriver-active flag is not a boolean

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -790,9 +790,9 @@ interface mixin <dfn>NavigatorAutomationInformation</dfn> {
 </pre>
 
 <dl>
-<dt><dfn data-lt=navigator-webdriver><code>webdriver</code></dfn>
-<dd><p>Returns true if <a>webdriver-active flag</a> is true,
-false otherwise.
+<dt>
+<dfn data-lt=navigator-webdriver><code>webdriver</code></dfn>
+<dd><p>Returns true if <a>webdriver-active flag</a> is set, false otherwise.
 </dl>
 
 <aside class=example>


### PR DESCRIPTION
Small fixup to a224627 because webdriver-active is a flag, not a
boolean.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1220.html" title="Last updated on Feb 3, 2018, 3:34 PM GMT (e62ea8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1220/a224627...andreastt:e62ea8e.html" title="Last updated on Feb 3, 2018, 3:34 PM GMT (e62ea8e)">Diff</a>