### PR TITLE
Remove normative descriptions

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6602,7 +6602,7 @@ of the <a>current browsing context</a> <a>active document</a>.
  </tr>
 </table>
 
-<p class=note
+<p class=note>
 The <a>Execute Async Script</a> <a>command</a>
 causes JavaScript to execute as an anonymous function.
 Unlike the <a>Execute Script</a> <a>command</a>,

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -8765,24 +8765,27 @@ is also removed.
 </ol>
 </section> <!-- /Perform Actions -->
 
-<section><!-- Release Actions -->
-<h2>Release Actions</h2>
+<section>
+<h2><dfn>Release Actions</dfn></h2>
+
 <table class="simple jsoncommand">
  <tr>
-  <th>HTTP Method</th>
-  <th>URI Template</th>
+  <th>HTTP Method
+  <th>URI Template
  </tr>
  <tr>
-  <td>DELETE</td>
-  <td>/session/{<var>session id</var>}/actions</td>
+  <td>DELETE
+  <td>/session/{<var>session id</var>}/actions
  </tr>
 </table>
 
-<p>The <dfn>Release Actions</dfn> <a>command</a> is used to release
- all the keys and pointer buttons that are currently depressed. This
- causes events to be <a>fired</a> as if the state was released by an
- explicit series of actions. It also clears all the internal state of
- the virtual devices.
+<p class=note>
+The <a>Release Actions</a> <a>command</a>
+is used to release all the keys and pointer buttons
+that are currently depressed.
+This causes events to be <a>fired</a>
+as if the state was released by an explicit series of actions.
+It also clears all the internal state of the virtual devices.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6825,7 +6825,7 @@ This is a function that, when called, returns its first argument as the response
 </ol>
 
 <section>
-<h3>Get All Cookies</h3>
+<h3><dfn>Get All Cookies</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -6837,10 +6837,6 @@ This is a function that, when called, returns its first argument as the response
   <td>/session/{<var>session id</var>}/cookie</td>
  </tr>
 </table>
-
-<p>The <dfn>Get All Cookies</dfn> <a>command</a>
- returns all <a>cookies</a> associated with the <a>address</a>
- of the <a>current browsing context</a>’s <a>active document</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4984,7 +4984,7 @@ session.execute("arguments[0].remove()", [body]);
 </section> <!-- /Find Elements -->
 
 <section>
-<h3>Find Element From Element</h3>
+<h3><dfn>Find Element From Element</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -4996,11 +4996,6 @@ session.execute("arguments[0].remove()", [body]);
   <td>/session/{<var>session id</var>}/element/{<var>element id</var>}/element</td>
  </tr>
 </table>
-
-<p>The <dfn>Find Element From Element</dfn> <a>command</a>
- is used to find an <a>element</a> from a <a>web element</a>
- in the <a>current browsing context</a>
- that can be used for future <a>commands</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5423,7 +5423,7 @@ with the <a>Unicode character property</a> <code>"WSpace=Y"</code>.
 </section> <!-- /Get Element Text -->
 
 <section>
-<h3>Get Element Tag Name</h3>
+<h3><dfn>Get Element Tag Name</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5435,9 +5435,6 @@ with the <a>Unicode character property</a> <code>"WSpace=Y"</code>.
   <td>/session/{<var>session id</var>}/element/{<var>element id</var>}/name</td>
  </tr>
 </table>
-
-<p>The <dfn>Get Element Tag Name</dfn> <a>command</a>
- returns the <a>qualified element name</a> of the given <a>web element</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5321,7 +5321,7 @@ The <a>remote end steps</a> are:
 </section> <!-- /Get Element Property -->
 
 <section>
-<h3>Get Element CSS Value</h3>
+<h3><dfn>Get Element CSS Value</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5334,11 +5334,8 @@ The <a>remote end steps</a> are:
  </tr>
 </table>
 
