### PR TITLE
handling errors: remove unused invalid coordinates error

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1662,13 +1662,6 @@ It is acknowledged that this is complementary to the Evil Bit [[!RFC3514]].
  </tr>
 
  <tr>
-  <td><dfn>invalid coordinates</dfn>
-  <td>400
-  <td><code>invalid coordinates</code>
-  <td>The coordinates provided to an interactions operation are invalid.
- </tr>
-
- <tr>
   <td><dfn>invalid element state</dfn>
   <td>400
   <td><code>invalid element state</code>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1235.html" title="Last updated on Feb 26, 2018, 5:30 PM GMT (6522798)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1235/13c488e...andreastt:6522798.html" title="Last updated on Feb 26, 2018, 5:30 PM GMT (6522798)">Diff</a>