### PR TITLE
interface: fix WebIDL links after ReSpec 19.1.1 release

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -767,7 +767,7 @@ in the spec, as demonstrated in a (yet to be developed)
  and decorations (such as operating system widget borders).
 </section> <!-- /Terminology -->
 
-<section>
+<section data-dfn-for=NavigatorAutomationInformation data-link-for=NavigatorAutomationInformation>
 <h2>Interface</h2>
 
 <p>
@@ -785,14 +785,14 @@ should not be exposed on <a><code>WorkerNavigator</code></a>.
 
 <pre class=idl>
 interface mixin <dfn>NavigatorAutomationInformation</dfn> {
-	readonly attribute boolean <a>webdriver</a>;
+	readonly attribute boolean webdriver;
 };
 </pre>
 
 <dl>
-<dt>
-<dfn data-lt=navigator-webdriver><code>webdriver</code></dfn>
-<dd><p>Returns true if <a>webdriver-active flag</a> is set, false otherwise.
+<dt><dfn>webdriver</dfn>
+<dd>
+<p>Returns true if <a>webdriver-active flag</a> is set, false otherwise.
 </dl>
 
 <aside class=example>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1221.html" title="Last updated on Feb 6, 2018, 2:08 PM GMT (97ec338)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1221/3b6ccb7...andreastt:97ec338.html" title="Last updated on Feb 6, 2018, 2:08 PM GMT (97ec338)">Diff</a>