-<p>The <dfn>Get Element CSS Value</dfn> <a>command</a>
- retrieves the <a>computed value</a>
- of the given CSS property of the given <a>web element</a>.
-
-<p>The <a>remote end steps</a> are:
+<p>
+The <a>remote end steps</a> are:
 
 <ol>
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -9317,25 +9317,25 @@ sets the text field of a <a>window.<code>prompt</code></a>
 </section> <!-- /Take Screenshot -->
 
 <section>
-<h3>Take Element Screenshot</h3>
+<h3><dfn>Take Element Screenshot</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
-  <th>HTTP Method</th>
-  <th>URI Template</th>
+  <th>HTTP Method
+  <th>URI Template
  </tr>
  <tr>
-  <td>GET</td>
-  <td>/session/{<var>session id</var>}/element/{<var>element id</var>}/screenshot</td>
+  <td>GET
+  <td>/session/{<var>session id</var>}/element/{<var>element id</var>}/screenshot
  </tr>
 </table>
 
-<p>The <dfn>Take Element Screenshot</dfn> <a>command</a>
- takes a screenshot of the visible region encompassed
- by the <a>bounding rectangle</a> of an <a>element</a>.
- If given a parameter argument <code>scroll</code>
- that evaluates to false,
- the <a>element</a> will not be <a>scrolled into view</a>.
+<p class=note>
+The <a>Take Element Screenshot</a> <a>command</a>
+takes a screenshot of the visible region encompassed
+by the <a>bounding rectangle</a> of an <a>element</a>.
+If given a parameter argument <code>scroll</code>
+that evaluates to false, the <a>element</a> will not be <a>scrolled into view</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3641,10 +3641,6 @@ If the creation fails, a <a>session not created</a> <a>error</a> is returned.
  </tr>
 </table>
 
-<p class=note>This command returns the <a>window handle</a>
- for the <a>current top-level browsing context</a>.
- It can be used as an argument to <a>Switch To Window</a>.
-
 <p>The <a>remote end steps</a> are:
 
 <ol>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6536,7 +6536,7 @@ of the <a>current browsing context</a> <a>active document</a>.
  and is therefore not subject to the document CSP <a>directives</a>.
 
 <section>
-<h3>Execute Script</h3>
+<h3><dfn>Execute Script</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -6548,10 +6548,6 @@ of the <a>current browsing context</a> <a>active document</a>.
   <td>/session/{<var>session id</var>}/execute/sync</td>
  </tr>
 </table>
-
-<p>The <dfn>Execute Script</dfn> <a>command</a>
- executes a JavaScript function in the context of the <a>current browsing context</a>
- and returns the return value of the function.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5539,7 +5539,7 @@ Width of the <a>web element</a>’s
 </section> <!-- /Get Element Rect -->
 
 <section>
-<h3>Is Element Enabled</h3>
+<h3><dfn>Is Element Enabled</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5551,10 +5551,6 @@ Width of the <a>web element</a>’s
   <td>/session/{<var>session id</var>}/element/{<var>element id</var>}/enabled</td>
  </tr>
 </table>
-
-<p><dfn>Is Element Enabled</dfn> determines
- if the referenced <a>element</a> is enabled or not.
- This operation only makes sense on form controls.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4300,12 +4300,6 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p class=note>The <a>Fullscreen Window</a> command
- invokes the window manager-specific “full screen” operation, if any,
- on the window containing the <a>current top-level browsing context</a>.
- This typically increases the window to the size of the physical display
- and can hide browser chrome elements such as toolbars.
-
 <p>The <a>remote end steps</a> are:
 
 <ol>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6589,7 +6589,7 @@ of the <a>current browsing context</a> <a>active document</a>.
 </section> <!-- /Execute Script -->
 
 <section>
-<h3>Execute Async Script</h3>
+<h3><dfn>Execute Async Script</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -6602,12 +6602,13 @@ of the <a>current browsing context</a> <a>active document</a>.
  </tr>
 </table>
 
