### PR TITLE
Updating prompt handling during user script to be consistent

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1,4 +1,4 @@
-﻿<!doctype html>
+<!doctype html>
 <html
  data-issue-url="https://github.com/w3c/webdriver/"
  data-issue-param-milestone="Level 1">

--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html
  data-issue-url="https://github.com/w3c/webdriver/"
  data-issue-param-milestone="Level 1">
@@ -6450,15 +6450,11 @@ of the <a>current browsing context</a> <a>active document</a>.
  with the <a data-lt="clone an object">JSON representation</a>
  of the function’s return value,
  or an <a>error</a> if the evaluation of the function
- results in a JavaScript exception being thrown
- or at any point during its execution
- an <a data-lt="missing value default state">unhandled</a> <a>user prompt</a> appears.
+ results in a JavaScript exception being thrown.
 
 <p>If at any point during the algorithm a <a>user prompt</a> appears,
- the <a>user prompt handler</a> must be invoked.
- If its return value is an <a>error</a>,
- it must immediately return with that error
- and abort all subsequent substeps of this algorithm.
+ abort all subsequent substeps of this algorithm, and return
+ <a>success</a> with data <var>null</var>.
 
 <ol>
  <li><p>Let <var>window</var> be the <a>associated window</a>


### PR DESCRIPTION
**NOTE** This PR is intended to spark discussion. It touches on at least two issues already filed against the spec (#1153 and #1135), and should be considered, since user prompt handlers was largely removed from the Level 1 specification.

Section 18 of the spec states that, "When a user prompt appears, it is
the task of the subsequent command to handle it." The algorithm for
"Executing a function body" (Section 15.2) violates this statement,
insisting that the user prompt handler be invoked during the current
command, rather than by the subsequent command. Instead, we should
immediately abort the execute[Async]Script command, and let the subsequent
command handle the user prompt, if any.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jimevans/webdriver/pull/1248.html" title="Last updated on Apr 10, 2018, 2:59 PM GMT (3fa9de8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1248/582ae36...jimevans:3fa9de8.html" title="Last updated on Apr 10, 2018, 2:59 PM GMT (3fa9de8)">Diff</a>