### PR TITLE
user prompts: add missing stacktrace field to example

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -9004,15 +9004,17 @@ argument <var>value</var>:
 </ol>
 
 <aside class=example>
- <p>When returning an <a>error</a> with <a>unexpected alert open</a>,
-  a <a>remote end</a> may choose to return the <a>user prompt message</a>
-  as part of an additional "<code>data</code>" <a>Object</a>
-  on the <a data-lt="send an error">error representation</a>:
+<p>
+When returning an <a>error</a> with <a>unexpected alert open</a>,
+a <a>remote end</a> may choose to return the <a>user prompt message</a>
+as part of an additional "<code>data</code>" <a>Object</a>
+on the <a data-lt="send an error">error representation</a>:
 
- <pre><code>
+<pre><code>
 {
 	"error": "unexpected alert open",
 	"message": "implementation defined",
+	"stacktrace": "",
 	"data": {
 		"text": "the text from the alert"
 	}


### PR DESCRIPTION
Fixes: https://github.com/w3c/webdriver/issues/1236


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1237.html" title="Last updated on Mar 1, 2018, 1:40 PM GMT (1ded01a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1237/7438d6c...andreastt:1ded01a.html" title="Last updated on Mar 1, 2018, 1:40 PM GMT (1ded01a)">Diff</a>