-<p>The <dfn>Execute Async Script</dfn> <a>command</a>
- causes JavaScript to execute as an anonymous function.
- Unlike the <a>Execute Script</a> <a>command</a>,
- the result of the function is ignored.
- Instead an additional argument is provided as the final argument to the function.
- This is a function that, when called, returns its first argument as the response.
+<p class=note
+The <a>Execute Async Script</a> <a>command</a>
+causes JavaScript to execute as an anonymous function.
+Unlike the <a>Execute Script</a> <a>command</a>,
+the result of the function is ignored.
+instead an additional argument is provided as the final argument to the function.
+This is a function that, when called, returns its first argument as the response.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5890,7 +5890,7 @@ an <a>element not interactable</a> <a>error</a> is returned.
 </section> <!-- /Element Clear -->
 
 <section>
-<h3>Element Send Keys</h3>
+<h3><dfn>Element Send Keys</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5903,11 +5903,12 @@ an <a>element not interactable</a> <a>error</a> is returned.
  </tr>
 </table>
 
-<p>The <dfn>Element Send Keys</dfn> <a>command</a>
- <a>scrolls into view</a> the form control <a>element</a>
- and then sends the provided keys to the <a>element</a>.
- In case the <a>element</a> is not <a>keyboard-interactable</a>,
- an <a>element not interactable</a> <a>error</a> is returned.
+<p class=note>
+The <a>Element Send Keys</a> <a>command</a>
+<a>scrolls into view</a> the form control <a>element</a>
+and then sends the provided keys to the <a>element</a>.
+In case the <a>element</a> is not <a>keyboard-interactable</a>,
+an <a>element not interactable</a> <a>error</a> is returned.
 
 <p>The <a>key input state</a> used for input
  may be cleared mid-way through “typing”

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -9028,7 +9028,7 @@ argument <var>value</var>:
 </aside>
 
 <section>
-<h3>Dismiss Alert</h3>
+<h3><dfn>Dismiss Alert</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -9041,12 +9041,13 @@ argument <var>value</var>:
  </tr>
 </table>
 
-<p>The <dfn>Dismiss Alert</dfn> <a>command</a>
- <a>dismisses</a> a <a>simple dialog</a>
- if <a data-lt="current user prompt">present</a>.
- A request to <a>dismiss</a> an <a>alert</a> <a>user prompt</a>,
- which may not necessarily have a dismiss button,
- has the same effect as <a>accepting</a> it.
+<p class=note>
+The <a>Dismiss Alert</a> <a>command</a>
+<a>dismisses</a> a <a>simple dialog</a>
+if <a data-lt="current user prompt">present</a>.
+A request to <a>dismiss</a> an <a>alert</a> <a>user prompt</a>,
+which may not necessarily have a dismiss button,
+has the same effect as <a>accepting</a> it.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5178,7 +5178,7 @@ session.execute("arguments[0].remove()", [body]);
 </dl>
 
 <section>
-<h3>Is Element Selected</h3>
+<h3><dfn>Is Element Selected</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5191,11 +5191,12 @@ session.execute("arguments[0].remove()", [body]);
  </tr>
 </table>
 
-<p><dfn>Is Element Selected</dfn> determines
- if the referenced <a>element</a> is selected or not.
- This operation only makes sense on <a data-lt="input element"><code>input</code> elements</a>
- of the <a>Checkbox</a>- and <a>Radio Button</a> states,
- or <a><code>option</code> elements</a>.
+<p class=note>
+The <a>Is Element Selected</a> <a>command</a>
+determines if the referenced <a>element</a> is selected or not.
+This operation only makes sense on <a data-lt="input element"><code>input</code> elements</a>
+of the <a>Checkbox</a>- and <a>Radio Button</a> states,
+or on <a><code>option</code> elements</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -9065,7 +9065,7 @@ has the same effect as <a>accepting</a> it.
 </section>
 
 <section>
-<h3>Accept Alert</h3>
+<h3><dfn>Accept Alert</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -9077,10 +9077,6 @@ has the same effect as <a>accepting</a> it.
   <td>/session/{<var>session id</var>}/alert/accept</td>
  </tr>
 </table>
