### PR TITLE
take element screenshot: drop scroll feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -9311,17 +9311,10 @@ sets the text field of a <a>window.<code>prompt</code></a>
 The <a>Take Element Screenshot</a> <a>command</a>
 takes a screenshot of the visible region encompassed
 by the <a>bounding rectangle</a> of an <a>element</a>.
-If given a parameter argument <code>scroll</code>
-that evaluates to false, the <a>element</a> will not be <a>scrolled into view</a>.
 
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>Let <var>scroll</var> be the result
-  of <a>getting the property</a> <code>scroll</code> from
-  <var>parameters</var> if it is not <a>undefined</a>.
-  Otherwise let it be true.
-
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
@@ -9329,8 +9322,7 @@ that evaluates to false, the <a>element</a> will not be <a>scrolled into view</a
   <a>trying</a> to <a>get a known connected element</a>
   with <a>url variable</a> <var>element id</var>.
 
- <li><p>If asked to <var>scroll</var>,
-  <a>scroll into view</a> the <var>element</var>.
+ <li><p><a>Scroll into view</a> the <var>element</var>.
 
  <li><p>When the user agent is next to <a>run the animation frame callbacks</a>:
   <ol>


### PR DESCRIPTION
Issue #1245 points out that you cannot pass data parameters to a
GET method request, so it is currently impossible to pass a "scroll"
field to Take Element Screenshot.

It was also discovered in the discussion that no vendors implement
this feature.  Because we want the specification to match reality,
this patch removes the "scroll" field for Take Element Screenshot.

Fixes: https://github.com/w3c/webdriver/issues/1245


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1249.html" title="Last updated on Apr 6, 2018, 3:40 PM GMT (81c89fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1249/582ae36...andreastt:81c89fa.html" title="Last updated on Apr 6, 2018, 3:40 PM GMT (81c89fa)">Diff</a>