### PR TITLE
handling errors: drop element not selectable

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -1621,13 +1621,6 @@ It is acknowledged that this is complementary to the Evil Bit [[!RFC3514]].
  </tr>
 
  <tr>
-  <td><dfn>element not selectable</dfn>
-  <td>400
-  <td><code>element not selectable</code>
-  <td>An attempt was made to select an element that cannot be selected.
- </tr>
-
- <tr>
   <td><dfn>element not interactable</dfn>
   <td>400
   <td><code>element not interactable</code>


### PR DESCRIPTION
The element not selectable error is not used in any commands.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1250.html" title="Last updated on Apr 8, 2018, 3:28 PM GMT (a1760c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1250/582ae36...andreastt:a1760c6.html" title="Last updated on Apr 8, 2018, 3:28 PM GMT (a1760c6)">Diff</a>