-
-<p>The <dfn>Accept Alert</dfn> <a>command</a>
- <a>accepts</a> a <a>simple dialog</a>
- if <a data-lt="current user prompt">present</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5364,7 +5364,7 @@ The <a>remote end steps</a> are:
 </section> <!-- /Get CSS Value -->
 
 <section>
-<h3>Get Element Text</h3>
+<h3><dfn>Get Element Text</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5377,22 +5377,28 @@ The <a>remote end steps</a> are:
  </tr>
 </table>
 
-<p>The <dfn>Get Element Text</dfn> <a>command</a> intends to return
- an <a>element</a>’s text “as rendered”. An <a>element</a>’s rendered
- text is also used for locating <a><code>a</code> elements</a> by
- their <a>link text</a> and <a>partial link text</a>.
+<aside class=note>
+<p>
+The <a>Get Element Text</a> <a>command</a>
+intends to return an <a>element</a>’s text “as rendered”.
+An <a>element</a>’s rendered text is also used
+for locating <a><code>a</code> elements</a>
+by their <a>link text</a> and <a>partial link text</a>.
 
-<p class=note>One of the major inputs to this specification was the
- Open Source <a href="http://www.seleniumhq.org">Selenium</a>
- project. This was in wide-spread use before this specification
- written, and so had set user expectations of how the <a>Get Element
- Text</a> command should work. As such, the approach presented here is
- known to be flawed, but provides the best compatibility with existing
- users.
+<p>
+One of the major inputs to this specification
+was the open source <a href=https://www.seleniumhq.org>Selenium project</a>.
+This was in wide-spread use before this specification written,
+and so had set user expectations
+of how the <a>Get Element Text</a> command should work.
+As such, the approach presented here is known to be flawed,
+but provides the best compatibility with existing users.
+</aside>
 
-<p>When processing text, <dfn>whitespace</dfn> is defined as
- characters from the Unicode Character Database ([[UAX44]]) with the
- <a>Unicode character property</a> <code>"WSpace=Y"</code>.
+<p>
+When processing text, <dfn>whitespace</dfn> is defined as
+characters from the Unicode Character Database ([[UAX44]])
+with the <a>Unicode character property</a> <code>"WSpace=Y"</code>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6896,7 +6896,7 @@ This is a function that, when called, returns its first argument as the response
 </section> <!-- /Get Named Cookie -->
 
 <section>
-<h3>Add Cookie</h3>
+<h3><dfn data-lt="adding a cookie">Add Cookie</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -6908,10 +6908,6 @@ This is a function that, when called, returns its first argument as the response
   <td>/session/{<var>session id</var>}/cookie</td>
  </tr>
 </table>
-
-<p>The <dfn data-lt="adding a cookie">Add Cookie</dfn> <a>command</a>
- adds a single <a>cookie</a> to the <a>cookie store</a>
- associated with the <a>active document</a>’s <a>address</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5617,7 +5617,7 @@ Width of the <a>web element</a>’s
  to an empty string (thus clearing the element’s child nodes).
 
 <section>
-<h3>Element Click</h3>
+<h3><dfn>Element Click</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5630,15 +5630,20 @@ Width of the <a>web element</a>’s
  </tr>
 </table>
 
-<p>The <dfn>Element Click</dfn> <a>command</a>
- <a>scrolls into view</a> the <a>element</a>
- if it is not already <a>pointer-interactable</a>,
- and clicks its <a>in-view center point</a>.
- If the element’s <a>center point</a>
- is <a>obscured</a> by another element,
- an <a>element click intercepted</a> <a>error</a> is returned.
- If the element is outside the <a>viewport</a>,
- an <a>element not interactable</a> <a>error</a> is returned.
+<aside class=note>
+<p>
+The <a>Element Click</a> <a>command</a>
+<a>scrolls into view</a> the <a>element</a>
+if it is not already <a>pointer-interactable</a>,
+and clicks its <a>in-view center point</a>.
+
+<p>
+If the element’s <a>center point</a>
+is <a>obscured</a> by another element,
+an <a>element click intercepted</a> <a>error</a> is returned.
+If the element is outside the <a>viewport</a>,
+an <a>element not interactable</a> <a>error</a> is returned.
+</aside>
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3698,10 +3698,11 @@ If the creation fails, a <a>session not created</a> <a>error</a> is returned.
   </tr>
 </table>
 
-<p class=note>This command is used
- to select the <a>current top-level browsing context</a>
- for the current <a>session</a>,
- i.e. the one that will be used for processing <a>commands</a>.
+<p class=note>
+Switching window will select the <a>current top-level browsing context</a>
+used as the target for all subsequent <a>commands</a>.
+In a tabbed browser, this will typically
+make the tab containing the <a>browsing context</a> the selected tab.
 
 <p>The <a>remote end steps</a> are:
 
@@ -3727,9 +3728,6 @@ If the creation fails, a <a>session not created</a> <a>error</a> is returned.
  <li><p>Update any implementation-specific state that would result
   from the user selecting the <a>current browsing context</a> for
   interaction, without altering OS-level focus.
-
-  <p class="note">For example in a tabbed browser, make the tab
-   containing the browsing context the selected tab.
 
  <li><p>Return <a>success</a> with date <a>null</a>.
 </ol>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5245,7 +5245,8 @@ or on <a><code>option</code> elements</a>.
   </tr>
 </table>
 
-<p>The <a>remote end steps</a> are:
+<p>
+The <a>remote end steps</a> are:
 
 <ol>
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
@@ -5283,7 +5284,7 @@ or on <a><code>option</code> elements</a>.
 </section> <!-- /Get Element Attribute -->
 
 <section>
-<h3>Get Element Property</h3>
+<h3><dfn>Get Element Property</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5296,10 +5297,8 @@ or on <a><code>option</code> elements</a>.
  </tr>
 </table>
 
-<p>The <dfn>Get Element Property</dfn> <a>command</a>
- will return the result of <a>getting a property</a> of an <a>element</a>.
-
-<p>The <a>remote end steps</a> are:
+<p>
+The <a>remote end steps</a> are:
 
 <ol>
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -9275,7 +9275,7 @@ sets the text field of a <a>window.<code>prompt</code></a>
 </ol>
 
 <section>
-<h3>Take Screenshot</h3>
+<h3><dfn>Take Screenshot</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -9287,11 +9287,6 @@ sets the text field of a <a>window.<code>prompt</code></a>
   <td>/session/{<var>session id</var>}/screenshot</td>
  </tr>
 </table>
-
-<p>The <dfn>Take Screenshot</dfn> <a>command</a>
- takes a screenshot of the
- <a href=#>top-level browsing context</a>’s
- <a href=#>viewport</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6863,7 +6863,7 @@ This is a function that, when called, returns its first argument as the response
 </section> <!-- /Get All Cookies -->
 
 <section>
-<h3>Get Named Cookie</h3>
+<h3><dfn>Get Named Cookie</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -6875,13 +6875,6 @@ This is a function that, when called, returns its first argument as the response
   <td>/session/{<var>session id</var>}/cookie/{<var>name</var>}</td>
  </tr>
 </table>
-
-<p>The <dfn>Get Named Cookie</dfn> <a>command</a>
- returns the <a>cookie</a> with the requested name
- from the <a>associated cookies</a> in the <a>cookie store</a>
- of the <a>current browsing context</a>’s <a>active document</a>.
- If no cookie is found,
- a <a>no such cookie</a> <a>error</a> is returned.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5032,7 +5032,7 @@ session.execute("arguments[0].remove()", [body]);
 </section> <!-- /Find Element From Element -->
 
 <section>
-<h3>Find Elements From Element</h3>
+<h3><dfn>Find Elements From Element</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5044,11 +5044,6 @@ session.execute("arguments[0].remove()", [body]);
   <td>/session/{<var>session id</var>}/element/{<var>element id</var>}/elements</td>
  </tr>
 </table>
-
-<p>The <dfn>Find Elements From Element</dfn> <a>command</a>
- is used to find elements from a <a>web element</a>
- in the <a>current browsing context</a>
- that can be used for future <a>commands</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -7234,8 +7234,7 @@ is also removed.
  up in implementation-specific territory. However there are certain
  content observable effects that must be consistent across
  implementations. To accommodate this, the specification requires
- that <a>remote ends</a> <dfn data-lt="perform-actions|perform
- actions"> perform implementation-specific action dispatch
+ that <a>remote ends</a> <dfn>perform implementation-specific action dispatch
  steps</dfn>, along with a list of events and their properties. This
  list is not comprehensive; in particular the default action of the
  <a>input source</a> may cause additional events to be generated depending on
@@ -8730,30 +8729,21 @@ is also removed.
 </section> <!-- /Dispatching Actions -->
 
 
-<section> <!-- Perform Actions -->
-<h2>Perform Actions</h2>
+<section>
+<h2><dfn>Perform Actions</dfn></h2>
 
 <table class="simple jsoncommand">
  <tr>
-  <th>HTTP Method</th>
-  <th>URI Template</th>
+  <th>HTTP Method
+  <th>URI Template
  </tr>
  <tr>
-  <td>POST</td>
-  <td>/session/{<var>session id</var>}/actions</td>
+  <td>POST
+  <td>/session/{<var>session id</var>}/actions
  </tr>
 </table>
 
-<section> <!-- Payload Format -->
-<h2>Payload Format</h2>
-<p><i>This section is non-normative.</i>
-<!-- TODO -->
-</section> <!-- /Payload Format -->
-
-
-<section> <!-- Remote End Steps -->
-<h2>Remote End Steps</h2>
-<p>The <a>remote end steps</a> are:</p>
+<p>The <a>remote end steps</a> are:
 
 <ol>
  <li><p>Let <var>actions by tick</var> be the result of <a>trying</a>
@@ -8773,9 +8763,7 @@ is also removed.
 
  <li><p>Return <a>success</a> with data <a>null</a>.
 </ol>
-</section> <!-- Remote End Steps -->
-</section> <!-- Perform Actions -->
-
+</section> <!-- /Perform Actions -->
 
 <section><!-- Release Actions -->
 <h2>Release Actions</h2>

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -6235,8 +6235,9 @@ must run the following steps:
 
 <section>
 <h2>Document Handling</h2>
+
 <section>
-<h3>Getting Page Source</h3>
+<h3><dfn>Get Page Source</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -6249,9 +6250,10 @@ must run the following steps:
  </tr>
 </table>
 
-<p>The <dfn>Get Page Source</dfn> <a>command</a>
- returns a string serialization of the DOM
- of the <a>current browsing context</a> <a>active document</a>.
+<p class=note>
+The <a>Get Page Source</a> <a>command</a>
+returns a string serialization of the DOM
+of the <a>current browsing context</a> <a>active document</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4076,9 +4076,10 @@ make the tab containing the <a>browsing context</a> the selected tab.
  </tr>
 </table>
 
-<p class=ntoe>The <a>Set Window Rect</a> <a>command</a>
- alters the size and the position of the operating system window
- corresponding to the <a>current top-level browsing context</a>.
+<p class=note>
+The <a>Set Window Rect</a> <a>command</a>
+alters the size and the position of the operating system window
+corresponding to the <a>current top-level browsing context</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -2713,7 +2713,7 @@ with a "<code>moz:</code>" prefix:
  so that the <a>connection</a> is not prematurely closed.
 
 <section>
-<h3>New Session</h3>
+<h3><dfn data-lt="creating a new session">New Session</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -2726,10 +2726,10 @@ with a "<code>moz:</code>" prefix:
  </tr>
 </table>
 
-<p>The <dfn data-lt="creating a new session">New Session</dfn> <a>command</a>
- creates a new WebDriver <a>session</a> with the <a>endpoint node</a>.
- If the creation fails,
- a <a>session not created</a> <a>error</a> is returned.
+<p>
+The <a>New Session</a> <a>command</a>
+creates a new WebDriver <a>session</a> with the <a>endpoint node</a>.
+If the creation fails, a <a>session not created</a> <a>error</a> is returned.
 
 <p>If the <a>remote end</a> is an <a>intermediary node</a>,
  it MAY use the result of the <a>capabilities processing</a> algorithm

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -9094,7 +9094,7 @@ has the same effect as <a>accepting</a> it.
 </section>
 
 <section>
-<h3>Get Alert Text</h3>
+<h3><dfn>Get Alert Text</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -9106,10 +9106,6 @@ has the same effect as <a>accepting</a> it.
   <td>/session/{<var>session id</var>}/alert/text</td>
  </tr>
 </table>
-
-<p>The <dfn>Get Alert Text</dfn> <a>command</a>
- returns the message of the <a>current user prompt</a>.
- If there is no <a>current user prompt</a>, it returns an <a>error</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5232,7 +5232,7 @@ or on <a><code>option</code> elements</a>.
 </section> <!-- /Is Element Selected -->
 
 <section>
-<h3>Get Element Attribute</h3>
+<h3><dfn>Get Element Attribute</dfn></h3>
 
 <table class="simple jsoncommand">
   <tr>
@@ -5244,9 +5244,6 @@ or on <a><code>option</code> elements</a>.
     <td>/session/{<var>session id</var>}/element/{<var>element id</var>}/attribute/{<var>name</var>}</td>
   </tr>
 </table>
-
-<p>The <dfn>Get Element Attribute</dfn> <a>command</a>
- will return the <a>attribute</a> of a <a>web element</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -9125,7 +9125,7 @@ has the same effect as <a>accepting</a> it.
 </section>
 
 <section>
-<h3>Send Alert Text</h3>
+<h3><dfn>Send Alert Text</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -9138,9 +9138,10 @@ has the same effect as <a>accepting</a> it.
  </tr>
 </table>
 
-<p>The <dfn>Send Alert Text</dfn> <a>command</a>
- sets the text field of a <a>window.<code>prompt</code></a>
- <a>user prompt</a> to the given value.
+<p class=note>
+The <a>Send Alert Text</a> <a>command</a>
+sets the text field of a <a>window.<code>prompt</code></a>
+<a>user prompt</a> to the given value.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5075,7 +5075,7 @@ session.execute("arguments[0].remove()", [body]);
 </section> <!-- /Find Elements From Element -->
 
 <section>
-<h3>Get Active Element</h3>
+<h3><dfn>Get Active Element</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5087,11 +5087,6 @@ session.execute("arguments[0].remove()", [body]);
   <td>/session/{<var>session id</var>}/element/active</td>
  </tr>
 </table>
-
-<p><dfn>Get Active Element</dfn> returns
- the <a href=https://html.spec.whatwg.org/#dom-document-activeelement>active element</a>
- of the <a>current browsing context</a>’s
- <a href=https://dom.spec.whatwg.org/#concept-element>document element</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4871,7 +4871,7 @@ argument <var>reference</var>, run the following steps:
 </section> <!-- /Locator Strategies -->
 
 <section>
-<h3>Find Element</h3>
+<h3><dfn>Find Element</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -4884,9 +4884,23 @@ argument <var>reference</var>, run the following steps:
  </tr>
 </table>
 
-<p>The <dfn>Find Element</dfn> <a>command</a>
- is used to find an <a>element</a> in the <a>current browsing context</a>
- that can be used for future <a>commands</a>.
+<aside class=note>
+<p>
+The <a>Find Element</a> <a>command</a>
+is used to find an <a>element</a> in the <a>current browsing context</a>
+that can be used as the <a>web element</a> context
+for future element-centric <a>commands</a>.
+
+<p>
+For example, consider this pseudo code
+which retrieves an element with the <code>#toremove</code> ID
+and uses this as the argument for a script it injects
+to remove it from the HTML document:
+
+<pre><code>let body = session.find.css("#toremove");
+session.execute("arguments[0].remove()", [body]);
+</code></pre>
+</aside>
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -3747,9 +3747,6 @@ make the tab containing the <a>browsing context</a> the selected tab.
  </tr>
 </table>
 
-<p class=note>This command returns a list of <a>window handles</a>
- for every open <a>top-level browsing context</a>.
-
 <p>The order in which the window handles are returned is arbitrary.
 
 <p>The <a>remote end steps</a> are:

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -4939,7 +4939,7 @@ session.execute("arguments[0].remove()", [body]);
 </section> <!-- /Find Element -->
 
 <section>
-<h3>Find Elements</h3>
+<h3><dfn>Find Elements</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -4951,10 +4951,6 @@ session.execute("arguments[0].remove()", [body]);
   <td>/session/{<var>session id</var>}/elements</td>
  </tr>
 </table>
-
-<p>The <dfn>Find Elements</dfn> <a>command</a>
- is used to find <a>elements</a> in the <a>current browsing context</a>
- that can be used for future <a>commands</a>.
 
 <p>The <a>remote end steps</a> are:
 

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5456,7 +5456,7 @@ with the <a>Unicode character property</a> <code>"WSpace=Y"</code>.
 </section> <!-- /Get Element Tag Name -->
 
 <section>
-<h3>Get Element Rect</h3>
+<h3><dfn>Get Element Rect</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -5469,29 +5469,36 @@ with the <a>Unicode character property</a> <code>"WSpace=Y"</code>.
  </tr>
 </table>
 
-<p>The <dfn>Get Element Rect</dfn> command returns
- the dimensions and coordinates of the given <a>web element</a>.
- The returned value is a dictionary with the following members:
+<aside class=note>
+<p>
+The <a>Get Element Rect</a> <a>command</a>
+returns the dimensions and coordinates of the given <a>web element</a>.
+The returned value is a dictionary with the following members:
 
 <dl>
- <dt><dfn data-lt="elementrect-x">x</dfn>
- <dd>X axis position of the top-left corner of the <a>web element</a>
-  relative to the <a>current browsing context</a>’s
-  <a>document element</a> in <a>CSS pixels</a>.
+<dt><dfn data-lt="elementrect-x">x</dfn>
+<dd>
+X axis position of the top-left corner of the <a>web element</a>
+relative to the <a>current browsing context</a>’s
+<a>document element</a> in <a>CSS pixels</a>.
 
- <dt><dfn data-lt="elementrect-y">y</dfn>
- <dd>Y axis position of the top-left corner of the <a>web element</a>
-  relative to the <a>current browsing context</a>’s
-  <a>document element</a> in <a>CSS pixels</a>.
+<dt><dfn data-lt="elementrect-y">y</dfn>
+<dd>
+Y axis position of the top-left corner of the <a>web element</a>
+relative to the <a>current browsing context</a>’s
+<a>document element</a> in <a>CSS pixels</a>.
 
- <dt><dfn data-lt="elementrect-height">height</dfn>
- <dd>Height of the <a>web element</a>’s
-  <a>bounding rectangle</a> in <a>CSS pixels</a>.
+<dt><dfn data-lt="elementrect-height">height</dfn>
+<dd>
+Height of the <a>web element</a>’s
+<a>bounding rectangle</a> in <a>CSS pixels</a>.
 
- <dt><dfn data-lt="elementrect-width">width</dfn>
- <dd>Width of the <a>web element</a>’s
-  <a>bounding rectangle</a> in <a>CSS pixels</a>.
+<dt><dfn data-lt="elementrect-width">width</dfn>
+<dd>
+Width of the <a>web element</a>’s
+<a>bounding rectangle</a> in <a>CSS pixels</a>.
 </dl>
+</aside>
 
 <p>The <a>remote end steps</a> are:
 


### PR DESCRIPTION
This PR is a continuation of https://github.com/w3c/webdriver/issues/1105 to remove/improve/adapt command descriptions that could be mistaken as normative.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1231.html" title="Last updated on Feb 21, 2018, 4:28 PM GMT (32317d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1231/976387e...andreastt:32317d7.html" title="Last updated on Feb 21, 2018, 4:28 PM GMT (32317d7)">Diff</a>