### PR TITLE
Add updated test results for IEDriver

### DIFF
--- a/results/html/all.html
+++ b/results/html/all.html
@@ -2,17 +2,16 @@
 <html lang='en'>
   <head>
     <meta charset='utf-8'>
-    <title>WebDriver: All Results</title>
+    <title>All Results</title>
     <link rel='stylesheet' href='bootstrap.min.css'>
     <link rel='stylesheet' href='analysis.css'>
   </head>
   <body>
     <div class='container'>
       <header>
-        <h1>WebDriver: All Results</h1>
+        <h1>All Results</h1>
       </header>
-
-      <p><strong>Test files</strong>: 55; <strong>Total subtests</strong>: 879</p>
+      <p><strong>Test files</strong>: 55; <strong>Total subtests</strong>: 862</p>
       <h3>Test Files</h3>
 <ol class='toc'><li><a href='#test-file-0'>/webdriver/tests/document_handling/page_source.py</a></li>
 <li><a href='#test-file-1'>/webdriver/tests/state/is_element_selected.py</a></li>
@@ -71,949 +70,928 @@
 <li><a href='#test-file-54'>/webdriver/tests/element_send_keys/form_controls.py</a></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>eg42</th><th>ff60</th><th>ie11</th><th>wk18</th></tr></thead>
+        <thead><tr class='persist-header'><th>Test</th><th>eg42</th><th>ff60</th><th>ie11</th><th>wk18</th></tr></thead>
 <tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/webdriver/tests/document_handling/page_source.py' target='_blank'>/webdriver/tests/document_handling/page_source.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-0-0' class='subtest'><td>test_source_matches_outer_html</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_source_matches_outer_html</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/webdriver/tests/state/is_element_selected.py' target='_blank'>/webdriver/tests/state/is_element_selected.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-1-8' class='subtest'><td>test_checkbox_not_selected</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-1-6' class='subtest'><td>test_element_checked</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-1-12' class='subtest'><td>test_element_not_selected</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-1-10' class='subtest'><td>test_element_selected</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-1-4' class='subtest'><td>test_element_stale</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-1-3' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-1-0' class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_element_stale</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_element_checked</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_checkbox_not_selected</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_element_selected</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_element_not_selected</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/mouse.py' target='_blank'>/webdriver/tests/actions/mouse.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-0' class='subtest'><td>test_click_at_coordinates</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-3' class='subtest'><td>test_click_element_center</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-5' class='subtest'><td>test_click_navigation</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-1' class='subtest'><td>test_context_menu_at_coordinates</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-37' class='subtest'><td>test_drag_and_drop[-10--15-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-39' class='subtest'><td>test_drag_and_drop[-10--15-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-41' class='subtest'><td>test_drag_and_drop[-10--15-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-25' class='subtest'><td>test_drag_and_drop[-20-0-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-27' class='subtest'><td>test_drag_and_drop[-20-0-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-29' class='subtest'><td>test_drag_and_drop[-20-0-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-13' class='subtest'><td>test_drag_and_drop[0-15-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-15' class='subtest'><td>test_drag_and_drop[0-15-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-17' class='subtest'><td>test_drag_and_drop[0-15-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-31' class='subtest'><td>test_drag_and_drop[10--15-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-33' class='subtest'><td>test_drag_and_drop[10--15-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-35' class='subtest'><td>test_drag_and_drop[10--15-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-19' class='subtest'><td>test_drag_and_drop[10-15-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-21' class='subtest'><td>test_drag_and_drop[10-15-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-23' class='subtest'><td>test_drag_and_drop[10-15-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-7' class='subtest'><td>test_drag_and_drop[20-0-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-9' class='subtest'><td>test_drag_and_drop[20-0-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-2-11' class='subtest'><td>test_drag_and_drop[20-0-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_click_at_coordinates</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_context_menu_at_coordinates</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_click_element_center</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_click_navigation</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[20-0-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[20-0-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[20-0-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[0-15-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[0-15-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[0-15-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[10-15-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[10-15-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[10-15-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[-20-0-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[-20-0-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[-20-0-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[10--15-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[10--15-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[10--15-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[-10--15-0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[-10--15-300]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_drag_and_drop[-10--15-800]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/webdriver/tests/contexts/maximize_window.py' target='_blank'>/webdriver/tests/contexts/maximize_window.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-3-6' class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-3-2' class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-3-1' class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-3-3' class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-3-5' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-3-10' class='subtest'><td>test_maximize</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-3-14' class='subtest'><td>test_maximize_twice_is_idempotent</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-3-0' class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-3-12' class='subtest'><td>test_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-3-8' class='subtest'><td>test_restore_the_window</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_restore_the_window</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_maximize</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_maximize_twice_is_idempotent</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/webdriver/tests/user_prompts/send_alert_text.py' target='_blank'>/webdriver/tests/user_prompts/send_alert_text.py</a></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-4-7' class='subtest'><td>test_alert_element_not_interactable</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-4-8' class='subtest'><td>test_confirm_element_not_interactable</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-4-3' class='subtest'><td>test_invalid_input[42]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-4-0' class='subtest'><td>test_invalid_input[None]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-4-4' class='subtest'><td>test_invalid_input[True]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-4-1' class='subtest'><td>test_invalid_input[text1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-4-2' class='subtest'><td>test_invalid_input[text2]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-4-5' class='subtest'><td>test_no_browsing_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-4-6' class='subtest'><td>test_no_user_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-4-9' class='subtest'><td>test_send_alert_text</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-4-10' class='subtest'><td>test_send_alert_text_with_whitespace</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_input[None]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_input[text1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_input[text2]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_input[42]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_input[True]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_user_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_alert_element_not_interactable</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_confirm_element_not_interactable</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_send_alert_text</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_send_alert_text_with_whitespace</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/webdriver/tests/user_prompts/get_alert_text.py' target='_blank'>/webdriver/tests/user_prompts/get_alert_text.py</a></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-5-2' class='subtest'><td>test_get_alert_text</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-5-3' class='subtest'><td>test_get_confirm_text</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-5-4' class='subtest'><td>test_get_prompt_text</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-5-0' class='subtest'><td>test_no_browsing_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-5-1' class='subtest'><td>test_no_user_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_user_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_alert_text</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_confirm_text</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_prompt_text</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/status.py' target='_blank'>/webdriver/tests/sessions/status.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-6-0' class='subtest'><td>test_get_status_no_session</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-6-1' class='subtest'><td>test_status_with_session_running_on_endpoint_node</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_status_no_session</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_status_with_session_running_on_endpoint_node</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/webdriver/tests/interaction/send_keys_content_editable.py' target='_blank'>/webdriver/tests/interaction/send_keys_content_editable.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-7-1' class='subtest'><td>test_sets_insertion_point_to_after_last_text_node</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-7-0' class='subtest'><td>test_sets_insertion_point_to_end</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_sets_insertion_point_to_end</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_sets_insertion_point_to_after_last_text_node</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/webdriver/tests/minimize_window.py' target='_blank'>/webdriver/tests/minimize_window.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-8-6' class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-8-2' class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-8-1' class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-8-3' class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-8-5' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-8-8' class='subtest'><td>test_minimize</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-8-12' class='subtest'><td>test_minimize_twice_is_idempotent</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-8-0' class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-8-10' class='subtest'><td>test_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_minimize</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_minimize_twice_is_idempotent</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-9'><td><a href='http://www.w3c-test.org/webdriver/tests/element_retrieval/find_elements_from_element.py' target='_blank'>/webdriver/tests/element_retrieval/find_elements_from_element.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-9-17' class='subtest'><td>test_closed_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-19' class='subtest'><td>test_find_elements[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-21' class='subtest'><td>test_find_elements[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-23' class='subtest'><td>test_find_elements[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-25' class='subtest'><td>test_find_elements[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-27' class='subtest'><td>test_find_elements[xpath-//a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-11' class='subtest'><td>test_invalid_selector_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-13' class='subtest'><td>test_invalid_selector_argument[value1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-15' class='subtest'><td>test_invalid_selector_argument[value2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-5' class='subtest'><td>test_invalid_using_argument[1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-3' class='subtest'><td>test_invalid_using_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-1' class='subtest'><td>test_invalid_using_argument[True]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-0' class='subtest'><td>test_invalid_using_argument[a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-7' class='subtest'><td>test_invalid_using_argument[using4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-9' class='subtest'><td>test_invalid_using_argument[using5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-29' class='subtest'><td>test_no_element[css selector-#wontExist]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-41' class='subtest'><td>test_parent_htmldocument</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-31' class='subtest'><td>test_xhtml_namespace[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-33' class='subtest'><td>test_xhtml_namespace[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-35' class='subtest'><td>test_xhtml_namespace[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-37' class='subtest'><td>test_xhtml_namespace[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-9-39' class='subtest'><td>test_xhtml_namespace[xpath-//*[name()='a']]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[True]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[using4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[using5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[value1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[value2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_closed_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_elements[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_elements[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_elements[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_elements[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_elements[xpath-//a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_element[css selector-#wontExist]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[xpath-//*[name()='a']]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_parent_htmldocument</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-10'><td><a href='http://www.w3c-test.org/webdriver/tests/get_window_rect.py' target='_blank'>/webdriver/tests/get_window_rect.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-10-2' class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-10-1' class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-10-3' class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-10-5' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-10-0' class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-10-6' class='subtest'><td>test_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-11'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/new_session/default_values.py' target='_blank'>/webdriver/tests/sessions/new_session/default_values.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-11-0' class='subtest'><td>test_basic</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-11-5' class='subtest'><td>test_desired</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-11-6' class='subtest'><td>test_ignore_non_spec_fields_in_capabilities</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XPASS'>XPASS</td></tr>
-<tr id='subtest-11-4' class='subtest'><td>test_missing_always_match</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-11-3' class='subtest'><td>test_missing_first_match</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-11-2' class='subtest'><td>test_no_capabilites</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-11-1' class='subtest'><td>test_repeat_new_session</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-11-7' class='subtest'><td>test_valid_but_unmatchable_key</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_basic</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_repeat_new_session</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_capabilites</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_missing_first_match</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_missing_always_match</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_desired</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_ignore_non_spec_fields_in_capabilities</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XPASS'>XPASS</td></tr>
+<tr class='subtest'><td>test_valid_but_unmatchable_key</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-12'><td><a href='http://www.w3c-test.org/webdriver/tests/state/get_element_property.py' target='_blank'>/webdriver/tests/state/get_element_property.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-12-10' class='subtest'><td>test_element</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-12-8' class='subtest'><td>test_element_non_existent</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-12-4' class='subtest'><td>test_element_not_found</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-12-6' class='subtest'><td>test_element_stale</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-12-3' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-12-0' class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_element_not_found</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_element_stale</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_element_non_existent</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_element</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/webdriver/tests/user_prompts/dismiss_alert.py' target='_blank'>/webdriver/tests/user_prompts/dismiss_alert.py</a></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-13-2' class='subtest'><td>test_dismiss_alert</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-13-3' class='subtest'><td>test_dismiss_confirm</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-13-4' class='subtest'><td>test_dismiss_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-13-0' class='subtest'><td>test_no_browsing_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-13-1' class='subtest'><td>test_no_user_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_user_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_dismiss_alert</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_dismiss_confirm</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_dismiss_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/webdriver/tests/fullscreen_window.py' target='_blank'>/webdriver/tests/fullscreen_window.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-14-6' class='subtest'><td>test_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-14-10' class='subtest'><td>test_fullscreen_twice_is_idempotent</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-14-2' class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-14-1' class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-14-3' class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-14-5' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-14-0' class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-14-8' class='subtest'><td>test_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_fullscreen_twice_is_idempotent</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-15'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/key.py' target='_blank'>/webdriver/tests/actions/key.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-37' class='subtest'><td>test_backspace_erases_keys</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-0' class='subtest'><td>test_lone_keyup_sends_no_events</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-35' class='subtest'><td>test_sequence_of_keydown_character_keys</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-33' class='subtest'><td>test_sequence_of_keydown_printable_keys_sends_events</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-19' class='subtest'><td>test_single_emoji_records_correct_key[\U0001f604]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-21' class='subtest'><td>test_single_emoji_records_correct_key[\U0001f60d]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-27' class='subtest'><td>test_single_modifier_key_sends_correct_events[\ue009-ControlLeft-Control]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-23' class='subtest'><td>test_single_modifier_key_sends_correct_events[\ue050-ShiftRight-Shift]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-25' class='subtest'><td>test_single_modifier_key_sends_correct_events[\ue053-OSRight-Meta]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-29' class='subtest'><td>test_single_nonprintable_key_sends_events[\ue00c-Escape-Escape]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-31' class='subtest'><td>test_single_nonprintable_key_sends_events[\ue014-ArrowRight-ArrowRight]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-5' class='subtest'><td>test_single_printable_key_sends_correct_events["-Quote]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-7' class='subtest'><td>test_single_printable_key_sends_correct_events[,-Comma]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-13' class='subtest'><td>test_single_printable_key_sends_correct_events[@-Digit2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-11' class='subtest'><td>test_single_printable_key_sends_correct_events[\u0416-]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-15' class='subtest'><td>test_single_printable_key_sends_correct_events[\u2603-]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-17' class='subtest'><td>test_single_printable_key_sends_correct_events[\uf6c2-]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-9' class='subtest'><td>test_single_printable_key_sends_correct_events[\xe0-]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-1' class='subtest'><td>test_single_printable_key_sends_correct_events[a-KeyA0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-3' class='subtest'><td>test_single_printable_key_sends_correct_events[a-KeyA1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_lone_keyup_sends_no_events</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_printable_key_sends_correct_events[a-KeyA0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_printable_key_sends_correct_events[a-KeyA1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_printable_key_sends_correct_events["-Quote]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_printable_key_sends_correct_events[,-Comma]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_printable_key_sends_correct_events[\xe0-]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_printable_key_sends_correct_events[\u0416-]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_printable_key_sends_correct_events[@-Digit2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_printable_key_sends_correct_events[\u2603-]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_printable_key_sends_correct_events[\uf6c2-]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_emoji_records_correct_key[\U0001f604]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_emoji_records_correct_key[\U0001f60d]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_modifier_key_sends_correct_events[\ue050-ShiftRight-Shift]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_modifier_key_sends_correct_events[\ue053-OSRight-Meta]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_modifier_key_sends_correct_events[\ue009-ControlLeft-Control]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_nonprintable_key_sends_events[\ue00c-Escape-Escape]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_nonprintable_key_sends_events[\ue014-ArrowRight-ArrowRight]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_sequence_of_keydown_printable_keys_sends_events</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_sequence_of_keydown_character_keys</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_backspace_erases_keys</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-16'><td><a href='http://www.w3c-test.org/webdriver/tests/state/text/get_text.py' target='_blank'>/webdriver/tests/state/text/get_text.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-16-0' class='subtest'><td>test_getting_text_of_a_non_existant_element_is_an_error</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-16-1' class='subtest'><td>test_read_element_text</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_getting_text_of_a_non_existant_element_is_an_error</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_read_element_text</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/key_shortcuts.py' target='_blank'>/webdriver/tests/actions/key_shortcuts.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
-<tr id='subtest-17-0' class='subtest'><td>test_mod_a_and_backspace_deletes_all_text</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-17-1' class='subtest'><td>test_mod_a_mod_c_right_mod_v_pastes_text</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-17-3' class='subtest'><td>test_mod_a_mod_x_deletes_all_text</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_mod_a_and_backspace_deletes_all_text</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_mod_a_mod_c_right_mod_v_pastes_text</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_mod_a_mod_x_deletes_all_text</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/new_session/create_firstMatch.py' target='_blank'>/webdriver/tests/sessions/new_session/create_firstMatch.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-18-0' class='subtest'><td>test_valid[acceptInsecureCerts-False]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-1' class='subtest'><td>test_valid[acceptInsecureCerts-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-2' class='subtest'><td>test_valid[browserName-None]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-3' class='subtest'><td>test_valid[browserVersion-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-8' class='subtest'><td>test_valid[pageLoadStrategy-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-6' class='subtest'><td>test_valid[pageLoadStrategy-eager]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-5' class='subtest'><td>test_valid[pageLoadStrategy-none]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-7' class='subtest'><td>test_valid[pageLoadStrategy-normal]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-4' class='subtest'><td>test_valid[platformName-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-9' class='subtest'><td>test_valid[proxy-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-19' class='subtest'><td>test_valid[test:extension-123]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-22' class='subtest'><td>test_valid[test:extension-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-17' class='subtest'><td>test_valid[test:extension-True]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-18' class='subtest'><td>test_valid[test:extension-abc]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-20' class='subtest'><td>test_valid[test:extension-value20]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-21' class='subtest'><td>test_valid[test:extension-value21]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-10' class='subtest'><td>test_valid[timeouts-value10]</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-18-11' class='subtest'><td>test_valid[timeouts-value11]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-12' class='subtest'><td>test_valid[timeouts-value12]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-13' class='subtest'><td>test_valid[timeouts-value13]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-16' class='subtest'><td>test_valid[unhandledPromptBehavior-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-15' class='subtest'><td>test_valid[unhandledPromptBehavior-accept]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-18-14' class='subtest'><td>test_valid[unhandledPromptBehavior-dismiss]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[acceptInsecureCerts-False]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[acceptInsecureCerts-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[browserName-None]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[browserVersion-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[platformName-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[pageLoadStrategy-none]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[pageLoadStrategy-eager]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[pageLoadStrategy-normal]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[pageLoadStrategy-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[proxy-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[timeouts-value10]</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_valid[timeouts-value11]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[timeouts-value12]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[timeouts-value13]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[unhandledPromptBehavior-dismiss]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[unhandledPromptBehavior-accept]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[unhandledPromptBehavior-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-True]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-abc]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-123]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-value20]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-value21]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/webdriver/tests/contexts/json_serialize_windowproxy.py' target='_blank'>/webdriver/tests/contexts/json_serialize_windowproxy.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-19-3' class='subtest'><td>test_frame</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-19-0' class='subtest'><td>test_initial_window</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-19-1' class='subtest'><td>test_window_open</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_initial_window</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_window_open</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_frame</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-20'><td><a href='http://www.w3c-test.org/webdriver/tests/execute_async_script/user_prompts.py' target='_blank'>/webdriver/tests/execute_async_script/user_prompts.py</a></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-20-0' class='subtest'><td>test_handle_prompt_accept</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-3' class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-5' class='subtest'><td>test_handle_prompt_default</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-1' class='subtest'><td>test_handle_prompt_dismiss</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-2' class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-4' class='subtest'><td>test_handle_prompt_ignore</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-6' class='subtest'><td>test_handle_prompt_twice</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_ignore</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_default</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_twice</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-21'><td><a href='http://www.w3c-test.org/webdriver/tests/execute_script/cyclic.py' target='_blank'>/webdriver/tests/execute_script/cyclic.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-21-0' class='subtest'><td>test_array</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-21-3' class='subtest'><td>test_array_in_object</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-21-1' class='subtest'><td>test_object</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-21-5' class='subtest'><td>test_object_in_array</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_array</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_object</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_array_in_object</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_object_in_array</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-22'><td><a href='http://www.w3c-test.org/webdriver/tests/user_prompts/accept_alert.py' target='_blank'>/webdriver/tests/user_prompts/accept_alert.py</a></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-22-2' class='subtest'><td>test_accept_alert</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-22-3' class='subtest'><td>test_accept_confirm</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-22-4' class='subtest'><td>test_accept_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-22-0' class='subtest'><td>test_no_browsing_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-22-1' class='subtest'><td>test_no_user_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_user_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_accept_alert</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_accept_confirm</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_accept_prompt</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-23'><td><a href='http://www.w3c-test.org/webdriver/tests/switch_to_parent_frame.py' target='_blank'>/webdriver/tests/switch_to_parent_frame.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-23-0' class='subtest'><td>test_stale_element_from_iframe</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_stale_element_from_iframe</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-24'><td><a href='http://www.w3c-test.org/webdriver/tests/state/get_element_tag_name.py' target='_blank'>/webdriver/tests/state/get_element_tag_name.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-24-4' class='subtest'><td>test_element_not_found</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-24-6' class='subtest'><td>test_element_stale</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-24-8' class='subtest'><td>test_get_element_tag_name</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-24-3' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-24-0' class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_element_not_found</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_element_stale</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_element_tag_name</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-25'><td><a href='http://www.w3c-test.org/webdriver/tests/element_send_keys/scroll_into_view.py' target='_blank'>/webdriver/tests/element_send_keys/scroll_into_view.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-25-7' class='subtest'><td>test_contenteditable_element_outside_of_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-25-0' class='subtest'><td>test_element_outside_of_not_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-25-1' class='subtest'><td>test_element_outside_of_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-25-3' class='subtest'><td>test_option_select_container_outside_of_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-25-5' class='subtest'><td>test_option_stays_outside_of_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_element_outside_of_not_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_element_outside_of_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_option_select_container_outside_of_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_option_stays_outside_of_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_contenteditable_element_outside_of_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-26'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/sequence.py' target='_blank'>/webdriver/tests/actions/sequence.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
-<tr id='subtest-26-0' class='subtest'><td>test_no_actions_send_no_events</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-26-1' class='subtest'><td>test_release_char_sequence_sends_keyup_events_in_reverse</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-26-3' class='subtest'><td>test_release_no_actions_sends_no_events</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_no_actions_send_no_events</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_release_char_sequence_sends_keyup_events_in_reverse</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_release_no_actions_sends_no_events</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/webdriver/tests/cookies/add_cookie.py' target='_blank'>/webdriver/tests/cookies/add_cookie.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-27-1' class='subtest'><td>test_add_cookie_for_ip</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-27-0' class='subtest'><td>test_add_domain_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-27-3' class='subtest'><td>test_add_non_session_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-27-5' class='subtest'><td>test_add_session_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-27-7' class='subtest'><td>test_add_session_cookie_with_leading_dot_character_in_domain</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_add_domain_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_add_cookie_for_ip</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_add_non_session_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_add_session_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_add_session_cookie_with_leading_dot_character_in_domain</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-28'><td><a href='http://www.w3c-test.org/webdriver/tests/set_window_rect.py' target='_blank'>/webdriver/tests/set_window_rect.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-28-0' class='subtest'><td>test_current_top_level_browsing_context_no_longer_open</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-113' class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-28-4' class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-3' class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-5' class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-6' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-119' class='subtest'><td>test_height_width</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-123' class='subtest'><td>test_height_width_as_current</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-121' class='subtest'><td>test_height_width_larger_than_max</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-7' class='subtest'><td>test_invalid_types[rect0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-27' class='subtest'><td>test_invalid_types[rect10]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-29' class='subtest'><td>test_invalid_types[rect11]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-31' class='subtest'><td>test_invalid_types[rect12]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-33' class='subtest'><td>test_invalid_types[rect13]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-35' class='subtest'><td>test_invalid_types[rect14]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-37' class='subtest'><td>test_invalid_types[rect15]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-39' class='subtest'><td>test_invalid_types[rect16]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-41' class='subtest'><td>test_invalid_types[rect17]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-43' class='subtest'><td>test_invalid_types[rect18]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-45' class='subtest'><td>test_invalid_types[rect19]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-9' class='subtest'><td>test_invalid_types[rect1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-47' class='subtest'><td>test_invalid_types[rect20]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-49' class='subtest'><td>test_invalid_types[rect21]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-51' class='subtest'><td>test_invalid_types[rect22]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-53' class='subtest'><td>test_invalid_types[rect23]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-55' class='subtest'><td>test_invalid_types[rect24]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-57' class='subtest'><td>test_invalid_types[rect25]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-59' class='subtest'><td>test_invalid_types[rect26]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-61' class='subtest'><td>test_invalid_types[rect27]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-11' class='subtest'><td>test_invalid_types[rect2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-13' class='subtest'><td>test_invalid_types[rect3]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-15' class='subtest'><td>test_invalid_types[rect4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-17' class='subtest'><td>test_invalid_types[rect5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-19' class='subtest'><td>test_invalid_types[rect6]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-21' class='subtest'><td>test_invalid_types[rect7]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-23' class='subtest'><td>test_invalid_types[rect8]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-25' class='subtest'><td>test_invalid_types[rect9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-129' class='subtest'><td>test_move_to_same_position</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-131' class='subtest'><td>test_move_to_same_x</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-133' class='subtest'><td>test_move_to_same_y</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-127' class='subtest'><td>test_negative_x_y</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-28-73' class='subtest'><td>test_no_change[rect0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-93' class='subtest'><td>test_no_change[rect10]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-95' class='subtest'><td>test_no_change[rect11]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-97' class='subtest'><td>test_no_change[rect12]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-99' class='subtest'><td>test_no_change[rect13]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-101' class='subtest'><td>test_no_change[rect14]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-103' class='subtest'><td>test_no_change[rect15]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-105' class='subtest'><td>test_no_change[rect16]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-107' class='subtest'><td>test_no_change[rect17]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-109' class='subtest'><td>test_no_change[rect18]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-111' class='subtest'><td>test_no_change[rect19]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-75' class='subtest'><td>test_no_change[rect1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-77' class='subtest'><td>test_no_change[rect2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-79' class='subtest'><td>test_no_change[rect3]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-81' class='subtest'><td>test_no_change[rect4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-83' class='subtest'><td>test_no_change[rect5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-85' class='subtest'><td>test_no_change[rect6]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-87' class='subtest'><td>test_no_change[rect7]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-89' class='subtest'><td>test_no_change[rect8]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-91' class='subtest'><td>test_no_change[rect9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-63' class='subtest'><td>test_out_of_bounds[rect0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-65' class='subtest'><td>test_out_of_bounds[rect1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-67' class='subtest'><td>test_out_of_bounds[rect2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-141' class='subtest'><td>test_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-139' class='subtest'><td>test_resize_to_same_height</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-135' class='subtest'><td>test_resize_to_same_size</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-137' class='subtest'><td>test_resize_to_same_width</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-117' class='subtest'><td>test_restore_from_maximized</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-28-115' class='subtest'><td>test_restore_from_minimized</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-28-69' class='subtest'><td>test_width_height_floats</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-125' class='subtest'><td>test_x_y</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-28-71' class='subtest'><td>test_x_y_floats</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_current_top_level_browsing_context_no_longer_open</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect3]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect6]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect7]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect8]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect10]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect11]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect12]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect13]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect14]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect15]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect16]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect17]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect18]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect19]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect20]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect21]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect22]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect23]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect24]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect25]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect26]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_types[rect27]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_out_of_bounds[rect0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_out_of_bounds[rect1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_out_of_bounds[rect2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_width_height_floats</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_x_y_floats</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect3]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect6]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect7]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect8]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect10]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect11]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect12]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect13]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect14]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect15]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect16]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect17]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect18]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_change[rect19]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_restore_from_minimized</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_restore_from_maximized</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_height_width</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_height_width_larger_than_max</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_height_width_as_current</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_x_y</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_negative_x_y</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_move_to_same_position</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_move_to_same_x</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_move_to_same_y</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_resize_to_same_size</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_resize_to_same_width</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_resize_to_same_height</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-29'><td><a href='http://www.w3c-test.org/webdriver/tests/element_send_keys/interactability.py' target='_blank'>/webdriver/tests/element_send_keys/interactability.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-29-0' class='subtest'><td>test_body_is_interactable</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-29-17' class='subtest'><td>test_disabled_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-29-1' class='subtest'><td>test_document_element_is_interactable</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-29-15' class='subtest'><td>test_hidden_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-29-3' class='subtest'><td>test_iframe_is_interactable</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-29-11' class='subtest'><td>test_not_a_focusable_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-29-13' class='subtest'><td>test_not_displayed_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-29-9' class='subtest'><td>test_obscured_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-29-7' class='subtest'><td>test_readonly_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-29-5' class='subtest'><td>test_transparent_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_body_is_interactable</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_document_element_is_interactable</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_iframe_is_interactable</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_transparent_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_readonly_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_obscured_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_not_a_focusable_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_not_displayed_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_hidden_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_disabled_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-30'><td><a href='http://www.w3c-test.org/webdriver/tests/contexts/resizing_and_positioning.py' target='_blank'>/webdriver/tests/contexts/resizing_and_positioning.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-30-0' class='subtest'><td>test_window_resize</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_window_resize</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/webdriver/tests/element_click/select.py' target='_blank'>/webdriver/tests/element_click/select.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-31-7' class='subtest'><td>test_click_deselects_others</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-31-9' class='subtest'><td>test_click_multiple_does_not_deselect_others</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-31-1' class='subtest'><td>test_click_multiple_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-31-0' class='subtest'><td>test_click_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-31-5' class='subtest'><td>test_click_preselected_multiple_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-31-3' class='subtest'><td>test_click_preselected_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-31-13' class='subtest'><td>test_click_selected_multiple_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-31-11' class='subtest'><td>test_click_selected_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-31-19' class='subtest'><td>test_option_disabled</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-31-15' class='subtest'><td>test_out_of_view_dropdown</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-31-17' class='subtest'><td>test_out_of_view_multiple</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_click_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_click_multiple_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_click_preselected_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_click_preselected_multiple_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_click_deselects_others</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_click_multiple_does_not_deselect_others</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_click_selected_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_click_selected_multiple_option</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_out_of_view_dropdown</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_out_of_view_multiple</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_option_disabled</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-32'><td><a href='http://www.w3c-test.org/webdriver/tests/element_retrieval/find_element.py' target='_blank'>/webdriver/tests/element_retrieval/find_element.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-32-17' class='subtest'><td>test_closed_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-19' class='subtest'><td>test_find_element[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-21' class='subtest'><td>test_find_element[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-23' class='subtest'><td>test_find_element[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-25' class='subtest'><td>test_find_element[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-27' class='subtest'><td>test_find_element[xpath-//a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-41' class='subtest'><td>test_htmldocument[css selector-:root]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-43' class='subtest'><td>test_htmldocument[tag name-html]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-45' class='subtest'><td>test_htmldocument[xpath-/html]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-11' class='subtest'><td>test_invalid_selector_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-13' class='subtest'><td>test_invalid_selector_argument[value1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-15' class='subtest'><td>test_invalid_selector_argument[value2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-5' class='subtest'><td>test_invalid_using_argument[1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-3' class='subtest'><td>test_invalid_using_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-1' class='subtest'><td>test_invalid_using_argument[True]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-0' class='subtest'><td>test_invalid_using_argument[a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-7' class='subtest'><td>test_invalid_using_argument[using4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-9' class='subtest'><td>test_invalid_using_argument[using5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-29' class='subtest'><td>test_no_element[css selector-#wontExist]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-31' class='subtest'><td>test_xhtml_namespace[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-33' class='subtest'><td>test_xhtml_namespace[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-35' class='subtest'><td>test_xhtml_namespace[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-37' class='subtest'><td>test_xhtml_namespace[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-32-39' class='subtest'><td>test_xhtml_namespace[xpath-//*[name()='a']]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[True]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[using4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[using5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[value1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[value2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_closed_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_element[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_element[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_element[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_element[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_element[xpath-//a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_element[css selector-#wontExist]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[xpath-//*[name()='a']]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_htmldocument[css selector-:root]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_htmldocument[tag name-html]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_htmldocument[xpath-/html]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-33'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/get_timeouts.py' target='_blank'>/webdriver/tests/sessions/get_timeouts.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-33-1' class='subtest'><td>test_get_default_timeouts</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-33-3' class='subtest'><td>test_get_new_timeouts</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-33-0' class='subtest'><td>test_get_timeouts</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_timeouts</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_default_timeouts</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_new_timeouts</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-34'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/modifier_click.py' target='_blank'>/webdriver/tests/actions/modifier_click.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
-<tr id='subtest-34-12' class='subtest'><td>test_many_modifiers_click</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-34-8' class='subtest'><td>test_modifier_click[\ue008-shiftKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-34-0' class='subtest'><td>test_modifier_click[\ue00a-altKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-34-4' class='subtest'><td>test_modifier_click[\ue03d-metaKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-34-10' class='subtest'><td>test_modifier_click[\ue050-shiftKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-34-2' class='subtest'><td>test_modifier_click[\ue052-altKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-34-6' class='subtest'><td>test_modifier_click[\ue053-metaKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_modifier_click[\ue00a-altKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_modifier_click[\ue052-altKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_modifier_click[\ue03d-metaKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_modifier_click[\ue053-metaKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_modifier_click[\ue008-shiftKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_modifier_click[\ue050-shiftKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_many_modifiers_click</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-35'><td><a href='http://www.w3c-test.org/webdriver/tests/element_retrieval/find_elements.py' target='_blank'>/webdriver/tests/element_retrieval/find_elements.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-35-17' class='subtest'><td>test_closed_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-19' class='subtest'><td>test_find_elements[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-21' class='subtest'><td>test_find_elements[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-23' class='subtest'><td>test_find_elements[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-25' class='subtest'><td>test_find_elements[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-27' class='subtest'><td>test_find_elements[xpath-//a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-41' class='subtest'><td>test_htmldocument[css selector-:root]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-43' class='subtest'><td>test_htmldocument[tag name-html]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-45' class='subtest'><td>test_htmldocument[xpath-/html]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-11' class='subtest'><td>test_invalid_selector_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-13' class='subtest'><td>test_invalid_selector_argument[value1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-15' class='subtest'><td>test_invalid_selector_argument[value2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-5' class='subtest'><td>test_invalid_using_argument[1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-3' class='subtest'><td>test_invalid_using_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-1' class='subtest'><td>test_invalid_using_argument[True]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-0' class='subtest'><td>test_invalid_using_argument[a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-7' class='subtest'><td>test_invalid_using_argument[using4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-9' class='subtest'><td>test_invalid_using_argument[using5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-29' class='subtest'><td>test_no_element[css selector-#wontExist]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-31' class='subtest'><td>test_xhtml_namespace[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-33' class='subtest'><td>test_xhtml_namespace[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-35' class='subtest'><td>test_xhtml_namespace[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-37' class='subtest'><td>test_xhtml_namespace[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-35-39' class='subtest'><td>test_xhtml_namespace[xpath-//*[name()='a']]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[True]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[using4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[using5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[value1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[value2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_closed_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_elements[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_elements[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_elements[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_elements[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_elements[xpath-//a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_element[css selector-#wontExist]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[xpath-//*[name()='a']]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_htmldocument[css selector-:root]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_htmldocument[tag name-html]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_htmldocument[xpath-/html]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-36'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/mouse_dblclick.py' target='_blank'>/webdriver/tests/actions/mouse_dblclick.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
-<tr id='subtest-36-0' class='subtest'><td>test_dblclick_at_coordinates[0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-36-2' class='subtest'><td>test_dblclick_at_coordinates[200]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-36-4' class='subtest'><td>test_dblclick_with_pause_after_second_pointerdown</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-36-6' class='subtest'><td>test_no_dblclick</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_dblclick_at_coordinates[0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_dblclick_at_coordinates[200]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_dblclick_with_pause_after_second_pointerdown</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_no_dblclick</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-37'><td><a href='http://www.w3c-test.org/webdriver/tests/element_click/bubbling.py' target='_blank'>/webdriver/tests/element_click/bubbling.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-37-0' class='subtest'><td>test_click_event_bubbles_to_parents</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-37-3' class='subtest'><td>test_element_disappears_during_click</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-37-1' class='subtest'><td>test_spin_event_loop</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_click_event_bubbles_to_parents</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_spin_event_loop</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_element_disappears_during_click</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-38'><td><a href='http://www.w3c-test.org/webdriver/tests/navigation/get_title.py' target='_blank'>/webdriver/tests/navigation/get_title.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-38-10' class='subtest'><td>test_title_after_modification</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-38-0' class='subtest'><td>test_title_from_closed_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-38-14' class='subtest'><td>test_title_from_frame</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-38-4' class='subtest'><td>test_title_from_top_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-38-2' class='subtest'><td>test_title_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-38-1' class='subtest'><td>test_title_handle_prompt_dismiss</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-38-3' class='subtest'><td>test_title_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-38-12' class='subtest'><td>test_title_strip_and_collapse</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-38-6' class='subtest'><td>test_title_with_duplicate_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-38-8' class='subtest'><td>test_title_without_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_title_from_closed_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_title_handle_prompt_dismiss</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_title_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_title_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_title_from_top_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_title_with_duplicate_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_title_without_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_title_after_modification</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_title_strip_and_collapse</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_title_from_frame</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-39'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/new_session/response.py' target='_blank'>/webdriver/tests/sessions/new_session/response.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-39-4' class='subtest'><td>test_pageLoadStrategy</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-39-1' class='subtest'><td>test_resp_capabilites</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-39-2' class='subtest'><td>test_resp_data</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-39-0' class='subtest'><td>test_resp_sessionid</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-39-3' class='subtest'><td>test_timeouts</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_resp_sessionid</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_resp_capabilites</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_resp_data</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_timeouts</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_pageLoadStrategy</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-40'><td><a href='http://www.w3c-test.org/webdriver/tests/element_retrieval/find_element_from_element.py' target='_blank'>/webdriver/tests/element_retrieval/find_element_from_element.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-40-17' class='subtest'><td>test_closed_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-19' class='subtest'><td>test_find_element[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-21' class='subtest'><td>test_find_element[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-23' class='subtest'><td>test_find_element[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-25' class='subtest'><td>test_find_element[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-27' class='subtest'><td>test_find_element[xpath-//a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-11' class='subtest'><td>test_invalid_selector_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-13' class='subtest'><td>test_invalid_selector_argument[value1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-15' class='subtest'><td>test_invalid_selector_argument[value2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-5' class='subtest'><td>test_invalid_using_argument[1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-3' class='subtest'><td>test_invalid_using_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-1' class='subtest'><td>test_invalid_using_argument[True]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-0' class='subtest'><td>test_invalid_using_argument[a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-7' class='subtest'><td>test_invalid_using_argument[using4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-9' class='subtest'><td>test_invalid_using_argument[using5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-29' class='subtest'><td>test_no_element[css selector-#wontExist]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-41' class='subtest'><td>test_parent_htmldocument</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-31' class='subtest'><td>test_xhtml_namespace[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-33' class='subtest'><td>test_xhtml_namespace[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-35' class='subtest'><td>test_xhtml_namespace[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-37' class='subtest'><td>test_xhtml_namespace[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-40-39' class='subtest'><td>test_xhtml_namespace[xpath-//*[name()='a']]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[True]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[using4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_using_argument[using5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[None]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[value1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_selector_argument[value2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_closed_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_element[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_element[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_element[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_element[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_find_element[xpath-//a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_element[css selector-#wontExist]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[css selector-#linkText]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[link text-full link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[partial link text-link text]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[tag name-a]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_xhtml_namespace[xpath-//*[name()='a']]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_parent_htmldocument</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-41'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/new_session/invalid_capabilities.py' target='_blank'>/webdriver/tests/sessions/new_session/invalid_capabilities.py</a></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-41-5' class='subtest'><td>test_invalid_always_match[1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-4' class='subtest'><td>test_invalid_always_match[None]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-7' class='subtest'><td>test_invalid_always_match[value3]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-6' class='subtest'><td>test_invalid_always_match[{}]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-1' class='subtest'><td>test_invalid_capabilites[1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-0' class='subtest'><td>test_invalid_capabilites[None]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-3' class='subtest'><td>test_invalid_capabilites[value3]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-2' class='subtest'><td>test_invalid_capabilites[{}]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-162' class='subtest'><td>test_invalid_extensions[automaticInspection-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-163' class='subtest'><td>test_invalid_extensions[automaticInspection-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-164' class='subtest'><td>test_invalid_extensions[automaticProfiling-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-165' class='subtest'><td>test_invalid_extensions[automaticProfiling-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-170' class='subtest'><td>test_invalid_extensions[browser-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-171' class='subtest'><td>test_invalid_extensions[browser-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-160' class='subtest'><td>test_invalid_extensions[chromeOptions-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-161' class='subtest'><td>test_invalid_extensions[chromeOptions-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-194' class='subtest'><td>test_invalid_extensions[ensureCleanSession-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-195' class='subtest'><td>test_invalid_extensions[ensureCleanSession-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-154' class='subtest'><td>test_invalid_extensions[firefox-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-155' class='subtest'><td>test_invalid_extensions[firefox-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-158' class='subtest'><td>test_invalid_extensions[firefoxOptions-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-159' class='subtest'><td>test_invalid_extensions[firefoxOptions-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-156' class='subtest'><td>test_invalid_extensions[firefox_binary-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-157' class='subtest'><td>test_invalid_extensions[firefox_binary-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-184' class='subtest'><td>test_invalid_extensions[initialBrowserUrl-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-185' class='subtest'><td>test_invalid_extensions[initialBrowserUrl-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-174' class='subtest'><td>test_invalid_extensions[javascriptEnabled-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-175' class='subtest'><td>test_invalid_extensions[javascriptEnabled-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-188' class='subtest'><td>test_invalid_extensions[logFile-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-189' class='subtest'><td>test_invalid_extensions[logFile-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-190' class='subtest'><td>test_invalid_extensions[logLevel-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-191' class='subtest'><td>test_invalid_extensions[logLevel-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-176' class='subtest'><td>test_invalid_extensions[nativeEvents-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-177' class='subtest'><td>test_invalid_extensions[nativeEvents-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-166' class='subtest'><td>test_invalid_extensions[platform-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-167' class='subtest'><td>test_invalid_extensions[platform-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-172' class='subtest'><td>test_invalid_extensions[platformVersion-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-173' class='subtest'><td>test_invalid_extensions[platformVersion-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-180' class='subtest'><td>test_invalid_extensions[profile-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-181' class='subtest'><td>test_invalid_extensions[profile-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-186' class='subtest'><td>test_invalid_extensions[requireWindowFocus-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-187' class='subtest'><td>test_invalid_extensions[requireWindowFocus-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-192' class='subtest'><td>test_invalid_extensions[safari.options-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-193' class='subtest'><td>test_invalid_extensions[safari.options-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-178' class='subtest'><td>test_invalid_extensions[seleniumProtocol-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-179' class='subtest'><td>test_invalid_extensions[seleniumProtocol-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-182' class='subtest'><td>test_invalid_extensions[trustAllSSLCertificates-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-183' class='subtest'><td>test_invalid_extensions[trustAllSSLCertificates-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-168' class='subtest'><td>test_invalid_extensions[version-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-169' class='subtest'><td>test_invalid_extensions[version-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-9' class='subtest'><td>test_invalid_first_match[1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-8' class='subtest'><td>test_invalid_first_match[None]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-10' class='subtest'><td>test_invalid_first_match[[]]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-11' class='subtest'><td>test_invalid_first_match[value3]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-12' class='subtest'><td>test_invalid_values[acceptInsecureCerts-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-13' class='subtest'><td>test_invalid_values[acceptInsecureCerts-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-18' class='subtest'><td>test_invalid_values[acceptInsecureCerts-false-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-19' class='subtest'><td>test_invalid_values[acceptInsecureCerts-false-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-14' class='subtest'><td>test_invalid_values[acceptInsecureCerts-value1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-15' class='subtest'><td>test_invalid_values[acceptInsecureCerts-value1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-16' class='subtest'><td>test_invalid_values[acceptInsecureCerts-value2-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-17' class='subtest'><td>test_invalid_values[acceptInsecureCerts-value2-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-20' class='subtest'><td>test_invalid_values[browserName-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-21' class='subtest'><td>test_invalid_values[browserName-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-26' class='subtest'><td>test_invalid_values[browserName-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-27' class='subtest'><td>test_invalid_values[browserName-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-22' class='subtest'><td>test_invalid_values[browserName-value5-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-23' class='subtest'><td>test_invalid_values[browserName-value5-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-24' class='subtest'><td>test_invalid_values[browserName-value6-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-25' class='subtest'><td>test_invalid_values[browserName-value6-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-28' class='subtest'><td>test_invalid_values[browserVersion-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-29' class='subtest'><td>test_invalid_values[browserVersion-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-34' class='subtest'><td>test_invalid_values[browserVersion-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-35' class='subtest'><td>test_invalid_values[browserVersion-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-32' class='subtest'><td>test_invalid_values[browserVersion-value10-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-33' class='subtest'><td>test_invalid_values[browserVersion-value10-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-30' class='subtest'><td>test_invalid_values[browserVersion-value9-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-31' class='subtest'><td>test_invalid_values[browserVersion-value9-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-62' class='subtest'><td>test_invalid_values[pageLoadStrategy- eager-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-63' class='subtest'><td>test_invalid_values[pageLoadStrategy- eager-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-44' class='subtest'><td>test_invalid_values[pageLoadStrategy-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-45' class='subtest'><td>test_invalid_values[pageLoadStrategy-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-56' class='subtest'><td>test_invalid_values[pageLoadStrategy-Eager-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-57' class='subtest'><td>test_invalid_values[pageLoadStrategy-Eager-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-50' class='subtest'><td>test_invalid_values[pageLoadStrategy-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-51' class='subtest'><td>test_invalid_values[pageLoadStrategy-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-54' class='subtest'><td>test_invalid_values[pageLoadStrategy-NONE-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-55' class='subtest'><td>test_invalid_values[pageLoadStrategy-NONE-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-64' class='subtest'><td>test_invalid_values[pageLoadStrategy-eager -body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-65' class='subtest'><td>test_invalid_values[pageLoadStrategy-eager -body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-58' class='subtest'><td>test_invalid_values[pageLoadStrategy-eagerblah-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-59' class='subtest'><td>test_invalid_values[pageLoadStrategy-eagerblah-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-60' class='subtest'><td>test_invalid_values[pageLoadStrategy-interactive-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-61' class='subtest'><td>test_invalid_values[pageLoadStrategy-interactive-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-52' class='subtest'><td>test_invalid_values[pageLoadStrategy-invalid-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-53' class='subtest'><td>test_invalid_values[pageLoadStrategy-invalid-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-46' class='subtest'><td>test_invalid_values[pageLoadStrategy-value17-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-47' class='subtest'><td>test_invalid_values[pageLoadStrategy-value17-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-48' class='subtest'><td>test_invalid_values[pageLoadStrategy-value18-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-49' class='subtest'><td>test_invalid_values[pageLoadStrategy-value18-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-36' class='subtest'><td>test_invalid_values[platformName-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-37' class='subtest'><td>test_invalid_values[platformName-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-42' class='subtest'><td>test_invalid_values[platformName-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-43' class='subtest'><td>test_invalid_values[platformName-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-38' class='subtest'><td>test_invalid_values[platformName-value13-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-39' class='subtest'><td>test_invalid_values[platformName-value13-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-40' class='subtest'><td>test_invalid_values[platformName-value14-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-41' class='subtest'><td>test_invalid_values[platformName-value14-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-66' class='subtest'><td>test_invalid_values[proxy-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-67' class='subtest'><td>test_invalid_values[proxy-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-68' class='subtest'><td>test_invalid_values[proxy-value28-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-69' class='subtest'><td>test_invalid_values[proxy-value28-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-72' class='subtest'><td>test_invalid_values[proxy-value30-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-73' class='subtest'><td>test_invalid_values[proxy-value30-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-74' class='subtest'><td>test_invalid_values[proxy-value31-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-75' class='subtest'><td>test_invalid_values[proxy-value31-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-76' class='subtest'><td>test_invalid_values[proxy-value32-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-77' class='subtest'><td>test_invalid_values[proxy-value32-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-78' class='subtest'><td>test_invalid_values[proxy-value33-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-79' class='subtest'><td>test_invalid_values[proxy-value33-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-80' class='subtest'><td>test_invalid_values[proxy-value34-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-81' class='subtest'><td>test_invalid_values[proxy-value34-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-82' class='subtest'><td>test_invalid_values[proxy-value35-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-83' class='subtest'><td>test_invalid_values[proxy-value35-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-84' class='subtest'><td>test_invalid_values[proxy-value36-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-85' class='subtest'><td>test_invalid_values[proxy-value36-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-86' class='subtest'><td>test_invalid_values[proxy-value37-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-87' class='subtest'><td>test_invalid_values[proxy-value37-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-88' class='subtest'><td>test_invalid_values[proxy-value38-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-89' class='subtest'><td>test_invalid_values[proxy-value38-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-90' class='subtest'><td>test_invalid_values[proxy-value39-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-91' class='subtest'><td>test_invalid_values[proxy-value39-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-92' class='subtest'><td>test_invalid_values[proxy-value40-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-93' class='subtest'><td>test_invalid_values[proxy-value40-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-94' class='subtest'><td>test_invalid_values[proxy-value41-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-95' class='subtest'><td>test_invalid_values[proxy-value41-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-96' class='subtest'><td>test_invalid_values[proxy-value42-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-97' class='subtest'><td>test_invalid_values[proxy-value42-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-98' class='subtest'><td>test_invalid_values[proxy-value43-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-99' class='subtest'><td>test_invalid_values[proxy-value43-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-100' class='subtest'><td>test_invalid_values[proxy-value44-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-101' class='subtest'><td>test_invalid_values[proxy-value44-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-70' class='subtest'><td>test_invalid_values[proxy-{}-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-71' class='subtest'><td>test_invalid_values[proxy-{}-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-41-102' class='subtest'><td>test_invalid_values[timeouts-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-103' class='subtest'><td>test_invalid_values[timeouts-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-108' class='subtest'><td>test_invalid_values[timeouts-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-109' class='subtest'><td>test_invalid_values[timeouts-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-104' class='subtest'><td>test_invalid_values[timeouts-value46-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-105' class='subtest'><td>test_invalid_values[timeouts-value46-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-110' class='subtest'><td>test_invalid_values[timeouts-value49-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-111' class='subtest'><td>test_invalid_values[timeouts-value49-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-112' class='subtest'><td>test_invalid_values[timeouts-value50-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-113' class='subtest'><td>test_invalid_values[timeouts-value50-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-114' class='subtest'><td>test_invalid_values[timeouts-value51-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-115' class='subtest'><td>test_invalid_values[timeouts-value51-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-116' class='subtest'><td>test_invalid_values[timeouts-value52-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-117' class='subtest'><td>test_invalid_values[timeouts-value52-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-118' class='subtest'><td>test_invalid_values[timeouts-value53-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-119' class='subtest'><td>test_invalid_values[timeouts-value53-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-120' class='subtest'><td>test_invalid_values[timeouts-value54-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-121' class='subtest'><td>test_invalid_values[timeouts-value54-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-122' class='subtest'><td>test_invalid_values[timeouts-value55-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-123' class='subtest'><td>test_invalid_values[timeouts-value55-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-124' class='subtest'><td>test_invalid_values[timeouts-value56-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-125' class='subtest'><td>test_invalid_values[timeouts-value56-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-126' class='subtest'><td>test_invalid_values[timeouts-value57-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-127' class='subtest'><td>test_invalid_values[timeouts-value57-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-128' class='subtest'><td>test_invalid_values[timeouts-value58-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-129' class='subtest'><td>test_invalid_values[timeouts-value58-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-130' class='subtest'><td>test_invalid_values[timeouts-value59-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-131' class='subtest'><td>test_invalid_values[timeouts-value59-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-132' class='subtest'><td>test_invalid_values[timeouts-value60-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-133' class='subtest'><td>test_invalid_values[timeouts-value60-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-134' class='subtest'><td>test_invalid_values[timeouts-value61-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-135' class='subtest'><td>test_invalid_values[timeouts-value61-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-106' class='subtest'><td>test_invalid_values[timeouts-{}-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-107' class='subtest'><td>test_invalid_values[timeouts-{}-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-150' class='subtest'><td>test_invalid_values[unhandledPromptBehavior- dismiss-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-151' class='subtest'><td>test_invalid_values[unhandledPromptBehavior- dismiss-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-136' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-137' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-148' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-Accept-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-149' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-Accept-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-144' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-DISMISS-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-145' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-DISMISS-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-142' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-143' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-152' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-dismiss -body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-153' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-dismiss -body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-146' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-dismissABC-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-147' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-dismissABC-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-138' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-value63-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-139' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-value63-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-140' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-value64-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-41-141' class='subtest'><td>test_invalid_values[unhandledPromptBehavior-value64-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_capabilites[None]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_capabilites[1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_capabilites[{}]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_capabilites[value3]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_always_match[None]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_always_match[1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_always_match[{}]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_always_match[value3]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_first_match[None]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_first_match[1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_first_match[[]]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_first_match[value3]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[acceptInsecureCerts-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[acceptInsecureCerts-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[acceptInsecureCerts-value1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[acceptInsecureCerts-value1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[acceptInsecureCerts-value2-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[acceptInsecureCerts-value2-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[acceptInsecureCerts-false-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[acceptInsecureCerts-false-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserName-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserName-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserName-value5-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserName-value5-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserName-value6-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserName-value6-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserName-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserName-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserVersion-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserVersion-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserVersion-value9-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserVersion-value9-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserVersion-value10-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserVersion-value10-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserVersion-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[browserVersion-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[platformName-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[platformName-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[platformName-value13-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[platformName-value13-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[platformName-value14-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[platformName-value14-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[platformName-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[platformName-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-value17-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-value17-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-value18-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-value18-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-invalid-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-invalid-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-NONE-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-NONE-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-Eager-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-Eager-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-eagerblah-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-eagerblah-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-interactive-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-interactive-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy- eager-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy- eager-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-eager -body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[pageLoadStrategy-eager -body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value28-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value28-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-{}-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-{}-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value30-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value30-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value31-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value31-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value32-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value32-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value33-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value33-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value34-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value34-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value35-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value35-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value36-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value36-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value37-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value37-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value38-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value38-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value39-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value39-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value40-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value40-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value41-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value41-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value42-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value42-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value43-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value43-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value44-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[proxy-value44-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value46-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value46-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-{}-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-{}-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value49-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value49-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value50-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value50-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value51-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value51-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value52-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value52-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value53-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value53-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value54-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value54-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value55-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value55-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value56-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value56-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value57-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value57-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value58-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value58-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value59-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value59-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value60-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value60-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value61-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[timeouts-value61-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-1-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-1-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-value63-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-value63-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-value64-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-value64-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-False-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-False-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-DISMISS-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-DISMISS-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-dismissABC-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-dismissABC-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-Accept-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-Accept-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior- dismiss-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior- dismiss-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-dismiss -body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_values[unhandledPromptBehavior-dismiss -body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[firefox-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[firefox-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[firefox_binary-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[firefox_binary-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[firefoxOptions-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[firefoxOptions-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[chromeOptions-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[chromeOptions-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[automaticInspection-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[automaticInspection-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[automaticProfiling-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[automaticProfiling-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[platform-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[platform-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[version-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[version-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[browser-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[browser-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[platformVersion-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[platformVersion-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[javascriptEnabled-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[javascriptEnabled-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[nativeEvents-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[nativeEvents-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[seleniumProtocol-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[seleniumProtocol-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[profile-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[profile-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[trustAllSSLCertificates-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[trustAllSSLCertificates-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[initialBrowserUrl-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[initialBrowserUrl-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[requireWindowFocus-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[requireWindowFocus-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[logFile-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[logFile-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[logLevel-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[logLevel-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[safari.options-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[safari.options-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[ensureCleanSession-body0]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_invalid_extensions[ensureCleanSession-body1]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-42'><td><a href='http://www.w3c-test.org/webdriver/tests/execute_script/user_prompts.py' target='_blank'>/webdriver/tests/execute_script/user_prompts.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-42-0' class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-42-3' class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-42-5' class='subtest'><td>test_handle_prompt_default</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-42-1' class='subtest'><td>test_handle_prompt_dismiss</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-42-2' class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-42-4' class='subtest'><td>test_handle_prompt_ignore</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-42-6' class='subtest'><td>test_handle_prompt_twice</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-43'><td><a href='http://www.w3c-test.org/webdriver/tests/interface.html' target='_blank'>/webdriver/tests/interface.html</a></td><td class='OK'>OK</td><td class='undefined'>-</td><td class='ERROR'>ERROR</td><td class='undefined'>-</td></tr>
-<tr id='subtest-43-1' class='subtest'><td>Navigator interface: attribute webdriver</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-43-0' class='subtest'><td>navigator.webdriver is always true</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_ignore</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_default</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_twice</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-43'><td><a href='http://www.w3c-test.org/webdriver/tests/interface.html' target='_blank'>/webdriver/tests/interface.html</a></td><td class='OK'>OK</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-44'><td><a href='http://www.w3c-test.org/webdriver/tests/cookies/get_named_cookie.py' target='_blank'>/webdriver/tests/cookies/get_named_cookie.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-44-3' class='subtest'><td>test_duplicated_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-44-1' class='subtest'><td>test_get_named_cookie</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-44-0' class='subtest'><td>test_get_named_session_cookie</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_get_named_session_cookie</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_get_named_cookie</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_duplicated_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/special_keys.py' target='_blank'>/webdriver/tests/actions/special_keys.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-79' class='subtest'><td>test_webdriver_special_key_sends_keydown[ADD-expected40]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-133' class='subtest'><td>test_webdriver_special_key_sends_keydown[ALT-expected67]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-23' class='subtest'><td>test_webdriver_special_key_sends_keydown[BACKSPACE-expected12]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-87' class='subtest'><td>test_webdriver_special_key_sends_keydown[CANCEL-expected44]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-71' class='subtest'><td>test_webdriver_special_key_sends_keydown[CLEAR-expected36]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-33' class='subtest'><td>test_webdriver_special_key_sends_keydown[CONTROL-expected17]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-53' class='subtest'><td>test_webdriver_special_key_sends_keydown[DECIMAL-expected27]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-137' class='subtest'><td>test_webdriver_special_key_sends_keydown[DELETE-expected69]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-65' class='subtest'><td>test_webdriver_special_key_sends_keydown[DIVIDE-expected33]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-17' class='subtest'><td>test_webdriver_special_key_sends_keydown[DOWN-expected9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-63' class='subtest'><td>test_webdriver_special_key_sends_keydown[END-expected32]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-85' class='subtest'><td>test_webdriver_special_key_sends_keydown[ENTER-expected43]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-75' class='subtest'><td>test_webdriver_special_key_sends_keydown[EQUALS-expected38]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-9' class='subtest'><td>test_webdriver_special_key_sends_keydown[ESCAPE-expected5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-101' class='subtest'><td>test_webdriver_special_key_sends_keydown[F1-expected51]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-91' class='subtest'><td>test_webdriver_special_key_sends_keydown[F10-expected46]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-93' class='subtest'><td>test_webdriver_special_key_sends_keydown[F11-expected47]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-19' class='subtest'><td>test_webdriver_special_key_sends_keydown[F12-expected10]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-103' class='subtest'><td>test_webdriver_special_key_sends_keydown[F2-expected52]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-105' class='subtest'><td>test_webdriver_special_key_sends_keydown[F3-expected53]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-107' class='subtest'><td>test_webdriver_special_key_sends_keydown[F4-expected54]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-109' class='subtest'><td>test_webdriver_special_key_sends_keydown[F5-expected55]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-111' class='subtest'><td>test_webdriver_special_key_sends_keydown[F6-expected56]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-113' class='subtest'><td>test_webdriver_special_key_sends_keydown[F7-expected57]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-115' class='subtest'><td>test_webdriver_special_key_sends_keydown[F8-expected58]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-117' class='subtest'><td>test_webdriver_special_key_sends_keydown[F9-expected59]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-3' class='subtest'><td>test_webdriver_special_key_sends_keydown[HELP-expected2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-27' class='subtest'><td>test_webdriver_special_key_sends_keydown[HOME-expected14]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-35' class='subtest'><td>test_webdriver_special_key_sends_keydown[INSERT-expected18]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-55' class='subtest'><td>test_webdriver_special_key_sends_keydown[LEFT-expected28]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-21' class='subtest'><td>test_webdriver_special_key_sends_keydown[META-expected11]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-25' class='subtest'><td>test_webdriver_special_key_sends_keydown[MULTIPLY-expected13]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-29' class='subtest'><td>test_webdriver_special_key_sends_keydown[NULL-expected15]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-51' class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD0-expected26]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-81' class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD1-expected41]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-99' class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD2-expected50]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-69' class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD3-expected35]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-43' class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD4-expected22]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-121' class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD5-expected61]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-89' class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD6-expected45]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-97' class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD7-expected49]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-119' class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD8-expected60]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-0' class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD9-expected0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-59' class='subtest'><td>test_webdriver_special_key_sends_keydown[PAGE_DOWN-expected30]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-11' class='subtest'><td>test_webdriver_special_key_sends_keydown[PAGE_UP-expected6]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-61' class='subtest'><td>test_webdriver_special_key_sends_keydown[PAUSE-expected31]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-1' class='subtest'><td>test_webdriver_special_key_sends_keydown[RETURN-expected1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-45' class='subtest'><td>test_webdriver_special_key_sends_keydown[RIGHT-expected23]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-49' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ALT-expected25]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-135' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWDOWN-expected68]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-73' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWLEFT-expected37]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-7' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWRIGHT-expected4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-67' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWUP-expected34]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-123' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_CONTROL-expected62]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-57' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_DELETE-expected29]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-95' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_END-expected48]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-125' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_HOME-expected63]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-83' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_INSERT-expected42]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-37' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_META-expected19]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-77' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_PAGEDOWN-expected39]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-13' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_PAGEUP-expected7]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-129' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_SHIFT-expected65]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-39' class='subtest'><td>test_webdriver_special_key_sends_keydown[SEMICOLON-expected20]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-131' class='subtest'><td>test_webdriver_special_key_sends_keydown[SEPARATOR-expected66]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-5' class='subtest'><td>test_webdriver_special_key_sends_keydown[SHIFT-expected3]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-41' class='subtest'><td>test_webdriver_special_key_sends_keydown[SPACE-expected21]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-31' class='subtest'><td>test_webdriver_special_key_sends_keydown[SUBTRACT-expected16]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-47' class='subtest'><td>test_webdriver_special_key_sends_keydown[TAB-expected24]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-15' class='subtest'><td>test_webdriver_special_key_sends_keydown[UP-expected8]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-127' class='subtest'><td>test_webdriver_special_key_sends_keydown[ZENKAKUHANKAKU-expected64]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD9-expected0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[RETURN-expected1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[HELP-expected2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[SHIFT-expected3]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWRIGHT-expected4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[ESCAPE-expected5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[PAGE_UP-expected6]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_PAGEUP-expected7]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[UP-expected8]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[DOWN-expected9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F12-expected10]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[META-expected11]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[BACKSPACE-expected12]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[MULTIPLY-expected13]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[HOME-expected14]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NULL-expected15]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[SUBTRACT-expected16]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[CONTROL-expected17]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[INSERT-expected18]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_META-expected19]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[SEMICOLON-expected20]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[SPACE-expected21]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD4-expected22]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[RIGHT-expected23]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[TAB-expected24]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ALT-expected25]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD0-expected26]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[DECIMAL-expected27]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[LEFT-expected28]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_DELETE-expected29]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[PAGE_DOWN-expected30]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[PAUSE-expected31]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[END-expected32]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[DIVIDE-expected33]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWUP-expected34]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD3-expected35]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[CLEAR-expected36]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWLEFT-expected37]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[EQUALS-expected38]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_PAGEDOWN-expected39]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[ADD-expected40]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD1-expected41]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_INSERT-expected42]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[ENTER-expected43]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[CANCEL-expected44]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD6-expected45]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F10-expected46]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F11-expected47]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_END-expected48]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD7-expected49]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD2-expected50]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F1-expected51]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F2-expected52]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F3-expected53]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F4-expected54]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F5-expected55]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F6-expected56]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F7-expected57]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F8-expected58]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[F9-expected59]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD8-expected60]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD5-expected61]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_CONTROL-expected62]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_HOME-expected63]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[ZENKAKUHANKAKU-expected64]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_SHIFT-expected65]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[SEPARATOR-expected66]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[ALT-expected67]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWDOWN-expected68]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[DELETE-expected69]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-46'><td><a href='http://www.w3c-test.org/webdriver/tests/cookies/delete_cookie.py' target='_blank'>/webdriver/tests/cookies/delete_cookie.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-46-2' class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-46-1' class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-46-3' class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-46-5' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-46-0' class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-46-6' class='subtest'><td>test_unknown_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_ignore</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_unknown_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
 <tr class='test' id='test-file-47'><td><a href='http://www.w3c-test.org/webdriver/tests/element_click/stale.py' target='_blank'>/webdriver/tests/element_click/stale.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-47-0' class='subtest'><td>test_is_stale</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_is_stale</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-48'><td><a href='http://www.w3c-test.org/webdriver/tests/interaction/element_clear.py' target='_blank'>/webdriver/tests/interaction/element_clear.py</a></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-48-57' class='subtest'><td>test_button</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-3' class='subtest'><td>test_button_element_not_resettable</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-58' class='subtest'><td>test_button_with_subtree</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-9' class='subtest'><td>test_clear_content_editable_resettable_element[element0]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-19' class='subtest'><td>test_clear_content_editable_resettable_element[element10]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-20' class='subtest'><td>test_clear_content_editable_resettable_element[element11]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-21' class='subtest'><td>test_clear_content_editable_resettable_element[element12]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-22' class='subtest'><td>test_clear_content_editable_resettable_element[element13]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-23' class='subtest'><td>test_clear_content_editable_resettable_element[element14]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-24' class='subtest'><td>test_clear_content_editable_resettable_element[element15]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-10' class='subtest'><td>test_clear_content_editable_resettable_element[element1]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-11' class='subtest'><td>test_clear_content_editable_resettable_element[element2]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-12' class='subtest'><td>test_clear_content_editable_resettable_element[element3]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-13' class='subtest'><td>test_clear_content_editable_resettable_element[element4]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-14' class='subtest'><td>test_clear_content_editable_resettable_element[element5]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-15' class='subtest'><td>test_clear_content_editable_resettable_element[element6]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-16' class='subtest'><td>test_clear_content_editable_resettable_element[element7]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-17' class='subtest'><td>test_clear_content_editable_resettable_element[element8]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-18' class='subtest'><td>test_clear_content_editable_resettable_element[element9]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-0' class='subtest'><td>test_closed_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-1' class='subtest'><td>test_connected_element</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-59' class='subtest'><td>test_contenteditable</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-60' class='subtest'><td>test_contenteditable_focus</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-60' class='subtest'><td>test_designmode</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-4' class='subtest'><td>test_disabled_element_not_resettable</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-48-7' class='subtest'><td>test_element_disabled</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-48-2' class='subtest'><td>test_element_not_editable</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-1' class='subtest'><td>test_element_not_found</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-8' class='subtest'><td>test_element_pointer_events_disabled</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-6' class='subtest'><td>test_element_readonly</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-48-12' class='subtest'><td>test_input[color-#ff0000-#000000]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-13' class='subtest'><td>test_input[date-2017-12-26-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-14' class='subtest'><td>test_input[datetime-2017-12-26T19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-15' class='subtest'><td>test_input[datetime-local-2017-12-26T19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-6' class='subtest'><td>test_input[email-foo@example.com-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-17' class='subtest'><td>test_input[month-2017-11-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-4' class='subtest'><td>test_input[number-42-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-7' class='subtest'><td>test_input[password-password-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-5' class='subtest'><td>test_input[range-42-50]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-8' class='subtest'><td>test_input[search-search-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-9' class='subtest'><td>test_input[tel-999-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-10' class='subtest'><td>test_input[text-text-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-16' class='subtest'><td>test_input[time-19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-11' class='subtest'><td>test_input[url-https://example.com/-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-18' class='subtest'><td>test_input[week-2017-W52-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-27' class='subtest'><td>test_input_disabled[color]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-28' class='subtest'><td>test_input_disabled[date]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-30' class='subtest'><td>test_input_disabled[datetime-local]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-29' class='subtest'><td>test_input_disabled[datetime]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-21' class='subtest'><td>test_input_disabled[email]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-34' class='subtest'><td>test_input_disabled[file]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-32' class='subtest'><td>test_input_disabled[month]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-19' class='subtest'><td>test_input_disabled[number]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-22' class='subtest'><td>test_input_disabled[password]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-20' class='subtest'><td>test_input_disabled[range]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-23' class='subtest'><td>test_input_disabled[search]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-24' class='subtest'><td>test_input_disabled[tel]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-25' class='subtest'><td>test_input_disabled[text]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-31' class='subtest'><td>test_input_disabled[time]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-26' class='subtest'><td>test_input_disabled[url]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-33' class='subtest'><td>test_input_disabled[week]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-54' class='subtest'><td>test_input_file</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-55' class='subtest'><td>test_input_file_multiple</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-43' class='subtest'><td>test_input_readonly[color]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-44' class='subtest'><td>test_input_readonly[date]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-46' class='subtest'><td>test_input_readonly[datetime-local]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-45' class='subtest'><td>test_input_readonly[datetime]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-37' class='subtest'><td>test_input_readonly[email]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-50' class='subtest'><td>test_input_readonly[file]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-48' class='subtest'><td>test_input_readonly[month]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-35' class='subtest'><td>test_input_readonly[number]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-38' class='subtest'><td>test_input_readonly[password]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-36' class='subtest'><td>test_input_readonly[range]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-39' class='subtest'><td>test_input_readonly[search]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-40' class='subtest'><td>test_input_readonly[tel]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-41' class='subtest'><td>test_input_readonly[text]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-47' class='subtest'><td>test_input_readonly[time]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-42' class='subtest'><td>test_input_readonly[url]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-49' class='subtest'><td>test_input_readonly[week]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-3' class='subtest'><td>test_keyboard_interactable</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-0' class='subtest'><td>test_no_browsing_context</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-48-77' class='subtest'><td>test_non_editable_inputs[button]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-73' class='subtest'><td>test_non_editable_inputs[checkbox]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-75' class='subtest'><td>test_non_editable_inputs[hidden]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-78' class='subtest'><td>test_non_editable_inputs[image]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-74' class='subtest'><td>test_non_editable_inputs[radio]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-76' class='subtest'><td>test_non_editable_inputs[submit]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-2' class='subtest'><td>test_pointer_interactable</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-66' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[color-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-67' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[date-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-68' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[datetime-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-69' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[datetime-local-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-64' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[email-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-71' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[month-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-62' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[number-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-63' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[range-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-70' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[time-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-65' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[url-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-72' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[week-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-62' class='subtest'><td>test_resettable_element_focus</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-61' class='subtest'><td>test_resettable_element_focus_when_empty</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-5' class='subtest'><td>test_scroll_into_element_view</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-79' class='subtest'><td>test_scroll_into_view</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-56' class='subtest'><td>test_select</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-51' class='subtest'><td>test_textarea</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-52' class='subtest'><td>test_textarea_disabled</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-53' class='subtest'><td>test_textarea_readonly</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_closed_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_connected_element</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_pointer_interactable</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_keyboard_interactable</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[number-42-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[range-42-50]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[email-foo@example.com-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[password-password-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[search-search-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[tel-999-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[text-text-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[url-https://example.com/-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[color-#ff0000-#000000]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[date-2017-12-26-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[datetime-2017-12-26T19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[datetime-local-2017-12-26T19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[time-19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[month-2017-11-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[week-2017-W52-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[number]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[range]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[email]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[password]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[search]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[tel]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[text]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[url]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[color]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[date]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[datetime]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[datetime-local]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[time]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[month]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[week]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_disabled[file]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[number]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[range]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[email]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[password]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[search]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[tel]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[text]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[url]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[color]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[date]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[datetime]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[datetime-local]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[time]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[month]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[week]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_readonly[file]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_textarea</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_textarea_disabled</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_textarea_readonly</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_file</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input_file_multiple</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_select</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_button</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_button_with_subtree</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_contenteditable</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_designmode</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_focus_when_empty</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[number-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[range-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[email-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[url-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[color-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[date-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[datetime-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[datetime-local-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[time-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[month-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[week-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_non_editable_inputs[checkbox]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_non_editable_inputs[radio]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_non_editable_inputs[hidden]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_non_editable_inputs[submit]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_non_editable_inputs[button]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_non_editable_inputs[image]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_scroll_into_view</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
 <tr class='test' id='test-file-49'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/new_session/create_alwaysMatch.py' target='_blank'>/webdriver/tests/sessions/new_session/create_alwaysMatch.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-49-0' class='subtest'><td>test_valid[acceptInsecureCerts-False]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-1' class='subtest'><td>test_valid[acceptInsecureCerts-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-2' class='subtest'><td>test_valid[browserName-None]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-3' class='subtest'><td>test_valid[browserVersion-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-8' class='subtest'><td>test_valid[pageLoadStrategy-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-6' class='subtest'><td>test_valid[pageLoadStrategy-eager]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-5' class='subtest'><td>test_valid[pageLoadStrategy-none]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-7' class='subtest'><td>test_valid[pageLoadStrategy-normal]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-4' class='subtest'><td>test_valid[platformName-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-9' class='subtest'><td>test_valid[proxy-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-19' class='subtest'><td>test_valid[test:extension-123]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-22' class='subtest'><td>test_valid[test:extension-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-17' class='subtest'><td>test_valid[test:extension-True]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-18' class='subtest'><td>test_valid[test:extension-abc]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-20' class='subtest'><td>test_valid[test:extension-value20]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-21' class='subtest'><td>test_valid[test:extension-value21]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-10' class='subtest'><td>test_valid[timeouts-value10]</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-49-11' class='subtest'><td>test_valid[timeouts-value11]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-12' class='subtest'><td>test_valid[timeouts-value12]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-13' class='subtest'><td>test_valid[timeouts-value13]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-16' class='subtest'><td>test_valid[unhandledPromptBehavior-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-15' class='subtest'><td>test_valid[unhandledPromptBehavior-accept]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-49-14' class='subtest'><td>test_valid[unhandledPromptBehavior-dismiss]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[acceptInsecureCerts-False]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[acceptInsecureCerts-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[browserName-None]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[browserVersion-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[platformName-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[pageLoadStrategy-none]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[pageLoadStrategy-eager]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[pageLoadStrategy-normal]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[pageLoadStrategy-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[proxy-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[timeouts-value10]</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_valid[timeouts-value11]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[timeouts-value12]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[timeouts-value13]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[unhandledPromptBehavior-dismiss]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[unhandledPromptBehavior-accept]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[unhandledPromptBehavior-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-True]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-abc]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-123]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-value20]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-value21]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_valid[test:extension-None]</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-50'><td><a href='http://www.w3c-test.org/webdriver/tests/element_retrieval/get_active_element.py' target='_blank'>/webdriver/tests/element_retrieval/get_active_element.py</a></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-50-0' class='subtest'><td>test_closed_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-50-3' class='subtest'><td>test_handle_prompt_missing_value</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-50-9' class='subtest'><td>test_missing_document_element</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-50-4' class='subtest'><td>test_success_document</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-50-7' class='subtest'><td>test_success_explicit_focus</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-50-8' class='subtest'><td>test_success_iframe_content</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-50-5' class='subtest'><td>test_sucess_input</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-50-6' class='subtest'><td>test_sucess_input_non_interactable</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_closed_context</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_success_document</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_sucess_input</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_sucess_input_non_interactable</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_success_explicit_focus</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_success_iframe_content</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_missing_document_element</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-51'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/new_session/merge.py' target='_blank'>/webdriver/tests/sessions/new_session/merge.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-51-8' class='subtest'><td>test_merge_browserName</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-51-2' class='subtest'><td>test_merge_invalid[acceptInsecureCerts-value0]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-51-5' class='subtest'><td>test_merge_invalid[timeouts-value3]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-51-6' class='subtest'><td>test_merge_invalid[timeouts-value4]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-51-3' class='subtest'><td>test_merge_invalid[unhandledPromptBehavior-value1]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-51-4' class='subtest'><td>test_merge_invalid[unhandledPromptBehavior-value2]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-51-7' class='subtest'><td>test_merge_platformName</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-51-0' class='subtest'><td>test_platform_name[body0]</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-51-1' class='subtest'><td>test_platform_name[body1]</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_platform_name[body0]</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_platform_name[body1]</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_merge_invalid[acceptInsecureCerts-value0]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_merge_invalid[unhandledPromptBehavior-value1]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_merge_invalid[unhandledPromptBehavior-value2]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_merge_invalid[timeouts-value3]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_merge_invalid[timeouts-value4]</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_merge_platformName</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_merge_browserName</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-52'><td><a href='http://www.w3c-test.org/webdriver/tests/state/get_element_attribute.py' target='_blank'>/webdriver/tests/state/get_element_attribute.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-52-10' class='subtest'><td>test_boolean_attribute[audio-attrs0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-12' class='subtest'><td>test_boolean_attribute[button-attrs1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-52-14' class='subtest'><td>test_boolean_attribute[details-attrs2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-16' class='subtest'><td>test_boolean_attribute[dialog-attrs3]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-52-18' class='subtest'><td>test_boolean_attribute[fieldset-attrs4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-20' class='subtest'><td>test_boolean_attribute[form-attrs5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-52-22' class='subtest'><td>test_boolean_attribute[iframe-attrs6]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-52-24' class='subtest'><td>test_boolean_attribute[img-attrs7]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-52-26' class='subtest'><td>test_boolean_attribute[input-attrs8]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-52-28' class='subtest'><td>test_boolean_attribute[menuitem-attrs9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-52-30' class='subtest'><td>test_boolean_attribute[object-attrs10]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-52-32' class='subtest'><td>test_boolean_attribute[ol-attrs11]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-34' class='subtest'><td>test_boolean_attribute[optgroup-attrs12]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-36' class='subtest'><td>test_boolean_attribute[option-attrs13]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-38' class='subtest'><td>test_boolean_attribute[script-attrs14]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-40' class='subtest'><td>test_boolean_attribute[select-attrs15]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-42' class='subtest'><td>test_boolean_attribute[textarea-attrs16]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-44' class='subtest'><td>test_boolean_attribute[track-attrs17]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-46' class='subtest'><td>test_boolean_attribute[video-attrs18]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-4' class='subtest'><td>test_element_not_found</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-52-6' class='subtest'><td>test_element_stale</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-48' class='subtest'><td>test_global_boolean_attributes</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-52-3' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-0' class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-52-8' class='subtest'><td>test_normal</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_element_not_found</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_element_stale</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_normal</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[audio-attrs0]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[button-attrs1]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[details-attrs2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[dialog-attrs3]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[fieldset-attrs4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[form-attrs5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[iframe-attrs6]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[img-attrs7]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[input-attrs8]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[menuitem-attrs9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[object-attrs10]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[ol-attrs11]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[optgroup-attrs12]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[option-attrs13]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[script-attrs14]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[select-attrs15]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[textarea-attrs16]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[track-attrs17]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[video-attrs18]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_global_boolean_attributes</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
 <tr class='test' id='test-file-53'><td><a href='http://www.w3c-test.org/webdriver/tests/navigation/current_url.py' target='_blank'>/webdriver/tests/navigation/current_url.py</a></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-53-13' class='subtest'><td>test_get_current_url_after_modified_location</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-53-1' class='subtest'><td>test_get_current_url_alert_prompt</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-53-9' class='subtest'><td>test_get_current_url_file_protocol</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-53-3' class='subtest'><td>test_get_current_url_matches_location</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-53-15' class='subtest'><td>test_get_current_url_nested_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-53-17' class='subtest'><td>test_get_current_url_nested_browsing_contexts</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-53-0' class='subtest'><td>test_get_current_url_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-53-5' class='subtest'><td>test_get_current_url_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-53-7' class='subtest'><td>test_get_current_url_special_pages</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-53-11' class='subtest'><td>test_set_malformed_url</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_get_current_url_no_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_current_url_alert_prompt</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_current_url_matches_location</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_current_url_payload</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_current_url_special_pages</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_get_current_url_file_protocol</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_set_malformed_url</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_get_current_url_after_modified_location</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_get_current_url_nested_browsing_context</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_get_current_url_nested_browsing_contexts</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td><td class='PASS'>PASS</td></tr>
 <tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/webdriver/tests/element_send_keys/form_controls.py' target='_blank'>/webdriver/tests/element_send_keys/form_controls.py</a></td><td class='undefined'>-</td><td class='OK'>OK</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-4' class='subtest'><td>test_events[input]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-5' class='subtest'><td>test_events[textarea]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-0' class='subtest'><td>test_input</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-2' class='subtest'><td>test_input_append</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-1' class='subtest'><td>test_textarea</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-3' class='subtest'><td>test_textarea_append</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
 
       </table>
     </div>
     <script src='jquery.min.js'></script>
     <script src='sticky-headers.js'></script>
-    <script type='application/javascript'>
-
-    </script>
   </body>
 </html>

--- a/results/html/analysis.css
+++ b/results/html/analysis.css
@@ -1,27 +1,23 @@
-a {
-  color: hsl(213, 65%, 48%);
-}
-
 
 th {
     text-align: left;
-    background: hsl(213, 65%, 48%);
+    background: #4a89dc;
     color:      #fff;
 }
 
 td.FAIL {
-    background: hsl(353, 65%, 52%);
+    background: #da4453;
     color:      #fff;
 }
 
 td.PASS {
-    background: hsl(165, 50%, 35%);
+    background: #37bc9b;
     color:      #fff;
 }
 
 td.NOTRUN, td.TIMEOUT, td.undefined {
     background: #f6bb42;
-    color:  hsl(219, 8%, 33%);
+    color:  #fff;
 }
 
 table > tbody > tr > td.NOTRUN, table > tbody > tr > td.TIMEOUT {
@@ -57,28 +53,10 @@ tr.subtest > td:first-of-type {
     white-space:    nowrap;
 }
 
-tr.messages > td:first-of-type {
-    width: 100%;
-    padding-left:   2em;
-}
-
-tr.message > td.ua {
-  font-weight: bold;
-  vertical-align: top;
-  padding-right: 1em;
-}
-
 .floatingHeader {
     position: fixed;
     top: 0;
     visibility: hidden;
-}
-
-.message_toggle {
-  padding-left: 3em;
-  display: none;
-  font-size: 0.7em;
-  cursor: pointer;
 }
 
 dd {

--- a/results/html/complete-fails.html
+++ b/results/html/complete-fails.html
@@ -2,88 +2,33 @@
 <html lang='en'>
   <head>
     <meta charset='utf-8'>
-    <title>WebDriver: Complete Failures</title>
+    <title>Complete Failures</title>
     <link rel='stylesheet' href='bootstrap.min.css'>
     <link rel='stylesheet' href='analysis.css'>
   </head>
   <body>
     <div class='container'>
       <header>
-        <h1>WebDriver: Complete Failures</h1>
+        <h1>Complete Failures</h1>
       </header>
-      
-      <p><strong>Completely failed files</strong>: 31; <strong>Completely failed subtests</strong>: 42; <strong>Failure level</strong>: 42/897 (4.68%)</p>
+      <p><strong>Completely failed files</strong>: 19; <strong>Completely failed subtests</strong>: 5; <strong>Failure level</strong>: 5/862 (0.58%)</p>
       <h3>Test Files</h3>
-<ol class='toc'><li><a href='#test-file-0'>/webdriver/tests/contexts/maximize_window.py</a> <small>(1/11, 9.09%, 0.11% of total)</small></li>
-<li><a href='#test-file-1'>/webdriver/tests/minimize_window.py</a> <small>(1/10, 10.00%, 0.11% of total)</small></li>
-<li><a href='#test-file-2'>/webdriver/tests/state/get_element_property.py</a> <small>(1/8, 12.50%, 0.11% of total)</small></li>
-<li><a href='#test-file-3'>/webdriver/tests/fullscreen_window.py</a> <small>(2/9, 22.22%, 0.22% of total)</small></li>
-<li><a href='#test-file-4'>/webdriver/tests/contexts/json_serialize_windowproxy.py</a> <small>(3/3, 100.00%, 0.33% of total)</small></li>
-<li><a href='#test-file-5'>/webdriver/tests/cookies/add_cookie.py</a> <small>(4/5, 80.00%, 0.45% of total)</small></li>
-<li><a href='#test-file-6'>/webdriver/tests/cookies/delete_cookie.py</a> <small>(1/7, 14.29%, 0.11% of total)</small></li>
-<li><a href='#test-file-7'>/webdriver/tests/interaction/element_clear.py</a> <small>(27/107, 25.23%, 3.01% of total)</small></li>
-<li><a href='#test-file-8'>/webdriver/tests/element_send_keys/form_controls.py</a> <small>(2/6, 33.33%, 0.22% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/webdriver/tests/contexts/json_serialize_windowproxy.py</a> <small>(3/3, 100.00%, 0.35% of total)</small></li>
+<li><a href='#test-file-1'>/webdriver/tests/interaction/element_clear.py</a> <small>(2/80, 2.50%, 0.23% of total)</small></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>eg42</th><th>ff60</th><th>ie11</th><th>wk18</th></tr></thead>
-<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/webdriver/tests/contexts/maximize_window.py' target='_blank'>/webdriver/tests/contexts/maximize_window.py</a> <small>(1/11, 9.09%, 0.11% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-3-4' class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
-<tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/webdriver/tests/minimize_window.py' target='_blank'>/webdriver/tests/minimize_window.py</a> <small>(1/10, 10.00%, 0.11% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-8-4' class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
-<tr class='test' id='test-file-12'><td><a href='http://www.w3c-test.org/webdriver/tests/state/get_element_property.py' target='_blank'>/webdriver/tests/state/get_element_property.py</a> <small>(1/8, 12.50%, 0.11% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-12-10' class='subtest'><td>test_element</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
-<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/webdriver/tests/fullscreen_window.py' target='_blank'>/webdriver/tests/fullscreen_window.py</a> <small>(2/9, 22.22%, 0.22% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-14-4' class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-14-5' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
-<tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/webdriver/tests/contexts/json_serialize_windowproxy.py' target='_blank'>/webdriver/tests/contexts/json_serialize_windowproxy.py</a> <small>(3/3, 100.00%, 0.33% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-19-3' class='subtest'><td>test_frame</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-19-0' class='subtest'><td>test_initial_window</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-19-1' class='subtest'><td>test_window_open</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
-<tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/webdriver/tests/cookies/add_cookie.py' target='_blank'>/webdriver/tests/cookies/add_cookie.py</a> <small>(4/5, 80.00%, 0.45% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-27-1' class='subtest'><td>test_add_cookie_for_ip</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-27-0' class='subtest'><td>test_add_domain_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-27-3' class='subtest'><td>test_add_non_session_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-27-7' class='subtest'><td>test_add_session_cookie_with_leading_dot_character_in_domain</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-46'><td><a href='http://www.w3c-test.org/webdriver/tests/cookies/delete_cookie.py' target='_blank'>/webdriver/tests/cookies/delete_cookie.py</a> <small>(1/7, 14.29%, 0.11% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-46-6' class='subtest'><td>test_unknown_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-48'><td><a href='http://www.w3c-test.org/webdriver/tests/interaction/element_clear.py' target='_blank'>/webdriver/tests/interaction/element_clear.py</a> <small>(27/107, 25.23%, 3.01% of total)</small></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-48-3' class='subtest'><td>test_button_element_not_resettable</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-9' class='subtest'><td>test_clear_content_editable_resettable_element[element0]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-19' class='subtest'><td>test_clear_content_editable_resettable_element[element10]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-20' class='subtest'><td>test_clear_content_editable_resettable_element[element11]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-21' class='subtest'><td>test_clear_content_editable_resettable_element[element12]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-22' class='subtest'><td>test_clear_content_editable_resettable_element[element13]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-23' class='subtest'><td>test_clear_content_editable_resettable_element[element14]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-24' class='subtest'><td>test_clear_content_editable_resettable_element[element15]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-10' class='subtest'><td>test_clear_content_editable_resettable_element[element1]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-11' class='subtest'><td>test_clear_content_editable_resettable_element[element2]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-12' class='subtest'><td>test_clear_content_editable_resettable_element[element3]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-13' class='subtest'><td>test_clear_content_editable_resettable_element[element4]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-14' class='subtest'><td>test_clear_content_editable_resettable_element[element5]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-15' class='subtest'><td>test_clear_content_editable_resettable_element[element6]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-16' class='subtest'><td>test_clear_content_editable_resettable_element[element7]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-17' class='subtest'><td>test_clear_content_editable_resettable_element[element8]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-18' class='subtest'><td>test_clear_content_editable_resettable_element[element9]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-1' class='subtest'><td>test_connected_element</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-59' class='subtest'><td>test_contenteditable</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-60' class='subtest'><td>test_contenteditable_focus</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-2' class='subtest'><td>test_element_not_editable</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-1' class='subtest'><td>test_element_not_found</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-8' class='subtest'><td>test_element_pointer_events_disabled</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr id='subtest-48-12' class='subtest'><td>test_input[color-#ff0000-#000000]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-5' class='subtest'><td>test_input[range-42-50]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-62' class='subtest'><td>test_resettable_element_focus</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-5' class='subtest'><td>test_scroll_into_element_view</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='XFAIL'>XFAIL</td></tr>
-<tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/webdriver/tests/element_send_keys/form_controls.py' target='_blank'>/webdriver/tests/element_send_keys/form_controls.py</a> <small>(2/6, 33.33%, 0.22% of total)</small></td><td class='undefined'>-</td><td class='OK'>OK</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-4' class='subtest'><td>test_events[input]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-5' class='subtest'><td>test_events[textarea]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
+        <thead><tr class='persist-header'><th>Test</th><th>eg42</th><th>ff60</th><th>ie11</th><th>wk18</th></tr></thead>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/webdriver/tests/contexts/json_serialize_windowproxy.py' target='_blank'>/webdriver/tests/contexts/json_serialize_windowproxy.py</a> <small>(3/3, 100.00%, 0.35% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_initial_window</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_window_open</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_frame</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/webdriver/tests/interaction/element_clear.py' target='_blank'>/webdriver/tests/interaction/element_clear.py</a> <small>(2/80, 2.50%, 0.23% of total)</small></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_input[color-#ff0000-#000000]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_contenteditable</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
 
       </table>
     </div>
     <script src='jquery.min.js'></script>
     <script src='sticky-headers.js'></script>
-    <script type='application/javascript'>
-      
-    </script>
   </body>
 </html>

--- a/results/html/consolidated.json
+++ b/results/html/consolidated.json
@@ -13,21 +13,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_source_matches_outer_html": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -44,21 +39,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -66,60 +56,47 @@
           }
         },
         "test_handle_prompt_dismiss": {
-          "stNum": 1,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_handle_prompt_accept": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_handle_prompt_missing_value": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
-            "PASS": 2,
-            "FAIL": 1
+            "PASS": 3
           }
         },
         "test_element_stale": {
-          "stNum": 4,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -128,15 +105,11 @@
           }
         },
         "test_element_checked": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -144,15 +117,11 @@
           }
         },
         "test_checkbox_not_selected": {
-          "stNum": 8,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -160,15 +129,11 @@
           }
         },
         "test_element_selected": {
-          "stNum": 10,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -176,15 +141,11 @@
           }
         },
         "test_element_not_selected": {
-          "stNum": 12,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -199,20 +160,15 @@
         "ff60": "OK",
         "ie11": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "test_click_at_coordinates": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -220,14 +176,10 @@
           }
         },
         "test_context_menu_at_coordinates": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -236,14 +188,10 @@
           }
         },
         "test_click_element_center": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -252,14 +200,10 @@
           }
         },
         "test_click_navigation": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -268,14 +212,10 @@
           }
         },
         "test_drag_and_drop[20-0-0]": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -284,14 +224,10 @@
           }
         },
         "test_drag_and_drop[20-0-300]": {
-          "stNum": 9,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -300,14 +236,10 @@
           }
         },
         "test_drag_and_drop[20-0-800]": {
-          "stNum": 11,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -316,14 +248,10 @@
           }
         },
         "test_drag_and_drop[0-15-0]": {
-          "stNum": 13,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -332,14 +260,10 @@
           }
         },
         "test_drag_and_drop[0-15-300]": {
-          "stNum": 15,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -348,14 +272,10 @@
           }
         },
         "test_drag_and_drop[0-15-800]": {
-          "stNum": 17,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -364,14 +284,10 @@
           }
         },
         "test_drag_and_drop[10-15-0]": {
-          "stNum": 19,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -380,14 +296,10 @@
           }
         },
         "test_drag_and_drop[10-15-300]": {
-          "stNum": 21,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -396,14 +308,10 @@
           }
         },
         "test_drag_and_drop[10-15-800]": {
-          "stNum": 23,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -412,14 +320,10 @@
           }
         },
         "test_drag_and_drop[-20-0-0]": {
-          "stNum": 25,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -428,14 +332,10 @@
           }
         },
         "test_drag_and_drop[-20-0-300]": {
-          "stNum": 27,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -444,14 +344,10 @@
           }
         },
         "test_drag_and_drop[-20-0-800]": {
-          "stNum": 29,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -460,14 +356,10 @@
           }
         },
         "test_drag_and_drop[10--15-0]": {
-          "stNum": 31,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -476,14 +368,10 @@
           }
         },
         "test_drag_and_drop[10--15-300]": {
-          "stNum": 33,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -492,14 +380,10 @@
           }
         },
         "test_drag_and_drop[10--15-800]": {
-          "stNum": 35,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -508,14 +392,10 @@
           }
         },
         "test_drag_and_drop[-10--15-0]": {
-          "stNum": 37,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -524,14 +404,10 @@
           }
         },
         "test_drag_and_drop[-10--15-300]": {
-          "stNum": 39,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -540,14 +416,10 @@
           }
         },
         "test_drag_and_drop[-10--15-800]": {
-          "stNum": 41,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -564,21 +436,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -587,86 +454,70 @@
           }
         },
         "test_handle_prompt_dismiss_and_notify": {
-          "stNum": 1,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept_and_notify": {
-          "stNum": 2,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_ignore": {
-          "stNum": 3,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept": {
-          "stNum": 4,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
+            "FAIL": 2,
+            "PASS": 1,
             "XFAIL": 1
           }
         },
         "test_handle_prompt_missing_value": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
-            "PASS": 1,
-            "FAIL": 1,
+            "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_fully_exit_fullscreen": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -676,15 +527,11 @@
           }
         },
         "test_restore_the_window": {
-          "stNum": 8,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -694,15 +541,11 @@
           }
         },
         "test_maximize": {
-          "stNum": 10,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -712,15 +555,11 @@
           }
         },
         "test_payload": {
-          "stNum": 12,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -730,15 +569,11 @@
           }
         },
         "test_maximize_twice_is_idempotent": {
-          "stNum": 14,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -756,140 +591,125 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "TIMEOUT": 1,
         "OK": 3
       },
       "subtests": {
+        "/webdriver/tests/user_prompts/send_alert_text.py": {
+          "byUA": {
+            "eg42": "TIMEOUT"
+          },
+          "totals": {
+            "TIMEOUT": 1
+          }
+        },
         "test_invalid_input[None]": {
-          "stNum": 0,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_input[text1]": {
-          "stNum": 1,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_input[text2]": {
-          "stNum": 2,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_input[42]": {
-          "stNum": 3,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_input[True]": {
-          "stNum": 4,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_no_browsing_context": {
-          "stNum": 5,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_no_user_prompt": {
-          "stNum": 6,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_alert_element_not_interactable": {
-          "stNum": 7,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_confirm_element_not_interactable": {
-          "stNum": 8,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_send_alert_text": {
-          "stNum": 9,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_send_alert_text_with_whitespace": {
-          "stNum": 10,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -903,68 +723,65 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "TIMEOUT": 1,
         "OK": 3
       },
       "subtests": {
+        "/webdriver/tests/user_prompts/get_alert_text.py": {
+          "byUA": {
+            "eg42": "TIMEOUT"
+          },
+          "totals": {
+            "TIMEOUT": 1
+          }
+        },
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_no_user_prompt": {
-          "stNum": 1,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_get_alert_text": {
-          "stNum": 2,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_get_confirm_text": {
-          "stNum": 3,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_get_prompt_text": {
-          "stNum": 4,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -978,34 +795,29 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_get_status_no_session": {
-          "stNum": 0,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
           }
         },
         "test_status_with_session_running_on_endpoint_node": {
-          "stNum": 1,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
@@ -1020,21 +832,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_sets_insertion_point_to_end": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -1043,15 +850,11 @@
           }
         },
         "test_sets_insertion_point_to_after_last_text_node": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1069,21 +872,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -1092,86 +890,70 @@
           }
         },
         "test_handle_prompt_dismiss_and_notify": {
-          "stNum": 1,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept_and_notify": {
-          "stNum": 2,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_ignore": {
-          "stNum": 3,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept": {
-          "stNum": 4,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
+            "FAIL": 2,
+            "PASS": 1,
             "XFAIL": 1
           }
         },
         "test_handle_prompt_missing_value": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
-            "PASS": 1,
-            "FAIL": 1,
+            "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_fully_exit_fullscreen": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -1181,15 +963,11 @@
           }
         },
         "test_minimize": {
-          "stNum": 8,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1199,15 +977,11 @@
           }
         },
         "test_payload": {
-          "stNum": 10,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1217,15 +991,11 @@
           }
         },
         "test_minimize_twice_is_idempotent": {
-          "stNum": 12,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1243,21 +1013,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_invalid_using_argument[a]": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -1265,15 +1030,11 @@
           }
         },
         "test_invalid_using_argument[True]": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1282,15 +1043,11 @@
           }
         },
         "test_invalid_using_argument[None]": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1299,15 +1056,11 @@
           }
         },
         "test_invalid_using_argument[1]": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1316,15 +1069,11 @@
           }
         },
         "test_invalid_using_argument[using4]": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1333,15 +1082,11 @@
           }
         },
         "test_invalid_using_argument[using5]": {
-          "stNum": 9,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1350,15 +1095,11 @@
           }
         },
         "test_invalid_selector_argument[None]": {
-          "stNum": 11,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1367,15 +1108,11 @@
           }
         },
         "test_invalid_selector_argument[value1]": {
-          "stNum": 13,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1384,15 +1121,11 @@
           }
         },
         "test_invalid_selector_argument[value2]": {
-          "stNum": 15,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1401,15 +1134,11 @@
           }
         },
         "test_closed_context": {
-          "stNum": 17,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1418,15 +1147,11 @@
           }
         },
         "test_find_elements[css selector-#linkText]": {
-          "stNum": 19,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -1434,15 +1159,11 @@
           }
         },
         "test_find_elements[link text-full link text]": {
-          "stNum": 21,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -1450,15 +1171,11 @@
           }
         },
         "test_find_elements[partial link text-link text]": {
-          "stNum": 23,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -1466,15 +1183,11 @@
           }
         },
         "test_find_elements[tag name-a]": {
-          "stNum": 25,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -1482,15 +1195,11 @@
           }
         },
         "test_find_elements[xpath-//a]": {
-          "stNum": 27,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -1498,15 +1207,11 @@
           }
         },
         "test_no_element[css selector-#wontExist]": {
-          "stNum": 29,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -1514,15 +1219,11 @@
           }
         },
         "test_xhtml_namespace[css selector-#linkText]": {
-          "stNum": 31,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1531,15 +1232,11 @@
           }
         },
         "test_xhtml_namespace[link text-full link text]": {
-          "stNum": 33,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1548,15 +1245,11 @@
           }
         },
         "test_xhtml_namespace[partial link text-link text]": {
-          "stNum": 35,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1565,15 +1258,11 @@
           }
         },
         "test_xhtml_namespace[tag name-a]": {
-          "stNum": 37,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1582,15 +1271,11 @@
           }
         },
         "test_xhtml_namespace[xpath-//*[name()='a']]": {
-          "stNum": 39,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1599,20 +1284,16 @@
           }
         },
         "test_parent_htmldocument": {
-          "stNum": 41,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 1,
             "ERROR": 1,
-            "PASS": 2
+            "PASS": 3
           }
         }
       }
@@ -1624,21 +1305,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -1646,85 +1322,68 @@
           }
         },
         "test_handle_prompt_dismiss_and_notify": {
-          "stNum": 1,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept_and_notify": {
-          "stNum": 2,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_ignore": {
-          "stNum": 3,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept": {
-          "stNum": 4,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_handle_prompt_missing_value": {
-          "stNum": 5,
-          "byUA": {
-            "eg42": "ERROR",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
-          },
-          "totals": {
-            "ERROR": 1,
-            "PASS": 2,
-            "FAIL": 1
-          }
-        },
-        "test_payload": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
+          "totals": {
+            "ERROR": 1,
+            "PASS": 3
+          }
+        },
+        "test_payload": {
+          "byUA": {
+            "eg42": "ERROR",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
           },
           "totals": {
             "FAIL": 1,
@@ -1741,102 +1400,87 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_basic": {
-          "stNum": 0,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
           }
         },
         "test_repeat_new_session": {
-          "stNum": 1,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 2,
-            "PASS": 2
+            "FAIL": 1,
+            "PASS": 3
           }
         },
         "test_no_capabilites": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 2
           }
         },
         "test_missing_first_match": {
-          "stNum": 3,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_missing_always_match": {
-          "stNum": 4,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_desired": {
-          "stNum": 5,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 2
           }
         },
         "test_ignore_non_spec_fields_in_capabilities": {
-          "stNum": 6,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XPASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 2,
@@ -1844,14 +1488,12 @@
           }
         },
         "test_valid_but_unmatchable_key": {
-          "stNum": 7,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 1,
@@ -1867,21 +1509,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -1889,60 +1526,47 @@
           }
         },
         "test_handle_prompt_dismiss": {
-          "stNum": 1,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_handle_prompt_accept": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_handle_prompt_missing_value": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
-            "PASS": 2,
-            "FAIL": 1
+            "PASS": 3
           }
         },
         "test_element_not_found": {
-          "stNum": 4,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -1952,15 +1576,11 @@
           }
         },
         "test_element_stale": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -1969,15 +1589,11 @@
           }
         },
         "test_element_non_existent": {
-          "stNum": 8,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -1986,19 +1602,16 @@
           }
         },
         "test_element": {
-          "stNum": 10,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
           "totals": {
-            "FAIL": 3,
+            "FAIL": 2,
             "ERROR": 1,
+            "PASS": 1,
             "XFAIL": 1
           }
         }
@@ -2011,68 +1624,65 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "TIMEOUT": 1,
         "OK": 3
       },
       "subtests": {
+        "/webdriver/tests/user_prompts/dismiss_alert.py": {
+          "byUA": {
+            "eg42": "TIMEOUT"
+          },
+          "totals": {
+            "TIMEOUT": 1
+          }
+        },
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_no_user_prompt": {
-          "stNum": 1,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_dismiss_alert": {
-          "stNum": 2,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_dismiss_confirm": {
-          "stNum": 3,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_dismiss_prompt": {
-          "stNum": 4,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -2086,21 +1696,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -2109,85 +1714,71 @@
           }
         },
         "test_handle_prompt_dismiss_and_notify": {
-          "stNum": 1,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept_and_notify": {
-          "stNum": 2,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_ignore": {
-          "stNum": 3,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept": {
-          "stNum": 4,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
+            "FAIL": 2,
+            "PASS": 1,
             "XFAIL": 1
           }
         },
         "test_handle_prompt_missing_value": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
-            "FAIL": 2,
+            "FAIL": 1,
+            "PASS": 1,
             "XFAIL": 1
           }
         },
         "test_fullscreen": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -2197,15 +1788,11 @@
           }
         },
         "test_payload": {
-          "stNum": 8,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2215,15 +1802,11 @@
           }
         },
         "test_fullscreen_twice_is_idempotent": {
-          "stNum": 10,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -2240,20 +1823,15 @@
         "ff60": "OK",
         "ie11": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "test_lone_keyup_sends_no_events": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -2261,14 +1839,10 @@
           }
         },
         "test_single_printable_key_sends_correct_events[a-KeyA0]": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2277,14 +1851,10 @@
           }
         },
         "test_single_printable_key_sends_correct_events[a-KeyA1]": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2293,14 +1863,10 @@
           }
         },
         "test_single_printable_key_sends_correct_events[\"-Quote]": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -2309,14 +1875,10 @@
           }
         },
         "test_single_printable_key_sends_correct_events[,-Comma]": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2325,14 +1887,10 @@
           }
         },
         "test_single_printable_key_sends_correct_events[\\xe0-]": {
-          "stNum": 9,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2341,14 +1899,10 @@
           }
         },
         "test_single_printable_key_sends_correct_events[\\u0416-]": {
-          "stNum": 11,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2357,14 +1911,10 @@
           }
         },
         "test_single_printable_key_sends_correct_events[@-Digit2]": {
-          "stNum": 13,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -2373,14 +1923,10 @@
           }
         },
         "test_single_printable_key_sends_correct_events[\\u2603-]": {
-          "stNum": 15,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2389,14 +1935,10 @@
           }
         },
         "test_single_printable_key_sends_correct_events[\\uf6c2-]": {
-          "stNum": 17,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2405,46 +1947,34 @@
           }
         },
         "test_single_emoji_records_correct_key[\\U0001f604]": {
-          "stNum": 19,
-          "byUA": {
-            "eg42": "ERROR",
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
-          "totals": {
-            "FAIL": 2,
-            "ERROR": 1,
-            "PASS": 1
-          }
-        },
-        "test_single_emoji_records_correct_key[\\U0001f60d]": {
-          "stNum": 21,
-          "byUA": {
-            "eg42": "ERROR",
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
-          "totals": {
-            "FAIL": 2,
-            "ERROR": 1,
-            "PASS": 1
-          }
-        },
-        "test_single_modifier_key_sends_correct_events[\\ue050-ShiftRight-Shift]": {
-          "stNum": 23,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
+          "totals": {
+            "FAIL": 1,
+            "ERROR": 1,
+            "PASS": 2
+          }
+        },
+        "test_single_emoji_records_correct_key[\\U0001f60d]": {
+          "byUA": {
+            "eg42": "ERROR",
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
+          "totals": {
+            "FAIL": 1,
+            "ERROR": 1,
+            "PASS": 2
+          }
+        },
+        "test_single_modifier_key_sends_correct_events[\\ue050-ShiftRight-Shift]": {
+          "byUA": {
+            "eg42": "ERROR",
+            "ff60": "PASS",
+            "ie11": "PASS"
           },
           "totals": {
             "FAIL": 1,
@@ -2453,14 +1983,10 @@
           }
         },
         "test_single_modifier_key_sends_correct_events[\\ue053-OSRight-Meta]": {
-          "stNum": 25,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -2469,14 +1995,10 @@
           }
         },
         "test_single_modifier_key_sends_correct_events[\\ue009-ControlLeft-Control]": {
-          "stNum": 27,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2485,14 +2007,10 @@
           }
         },
         "test_single_nonprintable_key_sends_events[\\ue00c-Escape-Escape]": {
-          "stNum": 29,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -2501,14 +2019,10 @@
           }
         },
         "test_single_nonprintable_key_sends_events[\\ue014-ArrowRight-ArrowRight]": {
-          "stNum": 31,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -2517,14 +2031,10 @@
           }
         },
         "test_sequence_of_keydown_printable_keys_sends_events": {
-          "stNum": 33,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2533,14 +2043,10 @@
           }
         },
         "test_sequence_of_keydown_character_keys": {
-          "stNum": 35,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2549,14 +2055,10 @@
           }
         },
         "test_backspace_erases_keys": {
-          "stNum": 37,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -2573,21 +2075,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_getting_text_of_a_non_existant_element_is_an_error": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -2596,15 +2093,11 @@
           }
         },
         "test_read_element_text": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -2619,20 +2112,15 @@
         "ff60": "OK",
         "ie11": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "test_mod_a_and_backspace_deletes_all_text": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -2640,30 +2128,22 @@
           }
         },
         "test_mod_a_mod_c_right_mod_v_pastes_text": {
-          "stNum": 1,
-          "byUA": {
-            "eg42": "ERROR",
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
-          "totals": {
-            "FAIL": 2,
-            "ERROR": 1,
-            "PASS": 1
-          }
-        },
-        "test_mod_a_mod_x_deletes_all_text": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
+          "totals": {
+            "FAIL": 1,
+            "ERROR": 1,
+            "PASS": 2
+          }
+        },
+        "test_mod_a_mod_x_deletes_all_text": {
+          "byUA": {
+            "eg42": "ERROR",
+            "ff60": "PASS",
+            "ie11": "PASS"
           },
           "totals": {
             "FAIL": 1,
@@ -2680,314 +2160,261 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_valid[acceptInsecureCerts-False]": {
-          "stNum": 0,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[acceptInsecureCerts-None]": {
-          "stNum": 1,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[browserName-None]": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
           }
         },
         "test_valid[browserVersion-None]": {
-          "stNum": 3,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[platformName-None]": {
-          "stNum": 4,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[pageLoadStrategy-none]": {
-          "stNum": 5,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[pageLoadStrategy-eager]": {
-          "stNum": 6,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[pageLoadStrategy-normal]": {
-          "stNum": 7,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[pageLoadStrategy-None]": {
-          "stNum": 8,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[proxy-None]": {
-          "stNum": 9,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[timeouts-value10]": {
-          "stNum": 10,
           "byUA": {
             "eg42": "PASS",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "FAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "FAIL": 2
           }
         },
         "test_valid[timeouts-value11]": {
-          "stNum": 11,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[timeouts-value12]": {
-          "stNum": 12,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[timeouts-value13]": {
-          "stNum": 13,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[unhandledPromptBehavior-dismiss]": {
-          "stNum": 14,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[unhandledPromptBehavior-dismiss]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[unhandledPromptBehavior-accept]": {
-          "stNum": 15,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[unhandledPromptBehavior-None]": {
-          "stNum": 16,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[test:extension-True]": {
-          "stNum": 17,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[test:extension-abc]": {
-          "stNum": 18,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[test:extension-123]": {
-          "stNum": 19,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[test:extension-value20]": {
-          "stNum": 20,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[test:extension-value21]": {
-          "stNum": 21,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[test:extension-None]": {
-          "stNum": 22,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[test:extension-abc]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[test:extension-123]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[test:extension-value20]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[test:extension-value21]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[test:extension-None]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
           "totals": {
             "PASS": 4
           }
@@ -3001,21 +2428,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_initial_window": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -3024,15 +2446,11 @@
           }
         },
         "test_window_open": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 3,
@@ -3041,15 +2459,11 @@
           }
         },
         "test_frame": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 3,
@@ -3066,98 +2480,91 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "TIMEOUT": 1,
         "OK": 3
       },
       "subtests": {
+        "/webdriver/tests/execute_async_script/user_prompts.py": {
+          "byUA": {
+            "eg42": "TIMEOUT"
+          },
+          "totals": {
+            "TIMEOUT": 1
+          }
+        },
         "test_handle_prompt_accept": {
-          "stNum": 0,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 1
           }
         },
         "test_handle_prompt_dismiss": {
-          "stNum": 1,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 1
           }
         },
         "test_handle_prompt_dismiss_and_notify": {
-          "stNum": 2,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 1
           }
         },
         "test_handle_prompt_accept_and_notify": {
-          "stNum": 3,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 1
           }
         },
         "test_handle_prompt_ignore": {
-          "stNum": 4,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 1
           }
         },
         "test_handle_prompt_default": {
-          "stNum": 5,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 1
           }
         },
         "test_handle_prompt_twice": {
-          "stNum": 6,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 1
@@ -3172,81 +2579,59 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_array": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "ERROR",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {
-            "eg42": "setup error",
-            "ie11": "teardown error"
-          },
           "totals": {
-            "ERROR": 2,
-            "PASS": 2,
-            "FAIL": 1
+            "ERROR": 1,
+            "PASS": 3
           }
         },
         "test_object": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "ERROR",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {
-            "eg42": "teardown error",
-            "ie11": "teardown error"
-          },
           "totals": {
-            "FAIL": 2,
-            "ERROR": 2,
-            "PASS": 2
+            "FAIL": 1,
+            "ERROR": 1,
+            "PASS": 3
           }
         },
         "test_array_in_object": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "ERROR",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {
-            "eg42": "teardown error",
-            "ie11": "teardown error"
-          },
           "totals": {
-            "FAIL": 2,
-            "ERROR": 2,
-            "PASS": 2
+            "FAIL": 1,
+            "ERROR": 1,
+            "PASS": 3
           }
         },
         "test_object_in_array": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "ERROR",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {
-            "eg42": "teardown error",
-            "ie11": "teardown error"
-          },
           "totals": {
-            "FAIL": 2,
-            "ERROR": 2,
-            "PASS": 2
+            "FAIL": 1,
+            "ERROR": 1,
+            "PASS": 3
           }
         }
       }
@@ -3258,68 +2643,65 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "TIMEOUT": 1,
         "OK": 3
       },
       "subtests": {
+        "/webdriver/tests/user_prompts/accept_alert.py": {
+          "byUA": {
+            "eg42": "TIMEOUT"
+          },
+          "totals": {
+            "TIMEOUT": 1
+          }
+        },
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_no_user_prompt": {
-          "stNum": 1,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_accept_alert": {
-          "stNum": 2,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_accept_confirm": {
-          "stNum": 3,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_accept_prompt": {
-          "stNum": 4,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -3333,21 +2715,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_stale_element_from_iframe": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -3363,21 +2740,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -3385,60 +2757,47 @@
           }
         },
         "test_handle_prompt_dismiss": {
-          "stNum": 1,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_handle_prompt_accept": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_handle_prompt_missing_value": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
-            "PASS": 2,
-            "FAIL": 1
+            "PASS": 3
           }
         },
         "test_element_not_found": {
-          "stNum": 4,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3448,15 +2807,11 @@
           }
         },
         "test_element_stale": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -3465,15 +2820,11 @@
           }
         },
         "test_get_element_tag_name": {
-          "stNum": 8,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -3489,21 +2840,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_element_outside_of_not_scrollable_viewport": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -3513,15 +2859,11 @@
           }
         },
         "test_element_outside_of_scrollable_viewport": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3531,33 +2873,25 @@
           }
         },
         "test_option_select_container_outside_of_scrollable_viewport": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 1,
             "ERROR": 1,
-            "PASS": 1,
+            "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_option_stays_outside_of_scrollable_viewport": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -3567,15 +2901,11 @@
           }
         },
         "test_contenteditable_element_outside_of_scrollable_viewport": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3592,20 +2922,15 @@
         "ff60": "OK",
         "ie11": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "test_no_actions_send_no_events": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -3613,14 +2938,10 @@
           }
         },
         "test_release_char_sequence_sends_keyup_events_in_reverse": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3629,14 +2950,10 @@
           }
         },
         "test_release_no_actions_sends_no_events": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3653,90 +2970,73 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_add_domain_cookie": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
-            "FAIL": 3
+            "FAIL": 2,
+            "PASS": 1
           }
         },
         "test_add_cookie_for_ip": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "FAIL"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
           "totals": {
-            "FAIL": 4,
-            "ERROR": 1
+            "FAIL": 3,
+            "ERROR": 1,
+            "PASS": 1
           }
         },
         "test_add_non_session_cookie": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "FAIL"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
           "totals": {
-            "FAIL": 4,
-            "ERROR": 1
+            "FAIL": 3,
+            "ERROR": 1,
+            "PASS": 1
           }
         },
         "test_add_session_cookie": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "FAIL"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
           "totals": {
-            "PASS": 1,
+            "PASS": 2,
             "ERROR": 1,
-            "FAIL": 3
+            "FAIL": 2
           }
         },
         "test_add_session_cookie_with_leading_dot_character_in_domain": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "FAIL"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
           "totals": {
-            "FAIL": 4,
-            "ERROR": 1
+            "FAIL": 3,
+            "ERROR": 1,
+            "PASS": 1
           }
         }
       }
@@ -3748,104 +3048,84 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_current_top_level_browsing_context_no_longer_open": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "ERROR",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {
-            "eg42": "setup error",
-            "ie11": "setup error"
-          },
           "totals": {
-            "ERROR": 2,
-            "PASS": 2
+            "ERROR": 1,
+            "PASS": 3
           }
         },
         "test_handle_prompt_dismiss": {
-          "stNum": 1,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 2
           }
         },
         "test_handle_prompt_dismiss_and_notify": {
-          "stNum": 3,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept_and_notify": {
-          "stNum": 4,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_ignore": {
-          "stNum": 5,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_missing_value": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -3853,15 +3133,11 @@
           }
         },
         "test_invalid_types[rect0]": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3870,15 +3146,11 @@
           }
         },
         "test_invalid_types[rect1]": {
-          "stNum": 9,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3887,15 +3159,11 @@
           }
         },
         "test_invalid_types[rect2]": {
-          "stNum": 11,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3904,15 +3172,11 @@
           }
         },
         "test_invalid_types[rect3]": {
-          "stNum": 13,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3921,15 +3185,11 @@
           }
         },
         "test_invalid_types[rect4]": {
-          "stNum": 15,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3938,15 +3198,11 @@
           }
         },
         "test_invalid_types[rect5]": {
-          "stNum": 17,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3955,15 +3211,11 @@
           }
         },
         "test_invalid_types[rect6]": {
-          "stNum": 19,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3972,15 +3224,11 @@
           }
         },
         "test_invalid_types[rect7]": {
-          "stNum": 21,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -3989,15 +3237,11 @@
           }
         },
         "test_invalid_types[rect8]": {
-          "stNum": 23,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4006,15 +3250,11 @@
           }
         },
         "test_invalid_types[rect9]": {
-          "stNum": 25,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4023,15 +3263,11 @@
           }
         },
         "test_invalid_types[rect10]": {
-          "stNum": 27,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4040,15 +3276,11 @@
           }
         },
         "test_invalid_types[rect11]": {
-          "stNum": 29,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4057,15 +3289,11 @@
           }
         },
         "test_invalid_types[rect12]": {
-          "stNum": 31,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4074,15 +3302,11 @@
           }
         },
         "test_invalid_types[rect13]": {
-          "stNum": 33,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4091,15 +3315,11 @@
           }
         },
         "test_invalid_types[rect14]": {
-          "stNum": 35,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4108,15 +3328,11 @@
           }
         },
         "test_invalid_types[rect15]": {
-          "stNum": 37,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4125,15 +3341,11 @@
           }
         },
         "test_invalid_types[rect16]": {
-          "stNum": 39,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4142,15 +3354,11 @@
           }
         },
         "test_invalid_types[rect17]": {
-          "stNum": 41,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4159,15 +3367,11 @@
           }
         },
         "test_invalid_types[rect18]": {
-          "stNum": 43,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4176,15 +3380,11 @@
           }
         },
         "test_invalid_types[rect19]": {
-          "stNum": 45,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4193,15 +3393,11 @@
           }
         },
         "test_invalid_types[rect20]": {
-          "stNum": 47,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4210,15 +3406,11 @@
           }
         },
         "test_invalid_types[rect21]": {
-          "stNum": 49,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4227,15 +3419,11 @@
           }
         },
         "test_invalid_types[rect22]": {
-          "stNum": 51,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4244,15 +3432,11 @@
           }
         },
         "test_invalid_types[rect23]": {
-          "stNum": 53,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4261,15 +3445,11 @@
           }
         },
         "test_invalid_types[rect24]": {
-          "stNum": 55,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4278,15 +3458,11 @@
           }
         },
         "test_invalid_types[rect25]": {
-          "stNum": 57,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4295,15 +3471,11 @@
           }
         },
         "test_invalid_types[rect26]": {
-          "stNum": 59,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4312,15 +3484,11 @@
           }
         },
         "test_invalid_types[rect27]": {
-          "stNum": 61,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4329,15 +3497,11 @@
           }
         },
         "test_out_of_bounds[rect0]": {
-          "stNum": 63,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4346,15 +3510,11 @@
           }
         },
         "test_out_of_bounds[rect1]": {
-          "stNum": 65,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4363,15 +3523,11 @@
           }
         },
         "test_out_of_bounds[rect2]": {
-          "stNum": 67,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4380,15 +3536,11 @@
           }
         },
         "test_width_height_floats": {
-          "stNum": 69,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4397,15 +3549,11 @@
           }
         },
         "test_x_y_floats": {
-          "stNum": 71,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4414,15 +3562,11 @@
           }
         },
         "test_no_change[rect0]": {
-          "stNum": 73,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4431,15 +3575,11 @@
           }
         },
         "test_no_change[rect1]": {
-          "stNum": 75,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4448,15 +3588,11 @@
           }
         },
         "test_no_change[rect2]": {
-          "stNum": 77,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4465,15 +3601,11 @@
           }
         },
         "test_no_change[rect3]": {
-          "stNum": 79,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4482,15 +3614,11 @@
           }
         },
         "test_no_change[rect4]": {
-          "stNum": 81,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4499,15 +3627,11 @@
           }
         },
         "test_no_change[rect5]": {
-          "stNum": 83,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4516,15 +3640,11 @@
           }
         },
         "test_no_change[rect6]": {
-          "stNum": 85,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4533,15 +3653,11 @@
           }
         },
         "test_no_change[rect7]": {
-          "stNum": 87,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4550,15 +3666,11 @@
           }
         },
         "test_no_change[rect8]": {
-          "stNum": 89,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4567,15 +3679,11 @@
           }
         },
         "test_no_change[rect9]": {
-          "stNum": 91,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4584,15 +3692,11 @@
           }
         },
         "test_no_change[rect10]": {
-          "stNum": 93,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4601,15 +3705,11 @@
           }
         },
         "test_no_change[rect11]": {
-          "stNum": 95,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4618,15 +3718,11 @@
           }
         },
         "test_no_change[rect12]": {
-          "stNum": 97,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4635,15 +3731,11 @@
           }
         },
         "test_no_change[rect13]": {
-          "stNum": 99,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4652,15 +3744,11 @@
           }
         },
         "test_no_change[rect14]": {
-          "stNum": 101,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4669,15 +3757,11 @@
           }
         },
         "test_no_change[rect15]": {
-          "stNum": 103,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4686,15 +3770,11 @@
           }
         },
         "test_no_change[rect16]": {
-          "stNum": 105,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4703,15 +3783,11 @@
           }
         },
         "test_no_change[rect17]": {
-          "stNum": 107,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4720,15 +3796,11 @@
           }
         },
         "test_no_change[rect18]": {
-          "stNum": 109,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4737,15 +3809,11 @@
           }
         },
         "test_no_change[rect19]": {
-          "stNum": 111,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4754,15 +3822,11 @@
           }
         },
         "test_fully_exit_fullscreen": {
-          "stNum": 113,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -4772,15 +3836,11 @@
           }
         },
         "test_restore_from_minimized": {
-          "stNum": 115,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4790,15 +3850,11 @@
           }
         },
         "test_restore_from_maximized": {
-          "stNum": 117,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4808,15 +3864,11 @@
           }
         },
         "test_height_width": {
-          "stNum": 119,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -4825,15 +3877,11 @@
           }
         },
         "test_height_width_larger_than_max": {
-          "stNum": 121,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4842,15 +3890,11 @@
           }
         },
         "test_height_width_as_current": {
-          "stNum": 123,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4859,15 +3903,11 @@
           }
         },
         "test_x_y": {
-          "stNum": 125,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4876,15 +3916,11 @@
           }
         },
         "test_negative_x_y": {
-          "stNum": 127,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4894,15 +3930,11 @@
           }
         },
         "test_move_to_same_position": {
-          "stNum": 129,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4911,15 +3943,11 @@
           }
         },
         "test_move_to_same_x": {
-          "stNum": 131,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4928,15 +3956,11 @@
           }
         },
         "test_move_to_same_y": {
-          "stNum": 133,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4945,15 +3969,11 @@
           }
         },
         "test_resize_to_same_size": {
-          "stNum": 135,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4962,15 +3982,11 @@
           }
         },
         "test_resize_to_same_width": {
-          "stNum": 137,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4979,15 +3995,11 @@
           }
         },
         "test_resize_to_same_height": {
-          "stNum": 139,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -4996,15 +4008,11 @@
           }
         },
         "test_payload": {
-          "stNum": 141,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5021,21 +4029,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_body_is_interactable": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -5044,15 +4047,11 @@
           }
         },
         "test_document_element_is_interactable": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5062,15 +4061,11 @@
           }
         },
         "test_iframe_is_interactable": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -5080,15 +4075,11 @@
           }
         },
         "test_transparent_element": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5098,15 +4089,11 @@
           }
         },
         "test_readonly_element": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5116,15 +4103,11 @@
           }
         },
         "test_obscured_element": {
-          "stNum": 9,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5134,33 +4117,25 @@
           }
         },
         "test_not_a_focusable_element": {
-          "stNum": 11,
-          "byUA": {
-            "eg42": "ERROR",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
-          "totals": {
-            "FAIL": 2,
-            "ERROR": 1,
-            "PASS": 1,
-            "XFAIL": 1
-          }
-        },
-        "test_not_displayed_element": {
-          "stNum": 13,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
+          "totals": {
+            "FAIL": 1,
+            "ERROR": 1,
+            "PASS": 2,
+            "XFAIL": 1
+          }
+        },
+        "test_not_displayed_element": {
+          "byUA": {
+            "eg42": "ERROR",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "XFAIL"
           },
           "totals": {
             "FAIL": 1,
@@ -5170,15 +4145,11 @@
           }
         },
         "test_hidden_element": {
-          "stNum": 15,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5188,20 +4159,16 @@
           }
         },
         "test_disabled_element": {
-          "stNum": 17,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 1,
             "ERROR": 1,
-            "PASS": 1,
+            "PASS": 2,
             "XFAIL": 1
           }
         }
@@ -5214,21 +4181,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_window_resize": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -5244,21 +4206,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_click_option": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -5266,15 +4223,11 @@
           }
         },
         "test_click_multiple_option": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5282,15 +4235,11 @@
           }
         },
         "test_click_preselected_option": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5298,15 +4247,11 @@
           }
         },
         "test_click_preselected_multiple_option": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5315,15 +4260,11 @@
           }
         },
         "test_click_deselects_others": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5331,15 +4272,11 @@
           }
         },
         "test_click_multiple_does_not_deselect_others": {
-          "stNum": 9,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5348,15 +4285,11 @@
           }
         },
         "test_click_selected_option": {
-          "stNum": 11,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5364,15 +4297,11 @@
           }
         },
         "test_click_selected_multiple_option": {
-          "stNum": 13,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5381,15 +4310,11 @@
           }
         },
         "test_out_of_view_dropdown": {
-          "stNum": 15,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5397,15 +4322,11 @@
           }
         },
         "test_out_of_view_multiple": {
-          "stNum": 17,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5413,19 +4334,15 @@
           }
         },
         "test_option_disabled": {
-          "stNum": 19,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
+            "ie11": "PASS"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 1,
             "ERROR": 1,
-            "PASS": 1
+            "PASS": 2
           }
         }
       }
@@ -5437,21 +4354,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_invalid_using_argument[a]": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -5459,15 +4371,11 @@
           }
         },
         "test_invalid_using_argument[True]": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5476,15 +4384,11 @@
           }
         },
         "test_invalid_using_argument[None]": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5493,15 +4397,11 @@
           }
         },
         "test_invalid_using_argument[1]": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5510,15 +4410,11 @@
           }
         },
         "test_invalid_using_argument[using4]": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5527,15 +4423,11 @@
           }
         },
         "test_invalid_using_argument[using5]": {
-          "stNum": 9,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5544,15 +4436,11 @@
           }
         },
         "test_invalid_selector_argument[None]": {
-          "stNum": 11,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5561,15 +4449,11 @@
           }
         },
         "test_invalid_selector_argument[value1]": {
-          "stNum": 13,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5578,15 +4462,11 @@
           }
         },
         "test_invalid_selector_argument[value2]": {
-          "stNum": 15,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5595,15 +4475,11 @@
           }
         },
         "test_closed_context": {
-          "stNum": 17,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5612,15 +4488,11 @@
           }
         },
         "test_find_element[css selector-#linkText]": {
-          "stNum": 19,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5628,15 +4500,11 @@
           }
         },
         "test_find_element[link text-full link text]": {
-          "stNum": 21,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5644,15 +4512,11 @@
           }
         },
         "test_find_element[partial link text-link text]": {
-          "stNum": 23,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5660,15 +4524,11 @@
           }
         },
         "test_find_element[tag name-a]": {
-          "stNum": 25,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5676,15 +4536,11 @@
           }
         },
         "test_find_element[xpath-//a]": {
-          "stNum": 27,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5692,15 +4548,11 @@
           }
         },
         "test_no_element[css selector-#wontExist]": {
-          "stNum": 29,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5709,15 +4561,11 @@
           }
         },
         "test_xhtml_namespace[css selector-#linkText]": {
-          "stNum": 31,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5726,15 +4574,11 @@
           }
         },
         "test_xhtml_namespace[link text-full link text]": {
-          "stNum": 33,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5743,15 +4587,11 @@
           }
         },
         "test_xhtml_namespace[partial link text-link text]": {
-          "stNum": 35,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5760,15 +4600,11 @@
           }
         },
         "test_xhtml_namespace[tag name-a]": {
-          "stNum": 37,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5777,15 +4613,11 @@
           }
         },
         "test_xhtml_namespace[xpath-//*[name()='a']]": {
-          "stNum": 39,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5794,15 +4626,11 @@
           }
         },
         "test_htmldocument[css selector-:root]": {
-          "stNum": 41,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5810,15 +4638,11 @@
           }
         },
         "test_htmldocument[tag name-html]": {
-          "stNum": 43,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5826,15 +4650,11 @@
           }
         },
         "test_htmldocument[xpath-/html]": {
-          "stNum": 45,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -5850,21 +4670,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_get_timeouts": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -5872,15 +4687,11 @@
           }
         },
         "test_get_default_timeouts": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5889,15 +4700,11 @@
           }
         },
         "test_get_new_timeouts": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5913,20 +4720,15 @@
         "ff60": "OK",
         "ie11": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "test_modifier_click[\\ue00a-altKey]": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5935,14 +4737,10 @@
           }
         },
         "test_modifier_click[\\ue052-altKey]": {
-          "stNum": 2,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5951,14 +4749,10 @@
           }
         },
         "test_modifier_click[\\ue03d-metaKey]": {
-          "stNum": 4,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -5967,14 +4761,10 @@
           }
         },
         "test_modifier_click[\\ue053-metaKey]": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -5983,14 +4773,10 @@
           }
         },
         "test_modifier_click[\\ue008-shiftKey]": {
-          "stNum": 8,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -5999,14 +4785,10 @@
           }
         },
         "test_modifier_click[\\ue050-shiftKey]": {
-          "stNum": 10,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6015,14 +4797,10 @@
           }
         },
         "test_many_modifiers_click": {
-          "stNum": 12,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6039,21 +4817,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_invalid_using_argument[a]": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -6061,15 +4834,11 @@
           }
         },
         "test_invalid_using_argument[True]": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6078,15 +4847,11 @@
           }
         },
         "test_invalid_using_argument[None]": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6095,15 +4860,11 @@
           }
         },
         "test_invalid_using_argument[1]": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6112,15 +4873,11 @@
           }
         },
         "test_invalid_using_argument[using4]": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6129,15 +4886,11 @@
           }
         },
         "test_invalid_using_argument[using5]": {
-          "stNum": 9,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6146,15 +4899,11 @@
           }
         },
         "test_invalid_selector_argument[None]": {
-          "stNum": 11,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6163,15 +4912,11 @@
           }
         },
         "test_invalid_selector_argument[value1]": {
-          "stNum": 13,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6180,15 +4925,11 @@
           }
         },
         "test_invalid_selector_argument[value2]": {
-          "stNum": 15,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6197,15 +4938,11 @@
           }
         },
         "test_closed_context": {
-          "stNum": 17,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6214,15 +4951,11 @@
           }
         },
         "test_find_elements[css selector-#linkText]": {
-          "stNum": 19,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6230,15 +4963,11 @@
           }
         },
         "test_find_elements[link text-full link text]": {
-          "stNum": 21,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6246,15 +4975,11 @@
           }
         },
         "test_find_elements[partial link text-link text]": {
-          "stNum": 23,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6262,15 +4987,11 @@
           }
         },
         "test_find_elements[tag name-a]": {
-          "stNum": 25,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6278,15 +4999,11 @@
           }
         },
         "test_find_elements[xpath-//a]": {
-          "stNum": 27,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6294,15 +5011,11 @@
           }
         },
         "test_no_element[css selector-#wontExist]": {
-          "stNum": 29,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6310,15 +5023,11 @@
           }
         },
         "test_xhtml_namespace[css selector-#linkText]": {
-          "stNum": 31,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6327,15 +5036,11 @@
           }
         },
         "test_xhtml_namespace[link text-full link text]": {
-          "stNum": 33,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6344,15 +5049,11 @@
           }
         },
         "test_xhtml_namespace[partial link text-link text]": {
-          "stNum": 35,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6361,15 +5062,11 @@
           }
         },
         "test_xhtml_namespace[tag name-a]": {
-          "stNum": 37,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6378,15 +5075,11 @@
           }
         },
         "test_xhtml_namespace[xpath-//*[name()='a']]": {
-          "stNum": 39,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6395,15 +5088,11 @@
           }
         },
         "test_htmldocument[css selector-:root]": {
-          "stNum": 41,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6411,15 +5100,11 @@
           }
         },
         "test_htmldocument[tag name-html]": {
-          "stNum": 43,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6427,15 +5112,11 @@
           }
         },
         "test_htmldocument[xpath-/html]": {
-          "stNum": 45,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6450,20 +5131,15 @@
         "ff60": "OK",
         "ie11": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "test_dblclick_at_coordinates[0]": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6472,14 +5148,10 @@
           }
         },
         "test_dblclick_at_coordinates[200]": {
-          "stNum": 2,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6488,14 +5160,10 @@
           }
         },
         "test_dblclick_with_pause_after_second_pointerdown": {
-          "stNum": 4,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6504,14 +5172,10 @@
           }
         },
         "test_no_dblclick": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6528,56 +5192,42 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_click_event_bubbles_to_parents": {
-          "stNum": 0,
-          "byUA": {
-            "eg42": "ERROR",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
-          },
-          "totals": {
-            "ERROR": 1,
-            "PASS": 2,
-            "FAIL": 1
-          }
-        },
-        "test_spin_event_loop": {
-          "stNum": 1,
-          "byUA": {
-            "eg42": "ERROR",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
-          "totals": {
-            "FAIL": 2,
-            "ERROR": 1,
-            "PASS": 1,
-            "XFAIL": 1
-          }
-        },
-        "test_element_disappears_during_click": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
+          "totals": {
+            "ERROR": 1,
+            "PASS": 3
+          }
+        },
+        "test_spin_event_loop": {
+          "byUA": {
+            "eg42": "ERROR",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "XFAIL"
+          },
+          "totals": {
+            "FAIL": 1,
+            "ERROR": 1,
+            "PASS": 2,
+            "XFAIL": 1
+          }
+        },
+        "test_element_disappears_during_click": {
+          "byUA": {
+            "eg42": "ERROR",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
           },
           "totals": {
             "FAIL": 1,
@@ -6594,21 +5244,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_title_from_closed_context": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -6616,60 +5261,47 @@
           }
         },
         "test_title_handle_prompt_dismiss": {
-          "stNum": 1,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_title_handle_prompt_accept": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_title_handle_prompt_missing_value": {
-          "stNum": 3,
-          "byUA": {
-            "eg42": "ERROR",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
-          },
-          "totals": {
-            "ERROR": 1,
-            "PASS": 2,
-            "FAIL": 1
-          }
-        },
-        "test_title_from_top_context": {
-          "stNum": 4,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
+          "totals": {
+            "ERROR": 1,
+            "PASS": 3
+          }
+        },
+        "test_title_from_top_context": {
+          "byUA": {
+            "eg42": "ERROR",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
           },
           "totals": {
             "PASS": 4,
@@ -6677,15 +5309,11 @@
           }
         },
         "test_title_with_duplicate_element": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6693,15 +5321,11 @@
           }
         },
         "test_title_without_element": {
-          "stNum": 8,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6709,15 +5333,11 @@
           }
         },
         "test_title_after_modification": {
-          "stNum": 10,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6725,15 +5345,11 @@
           }
         },
         "test_title_strip_and_collapse": {
-          "stNum": 12,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6741,15 +5357,11 @@
           }
         },
         "test_title_from_frame": {
-          "stNum": 14,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -6765,75 +5377,64 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_resp_sessionid": {
-          "stNum": 0,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_resp_capabilites": {
-          "stNum": 1,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 2
           }
         },
         "test_resp_data": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 2
           }
         },
         "test_timeouts": {
-          "stNum": 3,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
           }
         },
         "test_pageLoadStrategy": {
-          "stNum": 4,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
@@ -6848,21 +5449,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_invalid_using_argument[a]": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -6870,15 +5466,11 @@
           }
         },
         "test_invalid_using_argument[True]": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6887,15 +5479,11 @@
           }
         },
         "test_invalid_using_argument[None]": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6904,15 +5492,11 @@
           }
         },
         "test_invalid_using_argument[1]": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6921,15 +5505,11 @@
           }
         },
         "test_invalid_using_argument[using4]": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6938,15 +5518,11 @@
           }
         },
         "test_invalid_using_argument[using5]": {
-          "stNum": 9,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6955,15 +5531,11 @@
           }
         },
         "test_invalid_selector_argument[None]": {
-          "stNum": 11,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6972,15 +5544,11 @@
           }
         },
         "test_invalid_selector_argument[value1]": {
-          "stNum": 13,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -6989,15 +5557,11 @@
           }
         },
         "test_invalid_selector_argument[value2]": {
-          "stNum": 15,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -7006,15 +5570,11 @@
           }
         },
         "test_closed_context": {
-          "stNum": 17,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -7023,15 +5583,11 @@
           }
         },
         "test_find_element[css selector-#linkText]": {
-          "stNum": 19,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -7039,15 +5595,11 @@
           }
         },
         "test_find_element[link text-full link text]": {
-          "stNum": 21,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -7055,15 +5607,11 @@
           }
         },
         "test_find_element[partial link text-link text]": {
-          "stNum": 23,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -7071,15 +5619,11 @@
           }
         },
         "test_find_element[tag name-a]": {
-          "stNum": 25,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -7087,15 +5631,11 @@
           }
         },
         "test_find_element[xpath-//a]": {
-          "stNum": 27,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -7103,15 +5643,11 @@
           }
         },
         "test_no_element[css selector-#wontExist]": {
-          "stNum": 29,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -7120,15 +5656,11 @@
           }
         },
         "test_xhtml_namespace[css selector-#linkText]": {
-          "stNum": 31,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -7137,15 +5669,11 @@
           }
         },
         "test_xhtml_namespace[link text-full link text]": {
-          "stNum": 33,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -7154,15 +5682,11 @@
           }
         },
         "test_xhtml_namespace[partial link text-link text]": {
-          "stNum": 35,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -7171,15 +5695,11 @@
           }
         },
         "test_xhtml_namespace[tag name-a]": {
-          "stNum": 37,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -7188,15 +5708,11 @@
           }
         },
         "test_xhtml_namespace[xpath-//*[name()='a']]": {
-          "stNum": 39,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -7205,20 +5721,15 @@
           }
         },
         "test_parent_htmldocument": {
-          "stNum": 41,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
           "totals": {
-            "PASS": 3,
-            "ERROR": 1,
-            "FAIL": 1
+            "PASS": 4,
+            "ERROR": 1
           }
         }
       }
@@ -7230,2396 +5741,2011 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "TIMEOUT": 1,
         "OK": 3
       },
       "subtests": {
+        "/webdriver/tests/sessions/new_session/invalid_capabilities.py": {
+          "byUA": {
+            "eg42": "TIMEOUT"
+          },
+          "totals": {
+            "TIMEOUT": 1
+          }
+        },
         "test_invalid_capabilites[None]": {
-          "stNum": 0,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_capabilites[1]": {
-          "stNum": 1,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_capabilites[{}]": {
-          "stNum": 2,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_capabilites[value3]": {
-          "stNum": 3,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_always_match[None]": {
-          "stNum": 4,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_always_match[1]": {
-          "stNum": 5,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_always_match[{}]": {
-          "stNum": 6,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_always_match[value3]": {
-          "stNum": 7,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_first_match[None]": {
-          "stNum": 8,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_first_match[1]": {
-          "stNum": 9,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_first_match[[]]": {
-          "stNum": 10,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_first_match[value3]": {
-          "stNum": 11,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[acceptInsecureCerts-1-body0]": {
-          "stNum": 12,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[acceptInsecureCerts-1-body1]": {
-          "stNum": 13,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[acceptInsecureCerts-value1-body0]": {
-          "stNum": 14,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[acceptInsecureCerts-value1-body1]": {
-          "stNum": 15,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[acceptInsecureCerts-value2-body0]": {
-          "stNum": 16,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[acceptInsecureCerts-value2-body1]": {
-          "stNum": 17,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[acceptInsecureCerts-false-body0]": {
-          "stNum": 18,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[acceptInsecureCerts-false-body1]": {
-          "stNum": 19,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserName-1-body0]": {
-          "stNum": 20,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserName-1-body1]": {
-          "stNum": 21,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserName-value5-body0]": {
-          "stNum": 22,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserName-value5-body1]": {
-          "stNum": 23,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserName-value6-body0]": {
-          "stNum": 24,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserName-value6-body1]": {
-          "stNum": 25,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserName-False-body0]": {
-          "stNum": 26,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserName-False-body1]": {
-          "stNum": 27,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserVersion-1-body0]": {
-          "stNum": 28,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserVersion-1-body1]": {
-          "stNum": 29,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserVersion-value9-body0]": {
-          "stNum": 30,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserVersion-value9-body1]": {
-          "stNum": 31,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserVersion-value10-body0]": {
-          "stNum": 32,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserVersion-value10-body1]": {
-          "stNum": 33,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserVersion-False-body0]": {
-          "stNum": 34,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[browserVersion-False-body1]": {
-          "stNum": 35,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[platformName-1-body0]": {
-          "stNum": 36,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[platformName-1-body1]": {
-          "stNum": 37,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[platformName-value13-body0]": {
-          "stNum": 38,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[platformName-value13-body1]": {
-          "stNum": 39,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[platformName-value14-body0]": {
-          "stNum": 40,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[platformName-value14-body1]": {
-          "stNum": 41,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[platformName-False-body0]": {
-          "stNum": 42,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[platformName-False-body1]": {
-          "stNum": 43,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-1-body0]": {
-          "stNum": 44,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-1-body1]": {
-          "stNum": 45,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-value17-body0]": {
-          "stNum": 46,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-value17-body1]": {
-          "stNum": 47,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-value18-body0]": {
-          "stNum": 48,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-value18-body1]": {
-          "stNum": 49,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-False-body0]": {
-          "stNum": 50,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-False-body1]": {
-          "stNum": 51,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-invalid-body0]": {
-          "stNum": 52,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-invalid-body1]": {
-          "stNum": 53,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-NONE-body0]": {
-          "stNum": 54,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-NONE-body1]": {
-          "stNum": 55,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-Eager-body0]": {
-          "stNum": 56,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-Eager-body1]": {
-          "stNum": 57,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-eagerblah-body0]": {
-          "stNum": 58,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-eagerblah-body1]": {
-          "stNum": 59,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-interactive-body0]": {
-          "stNum": 60,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-interactive-body1]": {
-          "stNum": 61,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy- eager-body0]": {
-          "stNum": 62,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy- eager-body1]": {
-          "stNum": 63,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-eager -body0]": {
-          "stNum": 64,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[pageLoadStrategy-eager -body1]": {
-          "stNum": 65,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[proxy-1-body0]": {
-          "stNum": 66,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-1-body1]": {
-          "stNum": 67,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value28-body0]": {
-          "stNum": 68,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value28-body1]": {
-          "stNum": 69,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-{}-body0]": {
-          "stNum": 70,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-{}-body1]": {
-          "stNum": 71,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value30-body0]": {
-          "stNum": 72,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value30-body1]": {
-          "stNum": 73,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value31-body0]": {
-          "stNum": 74,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value31-body1]": {
-          "stNum": 75,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value32-body0]": {
-          "stNum": 76,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value32-body1]": {
-          "stNum": 77,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value33-body0]": {
-          "stNum": 78,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value33-body1]": {
-          "stNum": 79,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value34-body0]": {
-          "stNum": 80,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value34-body1]": {
-          "stNum": 81,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value35-body0]": {
-          "stNum": 82,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value35-body1]": {
-          "stNum": 83,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value36-body0]": {
-          "stNum": 84,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value36-body1]": {
-          "stNum": 85,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value37-body0]": {
-          "stNum": 86,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value37-body1]": {
-          "stNum": 87,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value38-body0]": {
-          "stNum": 88,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value38-body1]": {
-          "stNum": 89,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value39-body0]": {
-          "stNum": 90,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value39-body1]": {
-          "stNum": 91,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value40-body0]": {
-          "stNum": 92,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value40-body1]": {
-          "stNum": 93,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value41-body0]": {
-          "stNum": 94,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value41-body1]": {
-          "stNum": 95,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value42-body0]": {
-          "stNum": 96,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value42-body1]": {
-          "stNum": 97,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value43-body0]": {
-          "stNum": 98,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value43-body1]": {
-          "stNum": 99,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value44-body0]": {
-          "stNum": 100,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[proxy-value44-body1]": {
-          "stNum": 101,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "XFAIL": 1
           }
         },
         "test_invalid_values[timeouts-1-body0]": {
-          "stNum": 102,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-1-body1]": {
-          "stNum": 103,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value46-body0]": {
-          "stNum": 104,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value46-body1]": {
-          "stNum": 105,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-{}-body0]": {
-          "stNum": 106,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-{}-body1]": {
-          "stNum": 107,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-False-body0]": {
-          "stNum": 108,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-False-body1]": {
-          "stNum": 109,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value49-body0]": {
-          "stNum": 110,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value49-body1]": {
-          "stNum": 111,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value50-body0]": {
-          "stNum": 112,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value50-body1]": {
-          "stNum": 113,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value51-body0]": {
-          "stNum": 114,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value51-body1]": {
-          "stNum": 115,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value52-body0]": {
-          "stNum": 116,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value52-body1]": {
-          "stNum": 117,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value53-body0]": {
-          "stNum": 118,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value53-body1]": {
-          "stNum": 119,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value54-body0]": {
-          "stNum": 120,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value54-body1]": {
-          "stNum": 121,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value55-body0]": {
-          "stNum": 122,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value55-body1]": {
-          "stNum": 123,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value56-body0]": {
-          "stNum": 124,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value56-body1]": {
-          "stNum": 125,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value57-body0]": {
-          "stNum": 126,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value57-body1]": {
-          "stNum": 127,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value58-body0]": {
-          "stNum": 128,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value58-body1]": {
-          "stNum": 129,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value59-body0]": {
-          "stNum": 130,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value59-body1]": {
-          "stNum": 131,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value60-body0]": {
-          "stNum": 132,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value60-body1]": {
-          "stNum": 133,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value61-body0]": {
-          "stNum": 134,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[timeouts-value61-body1]": {
-          "stNum": 135,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-1-body0]": {
-          "stNum": 136,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-1-body1]": {
-          "stNum": 137,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-value63-body0]": {
-          "stNum": 138,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-value63-body1]": {
-          "stNum": 139,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-value64-body0]": {
-          "stNum": 140,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-value64-body1]": {
-          "stNum": 141,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-False-body0]": {
-          "stNum": 142,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-False-body1]": {
-          "stNum": 143,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-DISMISS-body0]": {
-          "stNum": 144,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-DISMISS-body1]": {
-          "stNum": 145,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-dismissABC-body0]": {
-          "stNum": 146,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-dismissABC-body1]": {
-          "stNum": 147,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-Accept-body0]": {
-          "stNum": 148,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-Accept-body1]": {
-          "stNum": 149,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior- dismiss-body0]": {
-          "stNum": 150,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior- dismiss-body1]": {
-          "stNum": 151,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-dismiss -body0]": {
-          "stNum": 152,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_values[unhandledPromptBehavior-dismiss -body1]": {
-          "stNum": 153,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[firefox-body0]": {
-          "stNum": 154,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[firefox-body1]": {
-          "stNum": 155,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[firefox_binary-body0]": {
-          "stNum": 156,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[firefox_binary-body1]": {
-          "stNum": 157,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[firefoxOptions-body0]": {
-          "stNum": 158,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[firefoxOptions-body1]": {
-          "stNum": 159,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[chromeOptions-body0]": {
-          "stNum": 160,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[chromeOptions-body1]": {
-          "stNum": 161,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[automaticInspection-body0]": {
-          "stNum": 162,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[automaticInspection-body1]": {
-          "stNum": 163,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[automaticProfiling-body0]": {
-          "stNum": 164,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[automaticProfiling-body1]": {
-          "stNum": 165,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[platform-body0]": {
-          "stNum": 166,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[platform-body1]": {
-          "stNum": 167,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[version-body0]": {
-          "stNum": 168,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[version-body1]": {
-          "stNum": 169,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[browser-body0]": {
-          "stNum": 170,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[browser-body1]": {
-          "stNum": 171,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[platformVersion-body0]": {
-          "stNum": 172,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[platformVersion-body1]": {
-          "stNum": 173,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[javascriptEnabled-body0]": {
-          "stNum": 174,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[javascriptEnabled-body1]": {
-          "stNum": 175,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[nativeEvents-body0]": {
-          "stNum": 176,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[nativeEvents-body1]": {
-          "stNum": 177,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[seleniumProtocol-body0]": {
-          "stNum": 178,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[seleniumProtocol-body1]": {
-          "stNum": 179,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[profile-body0]": {
-          "stNum": 180,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[profile-body1]": {
-          "stNum": 181,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[trustAllSSLCertificates-body0]": {
-          "stNum": 182,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[trustAllSSLCertificates-body1]": {
-          "stNum": 183,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[initialBrowserUrl-body0]": {
-          "stNum": 184,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[initialBrowserUrl-body1]": {
-          "stNum": 185,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[requireWindowFocus-body0]": {
-          "stNum": 186,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[requireWindowFocus-body1]": {
-          "stNum": 187,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[logFile-body0]": {
-          "stNum": 188,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[logFile-body1]": {
-          "stNum": 189,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[logLevel-body0]": {
-          "stNum": 190,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[logLevel-body1]": {
-          "stNum": 191,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[safari.options-body0]": {
-          "stNum": 192,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[safari.options-body1]": {
-          "stNum": 193,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[ensureCleanSession-body0]": {
-          "stNum": 194,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_invalid_extensions[ensureCleanSession-body1]": {
-          "stNum": 195,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
@@ -9633,104 +7759,89 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_handle_prompt_accept": {
-          "stNum": 0,
-          "byUA": {
-            "eg42": "FAIL",
-            "ff60": "FAIL",
-            "ie11": "PASS",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "FAIL": 2,
-            "PASS": 2
-          }
-        },
-        "test_handle_prompt_dismiss": {
-          "stNum": 1,
-          "byUA": {
-            "eg42": "FAIL",
-            "ff60": "FAIL",
-            "ie11": "PASS",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "FAIL": 2,
-            "PASS": 2
-          }
-        },
-        "test_handle_prompt_dismiss_and_notify": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
+          "totals": {
+            "FAIL": 3,
+            "PASS": 1
+          }
+        },
+        "test_handle_prompt_dismiss": {
+          "byUA": {
+            "eg42": "FAIL",
+            "ff60": "FAIL",
+            "ie11": "FAIL",
+            "wk18": "PASS"
+          },
+          "totals": {
+            "FAIL": 3,
+            "PASS": 1
+          }
+        },
+        "test_handle_prompt_dismiss_and_notify": {
+          "byUA": {
+            "eg42": "FAIL",
+            "ff60": "FAIL",
+            "ie11": "FAIL",
+            "wk18": "PASS"
+          },
           "totals": {
             "FAIL": 3,
             "PASS": 1
           }
         },
         "test_handle_prompt_accept_and_notify": {
-          "stNum": 3,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 3,
             "PASS": 1
           }
         },
         "test_handle_prompt_ignore": {
-          "stNum": 4,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 3,
             "PASS": 1
           }
         },
         "test_handle_prompt_default": {
-          "stNum": 5,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 3,
             "PASS": 1
           }
         },
         "test_handle_prompt_twice": {
-          "stNum": 6,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "FAIL",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 3,
             "PASS": 1
@@ -9740,33 +7851,24 @@
     },
     "/webdriver/tests/interface.html": {
       "byUA": {
-        "eg42": "OK",
-        "ie11": "ERROR"
-      },
-      "UAmessage": {
-        "ie11": "Message: Page reload detected during async script\n"
+        "eg42": "OK"
       },
       "totals": {
-        "OK": 1,
-        "ERROR": 1
+        "OK": 1
       },
       "subtests": {
         "navigator.webdriver is always true": {
-          "stNum": 0,
           "byUA": {
             "eg42": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1
           }
         },
         "Navigator interface: attribute webdriver": {
-          "stNum": 1,
           "byUA": {
             "eg42": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1
           }
@@ -9780,60 +7882,47 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_get_named_session_cookie": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
-            "PASS": 1,
-            "FAIL": 2
+            "PASS": 2,
+            "FAIL": 1
           }
         },
         "test_get_named_cookie": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "FAIL"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
+          "totals": {
+            "PASS": 3,
+            "ERROR": 1,
+            "FAIL": 1
+          }
+        },
+        "test_duplicated_cookie": {
+          "byUA": {
+            "eg42": "ERROR",
+            "ff60": "FAIL",
+            "ie11": "PASS",
+            "wk18": "FAIL"
           },
           "totals": {
             "PASS": 2,
             "ERROR": 1,
             "FAIL": 2
-          }
-        },
-        "test_duplicated_cookie": {
-          "stNum": 3,
-          "byUA": {
-            "eg42": "ERROR",
-            "ff60": "FAIL",
-            "ie11": "FAIL",
-            "wk18": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
-          "totals": {
-            "PASS": 1,
-            "ERROR": 1,
-            "FAIL": 3
           }
         }
       }
@@ -9844,20 +7933,15 @@
         "ff60": "OK",
         "ie11": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 3
       },
       "subtests": {
         "test_webdriver_special_key_sends_keydown[NUMPAD9-expected0]": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -9865,14 +7949,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[RETURN-expected1]": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -9881,14 +7961,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[HELP-expected2]": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -9897,30 +7973,22 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[SHIFT-expected3]": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
+            "ie11": "PASS"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 1,
             "ERROR": 1,
-            "PASS": 1
+            "PASS": 2
           }
         },
         "test_webdriver_special_key_sends_keydown[R_ARROWRIGHT-expected4]": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -9929,14 +7997,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[ESCAPE-expected5]": {
-          "stNum": 9,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -9945,14 +8009,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[PAGE_UP-expected6]": {
-          "stNum": 11,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -9961,14 +8021,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_PAGEUP-expected7]": {
-          "stNum": 13,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -9977,14 +8033,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[UP-expected8]": {
-          "stNum": 15,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -9993,14 +8045,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[DOWN-expected9]": {
-          "stNum": 17,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10009,14 +8057,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F12-expected10]": {
-          "stNum": 19,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10025,14 +8069,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[META-expected11]": {
-          "stNum": 21,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10041,14 +8081,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[BACKSPACE-expected12]": {
-          "stNum": 23,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10057,14 +8093,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[MULTIPLY-expected13]": {
-          "stNum": 25,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10073,14 +8105,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[HOME-expected14]": {
-          "stNum": 27,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10089,14 +8117,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[NULL-expected15]": {
-          "stNum": 29,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10105,14 +8129,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[SUBTRACT-expected16]": {
-          "stNum": 31,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10121,14 +8141,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[CONTROL-expected17]": {
-          "stNum": 33,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10137,14 +8153,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[INSERT-expected18]": {
-          "stNum": 35,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10153,14 +8165,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_META-expected19]": {
-          "stNum": 37,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10169,14 +8177,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[SEMICOLON-expected20]": {
-          "stNum": 39,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10185,14 +8189,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[SPACE-expected21]": {
-          "stNum": 41,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10201,14 +8201,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[NUMPAD4-expected22]": {
-          "stNum": 43,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10217,14 +8213,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[RIGHT-expected23]": {
-          "stNum": 45,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10233,14 +8225,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[TAB-expected24]": {
-          "stNum": 47,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10249,46 +8237,34 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_ALT-expected25]": {
-          "stNum": 49,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
+            "ie11": "PASS"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 1,
             "ERROR": 1,
-            "PASS": 1
+            "PASS": 2
           }
         },
         "test_webdriver_special_key_sends_keydown[NUMPAD0-expected26]": {
-          "stNum": 51,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
+            "ie11": "PASS"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 1,
             "ERROR": 1,
-            "PASS": 1
+            "PASS": 2
           }
         },
         "test_webdriver_special_key_sends_keydown[DECIMAL-expected27]": {
-          "stNum": 53,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10297,14 +8273,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[LEFT-expected28]": {
-          "stNum": 55,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10313,14 +8285,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_DELETE-expected29]": {
-          "stNum": 57,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10329,14 +8297,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[PAGE_DOWN-expected30]": {
-          "stNum": 59,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10345,14 +8309,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[PAUSE-expected31]": {
-          "stNum": 61,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10361,14 +8321,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[END-expected32]": {
-          "stNum": 63,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10377,14 +8333,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[DIVIDE-expected33]": {
-          "stNum": 65,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10393,14 +8345,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_ARROWUP-expected34]": {
-          "stNum": 67,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10409,14 +8357,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[NUMPAD3-expected35]": {
-          "stNum": 69,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10425,14 +8369,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[CLEAR-expected36]": {
-          "stNum": 71,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10441,14 +8381,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_ARROWLEFT-expected37]": {
-          "stNum": 73,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10457,14 +8393,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[EQUALS-expected38]": {
-          "stNum": 75,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10473,14 +8405,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_PAGEDOWN-expected39]": {
-          "stNum": 77,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10489,14 +8417,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[ADD-expected40]": {
-          "stNum": 79,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10505,14 +8429,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[NUMPAD1-expected41]": {
-          "stNum": 81,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10521,14 +8441,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_INSERT-expected42]": {
-          "stNum": 83,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10537,14 +8453,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[ENTER-expected43]": {
-          "stNum": 85,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10553,14 +8465,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[CANCEL-expected44]": {
-          "stNum": 87,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10569,14 +8477,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[NUMPAD6-expected45]": {
-          "stNum": 89,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10585,14 +8489,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F10-expected46]": {
-          "stNum": 91,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10601,14 +8501,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F11-expected47]": {
-          "stNum": 93,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10617,14 +8513,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_END-expected48]": {
-          "stNum": 95,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10633,14 +8525,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[NUMPAD7-expected49]": {
-          "stNum": 97,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10649,14 +8537,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[NUMPAD2-expected50]": {
-          "stNum": 99,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10665,14 +8549,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F1-expected51]": {
-          "stNum": 101,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10681,14 +8561,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F2-expected52]": {
-          "stNum": 103,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10697,14 +8573,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F3-expected53]": {
-          "stNum": 105,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10713,14 +8585,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F4-expected54]": {
-          "stNum": 107,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10729,14 +8597,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F5-expected55]": {
-          "stNum": 109,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10745,14 +8609,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F6-expected56]": {
-          "stNum": 111,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10761,14 +8621,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F7-expected57]": {
-          "stNum": 113,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10777,14 +8633,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F8-expected58]": {
-          "stNum": 115,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10793,14 +8645,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[F9-expected59]": {
-          "stNum": 117,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10809,14 +8657,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[NUMPAD8-expected60]": {
-          "stNum": 119,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10825,14 +8669,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[NUMPAD5-expected61]": {
-          "stNum": 121,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10841,30 +8681,22 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_CONTROL-expected62]": {
-          "stNum": 123,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
+            "ie11": "PASS"
           },
           "totals": {
-            "FAIL": 2,
+            "FAIL": 1,
             "ERROR": 1,
-            "PASS": 1
+            "PASS": 2
           }
         },
         "test_webdriver_special_key_sends_keydown[R_HOME-expected63]": {
-          "stNum": 125,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10873,14 +8705,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[ZENKAKUHANKAKU-expected64]": {
-          "stNum": 127,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10889,14 +8717,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_SHIFT-expected65]": {
-          "stNum": 129,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10905,14 +8729,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[SEPARATOR-expected66]": {
-          "stNum": 131,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10921,14 +8741,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[ALT-expected67]": {
-          "stNum": 133,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -10937,14 +8753,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[R_ARROWDOWN-expected68]": {
-          "stNum": 135,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10953,14 +8765,10 @@
           }
         },
         "test_webdriver_special_key_sends_keydown[DELETE-expected69]": {
-          "stNum": 137,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -10977,21 +8785,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -10999,89 +8802,73 @@
           }
         },
         "test_handle_prompt_dismiss_and_notify": {
-          "stNum": 1,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept_and_notify": {
-          "stNum": 2,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_ignore": {
-          "stNum": 3,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_handle_prompt_accept": {
-          "stNum": 4,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_handle_prompt_missing_value": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
-            "PASS": 2,
-            "FAIL": 1
+            "PASS": 3
           }
         },
         "test_unknown_cookie": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "FAIL"
           },
-          "UAmessage": {
-            "eg42": "teardown error"
-          },
           "totals": {
-            "FAIL": 4,
-            "ERROR": 1
+            "FAIL": 3,
+            "ERROR": 1,
+            "PASS": 1
           }
         }
       }
@@ -11093,26 +8880,21 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_is_stale": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
-            "FAIL": 2,
-            "PASS": 1
+            "FAIL": 1,
+            "PASS": 2
           }
         }
       }
@@ -11124,1188 +8906,954 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "TIMEOUT": 1,
         "OK": 3
       },
       "subtests": {
+        "/webdriver/tests/interaction/element_clear.py": {
+          "byUA": {
+            "eg42": "TIMEOUT"
+          },
+          "totals": {
+            "TIMEOUT": 1
+          }
+        },
         "test_closed_context": {
-          "stNum": 0,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_connected_element": {
-          "stNum": 1,
           "byUA": {
             "ff60": "FAIL",
-            "ie11": "FAIL"
+            "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 2
+            "FAIL": 1,
+            "PASS": 1
           }
         },
         "test_pointer_interactable": {
-          "stNum": 2,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_keyboard_interactable": {
-          "stNum": 3,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_keyboard_interactable": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
           "totals": {
             "PASS": 2
           }
         },
         "test_input[number-42-]": {
-          "stNum": 4,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[range-42-50]": {
-          "stNum": 5,
-          "byUA": {
-            "ff60": "FAIL",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "FAIL": 2
-          }
-        },
-        "test_input[email-foo@example.com-]": {
-          "stNum": 6,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
+          "totals": {
+            "FAIL": 1,
+            "PASS": 1
+          }
+        },
+        "test_input[email-foo@example.com-]": {
+          "byUA": {
+            "ff60": "FAIL",
+            "ie11": "PASS"
+          },
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[password-password-]": {
-          "stNum": 7,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[search-search-]": {
-          "stNum": 8,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[tel-999-]": {
-          "stNum": 9,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[text-text-]": {
-          "stNum": 10,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[url-https://example.com/-]": {
-          "stNum": 11,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[color-#ff0000-#000000]": {
-          "stNum": 12,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "FAIL"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2
           }
         },
         "test_input[date-2017-12-26-]": {
-          "stNum": 13,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[datetime-2017-12-26T19:48-]": {
-          "stNum": 14,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[datetime-local-2017-12-26T19:48-]": {
-          "stNum": 15,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[time-19:48-]": {
-          "stNum": 16,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[month-2017-11-]": {
-          "stNum": 17,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input[week-2017-W52-]": {
-          "stNum": 18,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_input_disabled[number]": {
-          "stNum": 19,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[range]": {
-          "stNum": 20,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[email]": {
-          "stNum": 21,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[password]": {
-          "stNum": 22,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[search]": {
-          "stNum": 23,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[tel]": {
-          "stNum": 24,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[text]": {
-          "stNum": 25,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[url]": {
-          "stNum": 26,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[color]": {
-          "stNum": 27,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[date]": {
-          "stNum": 28,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[datetime]": {
-          "stNum": 29,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[datetime-local]": {
-          "stNum": 30,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[time]": {
-          "stNum": 31,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[month]": {
-          "stNum": 32,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[week]": {
-          "stNum": 33,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_disabled[file]": {
-          "stNum": 34,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[number]": {
-          "stNum": 35,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[range]": {
-          "stNum": 36,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[email]": {
-          "stNum": 37,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[password]": {
-          "stNum": 38,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[search]": {
-          "stNum": 39,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[tel]": {
-          "stNum": 40,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[text]": {
-          "stNum": 41,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[url]": {
-          "stNum": 42,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[color]": {
-          "stNum": 43,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[date]": {
-          "stNum": 44,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[datetime]": {
-          "stNum": 45,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[datetime-local]": {
-          "stNum": 46,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[time]": {
-          "stNum": 47,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[month]": {
-          "stNum": 48,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[week]": {
-          "stNum": 49,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_readonly[file]": {
-          "stNum": 50,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_textarea": {
-          "stNum": 51,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 1
           }
         },
         "test_textarea_disabled": {
-          "stNum": 52,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_textarea_readonly": {
-          "stNum": 53,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_file": {
-          "stNum": 54,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_input_file_multiple": {
-          "stNum": 55,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_select": {
-          "stNum": 56,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_button": {
-          "stNum": 57,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_button_with_subtree": {
-          "stNum": 58,
           "byUA": {
             "ff60": "PASS",
             "ie11": "FAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1,
             "FAIL": 1
           }
         },
         "test_contenteditable": {
-          "stNum": 59,
           "byUA": {
             "ff60": "FAIL",
             "ie11": "FAIL"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2
           }
         },
         "test_designmode": {
-          "stNum": 60,
           "byUA": {
             "ff60": "PASS",
             "ie11": "FAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1,
             "FAIL": 1
           }
         },
         "test_resettable_element_focus_when_empty": {
-          "stNum": 61,
           "byUA": {
             "ff60": "PASS",
             "ie11": "FAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1,
             "FAIL": 1
           }
         },
         "test_resettable_element_does_not_satisfy_validation_constraints[number-foo]": {
-          "stNum": 62,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_resettable_element_does_not_satisfy_validation_constraints[range-foo]": {
-          "stNum": 63,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_resettable_element_does_not_satisfy_validation_constraints[email-foo]": {
-          "stNum": 64,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_resettable_element_does_not_satisfy_validation_constraints[url-foo]": {
-          "stNum": 65,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_resettable_element_does_not_satisfy_validation_constraints[color-foo]": {
-          "stNum": 66,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_resettable_element_does_not_satisfy_validation_constraints[date-foo]": {
-          "stNum": 67,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_resettable_element_does_not_satisfy_validation_constraints[datetime-foo]": {
-          "stNum": 68,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_resettable_element_does_not_satisfy_validation_constraints[datetime-local-foo]": {
-          "stNum": 69,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_resettable_element_does_not_satisfy_validation_constraints[time-foo]": {
-          "stNum": 70,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_resettable_element_does_not_satisfy_validation_constraints[month-foo]": {
-          "stNum": 71,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_resettable_element_does_not_satisfy_validation_constraints[week-foo]": {
-          "stNum": 72,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_non_editable_inputs[checkbox]": {
-          "stNum": 73,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_resettable_element_does_not_satisfy_validation_constraints[range-foo]": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_resettable_element_does_not_satisfy_validation_constraints[email-foo]": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_resettable_element_does_not_satisfy_validation_constraints[url-foo]": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_resettable_element_does_not_satisfy_validation_constraints[color-foo]": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_resettable_element_does_not_satisfy_validation_constraints[date-foo]": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_resettable_element_does_not_satisfy_validation_constraints[datetime-foo]": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_resettable_element_does_not_satisfy_validation_constraints[datetime-local-foo]": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_resettable_element_does_not_satisfy_validation_constraints[time-foo]": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_resettable_element_does_not_satisfy_validation_constraints[month-foo]": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_resettable_element_does_not_satisfy_validation_constraints[week-foo]": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
+          "totals": {
+            "PASS": 2
+          }
+        },
+        "test_non_editable_inputs[checkbox]": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS"
+          },
           "totals": {
             "PASS": 2
           }
         },
         "test_non_editable_inputs[radio]": {
-          "stNum": 74,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_non_editable_inputs[hidden]": {
-          "stNum": 75,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_non_editable_inputs[submit]": {
-          "stNum": 76,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_non_editable_inputs[button]": {
-          "stNum": 77,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_non_editable_inputs[image]": {
-          "stNum": 78,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2
           }
         },
         "test_scroll_into_view": {
-          "stNum": 79,
           "byUA": {
             "ff60": "PASS",
-            "ie11": "FAIL"
+            "ie11": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "PASS": 1,
-            "FAIL": 1
-          }
-        },
-        "test_contenteditable_focus": {
-          "stNum": 60,
-          "byUA": {
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "FAIL": 1
-          }
-        },
-        "test_resettable_element_focus": {
-          "stNum": 62,
-          "byUA": {
-            "ie11": "FAIL"
-          },
-          "UAmessage": {},
-          "totals": {
-            "FAIL": 1
+            "PASS": 2
           }
         },
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1
           }
         },
         "test_element_not_found": {
-          "stNum": 1,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_element_not_editable": {
-          "stNum": 2,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_button_element_not_resettable": {
-          "stNum": 3,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_disabled_element_not_resettable": {
-          "stNum": 4,
           "byUA": {
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1
           }
         },
         "test_scroll_into_element_view": {
-          "stNum": 5,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_element_readonly": {
-          "stNum": 6,
           "byUA": {
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1
           }
         },
         "test_element_disabled": {
-          "stNum": 7,
           "byUA": {
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1
           }
         },
         "test_element_pointer_events_disabled": {
-          "stNum": 8,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element0]": {
-          "stNum": 9,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element1]": {
-          "stNum": 10,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element2]": {
-          "stNum": 11,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element3]": {
-          "stNum": 12,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element4]": {
-          "stNum": 13,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element5]": {
-          "stNum": 14,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element6]": {
-          "stNum": 15,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element7]": {
-          "stNum": 16,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element8]": {
-          "stNum": 17,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element9]": {
-          "stNum": 18,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element10]": {
-          "stNum": 19,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element11]": {
-          "stNum": 20,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element12]": {
-          "stNum": 21,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element13]": {
-          "stNum": 22,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element14]": {
-          "stNum": 23,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
         },
         "test_clear_content_editable_resettable_element[element15]": {
-          "stNum": 24,
           "byUA": {
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "XFAIL": 1
           }
@@ -12319,314 +9867,261 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_valid[acceptInsecureCerts-False]": {
-          "stNum": 0,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[acceptInsecureCerts-None]": {
-          "stNum": 1,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[browserName-None]": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
           }
         },
         "test_valid[browserVersion-None]": {
-          "stNum": 3,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[platformName-None]": {
-          "stNum": 4,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[pageLoadStrategy-none]": {
-          "stNum": 5,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[pageLoadStrategy-eager]": {
-          "stNum": 6,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[pageLoadStrategy-normal]": {
-          "stNum": 7,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[pageLoadStrategy-None]": {
-          "stNum": 8,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[proxy-None]": {
-          "stNum": 9,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[timeouts-value10]": {
-          "stNum": 10,
           "byUA": {
             "eg42": "PASS",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "FAIL"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 2,
             "FAIL": 2
           }
         },
         "test_valid[timeouts-value11]": {
-          "stNum": 11,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[timeouts-value12]": {
-          "stNum": 12,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[timeouts-value13]": {
-          "stNum": 13,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[unhandledPromptBehavior-dismiss]": {
-          "stNum": 14,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[unhandledPromptBehavior-dismiss]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[unhandledPromptBehavior-accept]": {
-          "stNum": 15,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[unhandledPromptBehavior-None]": {
-          "stNum": 16,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 4
           }
         },
         "test_valid[test:extension-True]": {
-          "stNum": 17,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[test:extension-abc]": {
-          "stNum": 18,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[test:extension-123]": {
-          "stNum": 19,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[test:extension-value20]": {
-          "stNum": 20,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[test:extension-value21]": {
-          "stNum": 21,
-          "byUA": {
-            "eg42": "PASS",
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 3,
-            "FAIL": 1
-          }
-        },
-        "test_valid[test:extension-None]": {
-          "stNum": 22,
           "byUA": {
             "eg42": "PASS",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[test:extension-abc]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[test:extension-123]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[test:extension-value20]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[test:extension-value21]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
+          "totals": {
+            "PASS": 4
+          }
+        },
+        "test_valid[test:extension-None]": {
+          "byUA": {
+            "eg42": "PASS",
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
           "totals": {
             "PASS": 4
           }
@@ -12640,134 +10135,119 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "TIMEOUT": 1,
         "OK": 3
       },
       "subtests": {
+        "/webdriver/tests/element_retrieval/get_active_element.py": {
+          "byUA": {
+            "eg42": "TIMEOUT"
+          },
+          "totals": {
+            "TIMEOUT": 1
+          }
+        },
         "test_closed_context": {
-          "stNum": 0,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_handle_prompt_dismiss": {
-          "stNum": 1,
           "byUA": {
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 2,
-            "PASS": 1
+            "FAIL": 1,
+            "PASS": 2
           }
         },
         "test_handle_prompt_accept": {
-          "stNum": 2,
           "byUA": {
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 2,
-            "PASS": 1
+            "FAIL": 1,
+            "PASS": 2
           }
         },
         "test_handle_prompt_missing_value": {
-          "stNum": 3,
-          "byUA": {
-            "ff60": "PASS",
-            "ie11": "FAIL",
-            "wk18": "PASS"
-          },
-          "UAmessage": {},
-          "totals": {
-            "PASS": 2,
-            "FAIL": 1
-          }
-        },
-        "test_success_document": {
-          "stNum": 4,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
+          "totals": {
+            "PASS": 3
+          }
+        },
+        "test_success_document": {
+          "byUA": {
+            "ff60": "PASS",
+            "ie11": "PASS",
+            "wk18": "PASS"
+          },
           "totals": {
             "PASS": 3
           }
         },
         "test_sucess_input": {
-          "stNum": 5,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_sucess_input_non_interactable": {
-          "stNum": 6,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_success_explicit_focus": {
-          "stNum": 7,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_success_iframe_content": {
-          "stNum": 8,
           "byUA": {
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 3
           }
         },
         "test_missing_document_element": {
-          "stNum": 9,
           "byUA": {
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "PASS": 2,
-            "FAIL": 1
+            "PASS": 3
           }
         }
       }
@@ -12779,118 +10259,101 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_platform_name[body0]": {
-          "stNum": 0,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 2
           }
         },
         "test_platform_name[body1]": {
-          "stNum": 1,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 2
           }
         },
         "test_merge_invalid[acceptInsecureCerts-value0]": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
           }
         },
         "test_merge_invalid[unhandledPromptBehavior-value1]": {
-          "stNum": 3,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
           }
         },
         "test_merge_invalid[unhandledPromptBehavior-value2]": {
-          "stNum": 4,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
           }
         },
         "test_merge_invalid[timeouts-value3]": {
-          "stNum": 5,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
           }
         },
         "test_merge_invalid[timeouts-value4]": {
-          "stNum": 6,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 3
           }
         },
         "test_merge_platformName": {
-          "stNum": 7,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 2,
             "PASS": 1,
@@ -12898,14 +10361,12 @@
           }
         },
         "test_merge_browserName": {
-          "stNum": 8,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1,
             "PASS": 2,
@@ -12921,21 +10382,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -12943,60 +10399,47 @@
           }
         },
         "test_handle_prompt_dismiss": {
-          "stNum": 1,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_handle_prompt_accept": {
-          "stNum": 2,
           "byUA": {
             "eg42": "FAIL",
             "ff60": "FAIL",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
           },
-          "UAmessage": {},
           "totals": {
-            "FAIL": 3,
-            "PASS": 1
+            "FAIL": 2,
+            "PASS": 2
           }
         },
         "test_handle_prompt_missing_value": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
-            "ie11": "FAIL",
+            "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
-            "PASS": 2,
-            "FAIL": 1
+            "PASS": 3
           }
         },
         "test_element_not_found": {
-          "stNum": 4,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -13006,15 +10449,11 @@
           }
         },
         "test_element_stale": {
-          "stNum": 6,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "FAIL",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -13023,15 +10462,11 @@
           }
         },
         "test_normal": {
-          "stNum": 8,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13039,15 +10474,11 @@
           }
         },
         "test_boolean_attribute[audio-attrs0]": {
-          "stNum": 10,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13055,15 +10486,11 @@
           }
         },
         "test_boolean_attribute[button-attrs1]": {
-          "stNum": 12,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 3,
@@ -13072,15 +10499,11 @@
           }
         },
         "test_boolean_attribute[details-attrs2]": {
-          "stNum": 14,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -13089,15 +10512,11 @@
           }
         },
         "test_boolean_attribute[dialog-attrs3]": {
-          "stNum": 16,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -13107,15 +10526,11 @@
           }
         },
         "test_boolean_attribute[fieldset-attrs4]": {
-          "stNum": 18,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13123,15 +10538,11 @@
           }
         },
         "test_boolean_attribute[form-attrs5]": {
-          "stNum": 20,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -13141,15 +10552,11 @@
           }
         },
         "test_boolean_attribute[iframe-attrs6]": {
-          "stNum": 22,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 2,
@@ -13159,15 +10566,11 @@
           }
         },
         "test_boolean_attribute[img-attrs7]": {
-          "stNum": 24,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 3,
@@ -13176,15 +10579,11 @@
           }
         },
         "test_boolean_attribute[input-attrs8]": {
-          "stNum": 26,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 3,
@@ -13193,15 +10592,11 @@
           }
         },
         "test_boolean_attribute[menuitem-attrs9]": {
-          "stNum": 28,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -13211,15 +10606,11 @@
           }
         },
         "test_boolean_attribute[object-attrs10]": {
-          "stNum": 30,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -13229,15 +10620,11 @@
           }
         },
         "test_boolean_attribute[ol-attrs11]": {
-          "stNum": 32,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -13246,15 +10633,11 @@
           }
         },
         "test_boolean_attribute[optgroup-attrs12]": {
-          "stNum": 34,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13262,15 +10645,11 @@
           }
         },
         "test_boolean_attribute[option-attrs13]": {
-          "stNum": 36,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13278,15 +10657,11 @@
           }
         },
         "test_boolean_attribute[script-attrs14]": {
-          "stNum": 38,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13294,15 +10669,11 @@
           }
         },
         "test_boolean_attribute[select-attrs15]": {
-          "stNum": 40,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13310,15 +10681,11 @@
           }
         },
         "test_boolean_attribute[textarea-attrs16]": {
-          "stNum": 42,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -13327,15 +10694,11 @@
           }
         },
         "test_boolean_attribute[track-attrs17]": {
-          "stNum": 44,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13343,15 +10706,11 @@
           }
         },
         "test_boolean_attribute[video-attrs18]": {
-          "stNum": 46,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13359,15 +10718,11 @@
           }
         },
         "test_global_boolean_attributes": {
-          "stNum": 48,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -13385,21 +10740,16 @@
         "ie11": "OK",
         "wk18": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 4
       },
       "subtests": {
         "test_get_current_url_no_browsing_context": {
-          "stNum": 0,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "setup error"
           },
           "totals": {
             "ERROR": 1,
@@ -13407,15 +10757,11 @@
           }
         },
         "test_get_current_url_alert_prompt": {
-          "stNum": 1,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -13424,15 +10770,11 @@
           }
         },
         "test_get_current_url_matches_location": {
-          "stNum": 3,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13440,15 +10782,11 @@
           }
         },
         "test_get_current_url_payload": {
-          "stNum": 5,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13456,15 +10794,11 @@
           }
         },
         "test_get_current_url_special_pages": {
-          "stNum": 7,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13472,15 +10806,11 @@
           }
         },
         "test_get_current_url_file_protocol": {
-          "stNum": 9,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "FAIL",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 2,
@@ -13489,15 +10819,11 @@
           }
         },
         "test_set_malformed_url": {
-          "stNum": 11,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -13507,15 +10833,11 @@
           }
         },
         "test_get_current_url_after_modified_location": {
-          "stNum": 13,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -13525,15 +10847,11 @@
           }
         },
         "test_get_current_url_nested_browsing_context": {
-          "stNum": 15,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "XFAIL"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "FAIL": 1,
@@ -13543,15 +10861,11 @@
           }
         },
         "test_get_current_url_nested_browsing_contexts": {
-          "stNum": 17,
           "byUA": {
             "eg42": "ERROR",
             "ff60": "PASS",
             "ie11": "PASS",
             "wk18": "PASS"
-          },
-          "UAmessage": {
-            "eg42": "teardown error"
           },
           "totals": {
             "PASS": 4,
@@ -13564,67 +10878,54 @@
       "byUA": {
         "ff60": "OK"
       },
-      "UAmessage": {},
       "totals": {
         "OK": 1
       },
       "subtests": {
         "test_input": {
-          "stNum": 0,
           "byUA": {
             "ff60": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1
           }
         },
         "test_textarea": {
-          "stNum": 1,
           "byUA": {
             "ff60": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1
           }
         },
         "test_input_append": {
-          "stNum": 2,
           "byUA": {
             "ff60": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1
           }
         },
         "test_textarea_append": {
-          "stNum": 3,
           "byUA": {
             "ff60": "PASS"
           },
-          "UAmessage": {},
           "totals": {
             "PASS": 1
           }
         },
         "test_events[input]": {
-          "stNum": 4,
           "byUA": {
             "ff60": "FAIL"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1
           }
         },
         "test_events[textarea]": {
-          "stNum": 5,
           "byUA": {
             "ff60": "FAIL"
           },
-          "UAmessage": {},
           "totals": {
             "FAIL": 1
           }

--- a/results/html/less-than-2.html
+++ b/results/html/less-than-2.html
@@ -2,237 +2,158 @@
 <html lang='en'>
   <head>
     <meta charset='utf-8'>
-    <title>WebDriver: Less Than 2 Passes</title>
+    <title>Less Than 2 Passes</title>
     <link rel='stylesheet' href='bootstrap.min.css'>
     <link rel='stylesheet' href='analysis.css'>
   </head>
   <body>
     <div class='container'>
       <header>
-        <h1>WebDriver: Less Than 2 Passes</h1>
+        <h1>Less Than 2 Passes</h1>
       </header>
-
-      <p><strong>Test files without 2 passes</strong>: 26; <strong>Subtests without 2 passes: </strong>156; <strong>Failure level</strong>: 156/879 (17.74%)</p>
+      <p><strong>Test files without 2 passes</strong>: 19; <strong>Subtests without 2 passes: </strong>96; <strong>Failure level</strong>: 96/862 (11.14%)</p>
       <h3>Test Files</h3>
-<ol class='toc'>
-<li><a href='#test-file-1'>/webdriver/tests/contexts/maximize_window.py</a> <small>(2/10, 20.00%, 0.33% of total)</small></li>
-<li><a href='#test-file-2'>/webdriver/tests/minimize_window.py</a> <small>(3/10, 30.00%, 0.33% of total)</small></li>
-<li><a href='#test-file-4'>/webdriver/tests/sessions/new_session/default_values.py</a> <small>(1/8, 12.50%, 0.11% of total)</small></li>
-<li><a href='#test-file-5'>/webdriver/tests/state/get_element_property.py</a> <small>(1/6, 16.66%, 0.33% of total)</small></li>
-<li><a href='#test-file-6'>/webdriver/tests/fullscreen_window.py</a> <small>(2/7, 28.57%, 0.45% of total)</small></li>
-<li><a href='#test-file-7'>/webdriver/tests/actions/key.py</a> <small>(7/20, 35.00%, 0.78% of total)</small></li>
-<li><a href='#test-file-8'>/webdriver/tests/actions/key_shortcuts.py</a> <small>(1/3, 33.33%, 0.11% of total)</small></li>
-<li><a href='#test-file-9'>/webdriver/tests/contexts/json_serialize_windowproxy.py</a> <small>(3/3, 100.00%, 0.33% of total)</small></li>
-<li><a href='#test-file-10'>/webdriver/tests/execute_async_script/user_prompts.py</a> <small>(7/7, 100.00%, 0.78% of total)</small></li>
-<li><a href='#test-file-12'>/webdriver/tests/element_send_keys/scroll_into_view.py</a> <small>(3/5, 60.00%, 0.33% of total)</small></li>
-<li><a href='#test-file-13'>/webdriver/tests/cookies/add_cookie.py</a> <small>(5/5, 100.00%, 0.56% of total)</small></li>
-<li><a href='#test-file-14'>/webdriver/tests/set_window_rect.py</a> <small>(1/75, 1.33%, 0.11% of total)</small></li>
-<li><a href='#test-file-15'>/webdriver/tests/element_send_keys/interactability.py</a> <small>(3/10, 30.00%, 0.33% of total)</small></li>
-<li><a href='#test-file-16'>/webdriver/tests/element_click/select.py</a> <small>(1/11, 9.09%, 0.11% of total)</small></li>
-<li><a href='#test-file-17'>/webdriver/tests/actions/modifier_click.py</a> <small>(2/7, 28.57%, 0.22% of total)</small></li>
-<li><a href='#test-file-18'>/webdriver/tests/element_click/bubbling.py</a> <small>(1/3, 33.33%, 0.11% of total)</small></li>
-<li><a href='#test-file-20'>/webdriver/tests/execute_script/user_prompts.py</a> <small>(5/7, 71.43%, 0.56% of total)</small></li>
-<li><a href='#test-file-21'>/webdriver/tests/interface.html</a> <small>(2/2, 100.00%, 0.22% of total)</small></li>
-<li><a href='#test-file-22'>/webdriver/tests/cookies/get_named_cookie.py</a> <small>(2/3, 66.67%, 0.22% of total)</small></li>
-<li><a href='#test-file-23'>/webdriver/tests/actions/special_keys.py</a> <small>(33/70, 47.14%, 3.68% of total)</small></li>
-<li><a href='#test-file-24'>/webdriver/tests/cookies/delete_cookie.py</a> <small>(1/6, 16.66%, 0.22% of total)</small></li>
-<li><a href='#test-file-25'>/webdriver/tests/element_click/stale.py</a> <small>(1/1, 100.00%, 0.11% of total)</small></li>
-<li><a href='#test-file-26'>/webdriver/tests/interaction/element_clear.py</a> <small>(61/107, 57.01%, 6.80% of total)</small></li>
-<li><a href='#test-file-28'>/webdriver/tests/sessions/new_session/merge.py</a> <small>(1/9, 11.11%, 0.11% of total)</small></li>
-<li><a href='#test-file-29'>/webdriver/tests/state/get_element_attribute.py</a> <small>(2/25, 8.00%, 0.45% of total)</small></li>
-<li><a href='#test-file-30'>/webdriver/tests/element_send_keys/form_controls.py</a> <small>(6/6, 100.00%, 0.67% of total)</small></li>
+<ol class='toc'><li><a href='#test-file-0'>/webdriver/tests/contexts/maximize_window.py</a> <small>(2/11, 18.18%, 0.23% of total)</small></li>
+<li><a href='#test-file-1'>/webdriver/tests/minimize_window.py</a> <small>(2/10, 20.00%, 0.23% of total)</small></li>
+<li><a href='#test-file-2'>/webdriver/tests/sessions/new_session/default_values.py</a> <small>(1/8, 12.50%, 0.12% of total)</small></li>
+<li><a href='#test-file-3'>/webdriver/tests/state/get_element_property.py</a> <small>(1/8, 12.50%, 0.12% of total)</small></li>
+<li><a href='#test-file-4'>/webdriver/tests/fullscreen_window.py</a> <small>(4/9, 44.44%, 0.46% of total)</small></li>
+<li><a href='#test-file-5'>/webdriver/tests/actions/key.py</a> <small>(5/20, 25.00%, 0.58% of total)</small></li>
+<li><a href='#test-file-6'>/webdriver/tests/contexts/json_serialize_windowproxy.py</a> <small>(3/3, 100.00%, 0.35% of total)</small></li>
+<li><a href='#test-file-7'>/webdriver/tests/execute_async_script/user_prompts.py</a> <small>(7/7, 100.00%, 0.81% of total)</small></li>
+<li><a href='#test-file-8'>/webdriver/tests/element_send_keys/scroll_into_view.py</a> <small>(2/5, 40.00%, 0.23% of total)</small></li>
+<li><a href='#test-file-9'>/webdriver/tests/cookies/add_cookie.py</a> <small>(4/5, 80.00%, 0.46% of total)</small></li>
+<li><a href='#test-file-10'>/webdriver/tests/set_window_rect.py</a> <small>(1/75, 1.33%, 0.12% of total)</small></li>
+<li><a href='#test-file-11'>/webdriver/tests/element_send_keys/interactability.py</a> <small>(1/10, 10.00%, 0.12% of total)</small></li>
+<li><a href='#test-file-12'>/webdriver/tests/actions/modifier_click.py</a> <small>(2/7, 28.57%, 0.23% of total)</small></li>
+<li><a href='#test-file-13'>/webdriver/tests/execute_script/user_prompts.py</a> <small>(7/7, 100.00%, 0.81% of total)</small></li>
+<li><a href='#test-file-14'>/webdriver/tests/actions/special_keys.py</a> <small>(29/70, 41.43%, 3.36% of total)</small></li>
+<li><a href='#test-file-15'>/webdriver/tests/cookies/delete_cookie.py</a> <small>(1/7, 14.29%, 0.12% of total)</small></li>
+<li><a href='#test-file-16'>/webdriver/tests/interaction/element_clear.py</a> <small>(21/80, 26.25%, 2.44% of total)</small></li>
+<li><a href='#test-file-17'>/webdriver/tests/sessions/new_session/merge.py</a> <small>(1/9, 11.11%, 0.12% of total)</small></li>
+<li><a href='#test-file-18'>/webdriver/tests/state/get_element_attribute.py</a> <small>(2/27, 7.41%, 0.23% of total)</small></li>
 </ol>
       <table class='table persist-area'>
-        <thead><tr class='persist-header'><th>Test <span class='message_toggle'>Show/Hide Messages</span></th><th>eg42</th><th>ff60</th><th>ie11</th><th>wk18</th></tr></thead>
-<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/webdriver/tests/contexts/maximize_window.py' target='_blank'>/webdriver/tests/contexts/maximize_window.py</a> <small>(2/10, 20.00%, 0.33% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-3-6' class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-3-5' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/webdriver/tests/minimize_window.py' target='_blank'>/webdriver/tests/minimize_window.py</a> <small>(2/10, 20.00%, 0.33% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-8-6' class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-8-5' class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-11'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/new_session/default_values.py' target='_blank'>/webdriver/tests/sessions/new_session/default_values.py</a> <small>(1/8, 12.50%, 0.11% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-11-7' class='subtest'><td>test_valid_but_unmatchable_key</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-12'><td><a href='http://www.w3c-test.org/webdriver/tests/state/get_element_property.py' target='_blank'>/webdriver/tests/state/get_element_property.py</a> <small>(1/6, 16.66%, 0.33% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-12-10' class='subtest'><td>test_element</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/webdriver/tests/fullscreen_window.py' target='_blank'>/webdriver/tests/fullscreen_window.py</a> <small>(2/7, 28.57%, 0.45% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-14-6' class='subtest'><td>test_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-14-10' class='subtest'><td>test_fullscreen_twice_is_idempotent</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-15'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/key.py' target='_blank'>/webdriver/tests/actions/key.py</a> <small>(7/20, 35.00%, 0.78% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-19' class='subtest'><td>test_single_emoji_records_correct_key[\U0001f604]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-21' class='subtest'><td>test_single_emoji_records_correct_key[\U0001f60d]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-25' class='subtest'><td>test_single_modifier_key_sends_correct_events[\ue053-OSRight-Meta]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-29' class='subtest'><td>test_single_nonprintable_key_sends_events[\ue00c-Escape-Escape]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-31' class='subtest'><td>test_single_nonprintable_key_sends_events[\ue014-ArrowRight-ArrowRight]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-5' class='subtest'><td>test_single_printable_key_sends_correct_events["-Quote]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-15-13' class='subtest'><td>test_single_printable_key_sends_correct_events[@-Digit2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/key_shortcuts.py' target='_blank'>/webdriver/tests/actions/key_shortcuts.py</a> <small>(1/3, 33.33%, 0.11% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
-<tr id='subtest-17-1' class='subtest'><td>test_mod_a_mod_c_right_mod_v_pastes_text</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='test' id='test-file-19'><td><a href='http://www.w3c-test.org/webdriver/tests/contexts/json_serialize_windowproxy.py' target='_blank'>/webdriver/tests/contexts/json_serialize_windowproxy.py</a> <small>(3/3, 100.00%, 0.33% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-19-3' class='subtest'><td>test_frame</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-19-0' class='subtest'><td>test_initial_window</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-19-1' class='subtest'><td>test_window_open</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-20'><td><a href='http://www.w3c-test.org/webdriver/tests/execute_async_script/user_prompts.py' target='_blank'>/webdriver/tests/execute_async_script/user_prompts.py</a> <small>(7/7, 100.00%, 0.78% of total)</small></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-20-0' class='subtest'><td>test_handle_prompt_accept</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-3' class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-5' class='subtest'><td>test_handle_prompt_default</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-1' class='subtest'><td>test_handle_prompt_dismiss</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-2' class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-4' class='subtest'><td>test_handle_prompt_ignore</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-20-6' class='subtest'><td>test_handle_prompt_twice</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-25'><td><a href='http://www.w3c-test.org/webdriver/tests/element_send_keys/scroll_into_view.py' target='_blank'>/webdriver/tests/element_send_keys/scroll_into_view.py</a> <small>(3/5, 60.00%, 0.33% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-25-0' class='subtest'><td>test_element_outside_of_not_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-25-3' class='subtest'><td>test_option_select_container_outside_of_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-25-5' class='subtest'><td>test_option_stays_outside_of_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-27'><td><a href='http://www.w3c-test.org/webdriver/tests/cookies/add_cookie.py' target='_blank'>/webdriver/tests/cookies/add_cookie.py</a> <small>(5/5, 100.00%, 0.56% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-27-1' class='subtest'><td>test_add_cookie_for_ip</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-27-0' class='subtest'><td>test_add_domain_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-27-3' class='subtest'><td>test_add_non_session_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-27-5' class='subtest'><td>test_add_session_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-27-7' class='subtest'><td>test_add_session_cookie_with_leading_dot_character_in_domain</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-28'><td><a href='http://www.w3c-test.org/webdriver/tests/set_window_rect.py' target='_blank'>/webdriver/tests/set_window_rect.py</a> <small>(1/75, 1.33%, 0.11% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-28-113' class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-29'><td><a href='http://www.w3c-test.org/webdriver/tests/element_send_keys/interactability.py' target='_blank'>/webdriver/tests/element_send_keys/interactability.py</a> <small>(3/10, 30.00%, 0.33% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-29-17' class='subtest'><td>test_disabled_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-29-3' class='subtest'><td>test_iframe_is_interactable</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-29-11' class='subtest'><td>test_not_a_focusable_element</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-31'><td><a href='http://www.w3c-test.org/webdriver/tests/element_click/select.py' target='_blank'>/webdriver/tests/element_click/select.py</a> <small>(1/11, 9.09%, 0.11% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-31-19' class='subtest'><td>test_option_disabled</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='test' id='test-file-34'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/modifier_click.py' target='_blank'>/webdriver/tests/actions/modifier_click.py</a> <small>(2/7, 28.57%, 0.22% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
-<tr id='subtest-34-4' class='subtest'><td>test_modifier_click[\ue03d-metaKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-34-6' class='subtest'><td>test_modifier_click[\ue053-metaKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='test' id='test-file-37'><td><a href='http://www.w3c-test.org/webdriver/tests/element_click/bubbling.py' target='_blank'>/webdriver/tests/element_click/bubbling.py</a> <small>(1/3, 33.33%, 0.11% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-37-1' class='subtest'><td>test_spin_event_loop</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-42'><td><a href='http://www.w3c-test.org/webdriver/tests/execute_script/user_prompts.py' target='_blank'>/webdriver/tests/execute_script/user_prompts.py</a> <small>(5/7, 71.43%, 0.56% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-42-3' class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-42-5' class='subtest'><td>test_handle_prompt_default</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-42-2' class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-42-4' class='subtest'><td>test_handle_prompt_ignore</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-42-6' class='subtest'><td>test_handle_prompt_twice</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-43'><td><a href='http://www.w3c-test.org/webdriver/tests/interface.html' target='_blank'>/webdriver/tests/interface.html</a> <small>(2/2, 100.00%, 0.22% of total)</small></td><td class='OK'>OK</td><td class='undefined'>-</td><td class='ERROR'>ERROR</td><td class='undefined'>-</td></tr>
-<tr id='subtest-43-1' class='subtest'><td>Navigator interface: attribute webdriver</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-43-0' class='subtest'><td>navigator.webdriver is always true</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr class='test' id='test-file-44'><td><a href='http://www.w3c-test.org/webdriver/tests/cookies/get_named_cookie.py' target='_blank'>/webdriver/tests/cookies/get_named_cookie.py</a> <small>(2/3, 66.67%, 0.22% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-44-3' class='subtest'><td>test_duplicated_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-44-0' class='subtest'><td>test_get_named_session_cookie</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-45'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/special_keys.py' target='_blank'>/webdriver/tests/actions/special_keys.py</a> <small>(33/70, 47.14%, 3.68% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-79' class='subtest'><td>test_webdriver_special_key_sends_keydown[ADD-expected40]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-87' class='subtest'><td>test_webdriver_special_key_sends_keydown[CANCEL-expected44]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-53' class='subtest'><td>test_webdriver_special_key_sends_keydown[DECIMAL-expected27]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-137' class='subtest'><td>test_webdriver_special_key_sends_keydown[DELETE-expected69]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-65' class='subtest'><td>test_webdriver_special_key_sends_keydown[DIVIDE-expected33]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-17' class='subtest'><td>test_webdriver_special_key_sends_keydown[DOWN-expected9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-85' class='subtest'><td>test_webdriver_special_key_sends_keydown[ENTER-expected43]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-9' class='subtest'><td>test_webdriver_special_key_sends_keydown[ESCAPE-expected5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-55' class='subtest'><td>test_webdriver_special_key_sends_keydown[LEFT-expected28]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-21' class='subtest'><td>test_webdriver_special_key_sends_keydown[META-expected11]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-25' class='subtest'><td>test_webdriver_special_key_sends_keydown[MULTIPLY-expected13]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-29' class='subtest'><td>test_webdriver_special_key_sends_keydown[NULL-expected15]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-51' class='subtest'><td>test_webdriver_special_key_sends_keydown[NUMPAD0-expected26]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-45' class='subtest'><td>test_webdriver_special_key_sends_keydown[RIGHT-expected23]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-49' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ALT-expected25]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-135' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWDOWN-expected68]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-73' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWLEFT-expected37]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-7' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWRIGHT-expected4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-67' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWUP-expected34]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-123' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_CONTROL-expected62]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-57' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_DELETE-expected29]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-95' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_END-expected48]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-125' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_HOME-expected63]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-83' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_INSERT-expected42]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-37' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_META-expected19]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-77' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_PAGEDOWN-expected39]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-13' class='subtest'><td>test_webdriver_special_key_sends_keydown[R_PAGEUP-expected7]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-131' class='subtest'><td>test_webdriver_special_key_sends_keydown[SEPARATOR-expected66]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-5' class='subtest'><td>test_webdriver_special_key_sends_keydown[SHIFT-expected3]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-41' class='subtest'><td>test_webdriver_special_key_sends_keydown[SPACE-expected21]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-31' class='subtest'><td>test_webdriver_special_key_sends_keydown[SUBTRACT-expected16]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-15' class='subtest'><td>test_webdriver_special_key_sends_keydown[UP-expected8]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-45-127' class='subtest'><td>test_webdriver_special_key_sends_keydown[ZENKAKUHANKAKU-expected64]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr class='test' id='test-file-46'><td><a href='http://www.w3c-test.org/webdriver/tests/cookies/delete_cookie.py' target='_blank'>/webdriver/tests/cookies/delete_cookie.py</a> <small>(1/6, 16.66%, 0.22% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-46-6' class='subtest'><td>test_unknown_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-47'><td><a href='http://www.w3c-test.org/webdriver/tests/element_click/stale.py' target='_blank'>/webdriver/tests/element_click/stale.py</a> <small>(1/1, 100.00%, 0.11% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-47-0' class='subtest'><td>test_is_stale</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
-<tr class='test' id='test-file-48'><td><a href='http://www.w3c-test.org/webdriver/tests/interaction/element_clear.py' target='_blank'>/webdriver/tests/interaction/element_clear.py</a> <small>(61/107, 57.01%, 6.80% of total)</small></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-48-3' class='subtest'><td>test_button_element_not_resettable</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-58' class='subtest'><td>test_button_with_subtree</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-9' class='subtest'><td>test_clear_content_editable_resettable_element[element0]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-19' class='subtest'><td>test_clear_content_editable_resettable_element[element10]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-20' class='subtest'><td>test_clear_content_editable_resettable_element[element11]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-21' class='subtest'><td>test_clear_content_editable_resettable_element[element12]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-22' class='subtest'><td>test_clear_content_editable_resettable_element[element13]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-23' class='subtest'><td>test_clear_content_editable_resettable_element[element14]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-24' class='subtest'><td>test_clear_content_editable_resettable_element[element15]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-10' class='subtest'><td>test_clear_content_editable_resettable_element[element1]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-11' class='subtest'><td>test_clear_content_editable_resettable_element[element2]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-12' class='subtest'><td>test_clear_content_editable_resettable_element[element3]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-13' class='subtest'><td>test_clear_content_editable_resettable_element[element4]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-14' class='subtest'><td>test_clear_content_editable_resettable_element[element5]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-15' class='subtest'><td>test_clear_content_editable_resettable_element[element6]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-16' class='subtest'><td>test_clear_content_editable_resettable_element[element7]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-17' class='subtest'><td>test_clear_content_editable_resettable_element[element8]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-18' class='subtest'><td>test_clear_content_editable_resettable_element[element9]</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-1' class='subtest'><td>test_connected_element</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-59' class='subtest'><td>test_contenteditable</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-60' class='subtest'><td>test_contenteditable_focus</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-60' class='subtest'><td>test_designmode</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-4' class='subtest'><td>test_disabled_element_not_resettable</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-48-7' class='subtest'><td>test_element_disabled</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-48-2' class='subtest'><td>test_element_not_editable</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-1' class='subtest'><td>test_element_not_found</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-8' class='subtest'><td>test_element_pointer_events_disabled</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-6' class='subtest'><td>test_element_readonly</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-48-12' class='subtest'><td>test_input[color-#ff0000-#000000]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-13' class='subtest'><td>test_input[date-2017-12-26-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-14' class='subtest'><td>test_input[datetime-2017-12-26T19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-15' class='subtest'><td>test_input[datetime-local-2017-12-26T19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-6' class='subtest'><td>test_input[email-foo@example.com-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-17' class='subtest'><td>test_input[month-2017-11-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-4' class='subtest'><td>test_input[number-42-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-7' class='subtest'><td>test_input[password-password-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-5' class='subtest'><td>test_input[range-42-50]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-8' class='subtest'><td>test_input[search-search-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-9' class='subtest'><td>test_input[tel-999-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-10' class='subtest'><td>test_input[text-text-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-16' class='subtest'><td>test_input[time-19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-11' class='subtest'><td>test_input[url-https://example.com/-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-18' class='subtest'><td>test_input[week-2017-W52-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-0' class='subtest'><td>test_no_browsing_context</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='PASS'>PASS</td></tr>
-<tr id='subtest-48-2' class='subtest'><td>test_pointer_interactable</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-66' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[color-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-67' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[date-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-68' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[datetime-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-69' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[datetime-local-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-64' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[email-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-71' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[month-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-62' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[number-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-63' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[range-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-70' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[time-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-65' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[url-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-72' class='subtest'><td>test_resettable_element_does_not_satisfy_validation_constraints[week-foo]</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-62' class='subtest'><td>test_resettable_element_focus</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-61' class='subtest'><td>test_resettable_element_focus_when_empty</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-5' class='subtest'><td>test_scroll_into_element_view</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-48-79' class='subtest'><td>test_scroll_into_view</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
-<tr id='subtest-48-51' class='subtest'><td>test_textarea</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
-<tr class='test' id='test-file-51'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/new_session/merge.py' target='_blank'>/webdriver/tests/sessions/new_session/merge.py</a> <small>(1/9, 11.11%, 0.11% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-51-7' class='subtest'><td>test_merge_platformName</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-52'><td><a href='http://www.w3c-test.org/webdriver/tests/state/get_element_attribute.py' target='_blank'>/webdriver/tests/state/get_element_attribute.py</a> <small>(2/25, 8.00%, 0.45% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
-<tr id='subtest-52-28' class='subtest'><td>test_boolean_attribute[menuitem-attrs9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr id='subtest-52-30' class='subtest'><td>test_boolean_attribute[object-attrs10]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td></tr>
-<tr class='test' id='test-file-54'><td><a href='http://www.w3c-test.org/webdriver/tests/element_send_keys/form_controls.py' target='_blank'>/webdriver/tests/element_send_keys/form_controls.py</a> <small>(6/6, 100.00%, 0.67% of total)</small></td><td class='undefined'>-</td><td class='OK'>OK</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-4' class='subtest'><td>test_events[input]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-5' class='subtest'><td>test_events[textarea]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-0' class='subtest'><td>test_input</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-2' class='subtest'><td>test_input_append</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-1' class='subtest'><td>test_textarea</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
-<tr id='subtest-54-3' class='subtest'><td>test_textarea_append</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='undefined'>-</td><td class='undefined'>-</td></tr>
+        <thead><tr class='persist-header'><th>Test</th><th>eg42</th><th>ff60</th><th>ie11</th><th>wk18</th></tr></thead>
+<tr class='test' id='test-file-0'><td><a href='http://www.w3c-test.org/webdriver/tests/contexts/maximize_window.py' target='_blank'>/webdriver/tests/contexts/maximize_window.py</a> <small>(2/11, 18.18%, 0.23% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='test' id='test-file-1'><td><a href='http://www.w3c-test.org/webdriver/tests/minimize_window.py' target='_blank'>/webdriver/tests/minimize_window.py</a> <small>(2/10, 20.00%, 0.23% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='test' id='test-file-2'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/new_session/default_values.py' target='_blank'>/webdriver/tests/sessions/new_session/default_values.py</a> <small>(1/8, 12.50%, 0.12% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_valid_but_unmatchable_key</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='test' id='test-file-3'><td><a href='http://www.w3c-test.org/webdriver/tests/state/get_element_property.py' target='_blank'>/webdriver/tests/state/get_element_property.py</a> <small>(1/8, 12.50%, 0.12% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_element</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='test' id='test-file-4'><td><a href='http://www.w3c-test.org/webdriver/tests/fullscreen_window.py' target='_blank'>/webdriver/tests/fullscreen_window.py</a> <small>(4/9, 44.44%, 0.46% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_handle_prompt_missing_value</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_fullscreen_twice_is_idempotent</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='test' id='test-file-5'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/key.py' target='_blank'>/webdriver/tests/actions/key.py</a> <small>(5/20, 25.00%, 0.58% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_printable_key_sends_correct_events["-Quote]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_printable_key_sends_correct_events[@-Digit2]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_modifier_key_sends_correct_events[\ue053-OSRight-Meta]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_nonprintable_key_sends_events[\ue00c-Escape-Escape]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_single_nonprintable_key_sends_events[\ue014-ArrowRight-ArrowRight]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='test' id='test-file-6'><td><a href='http://www.w3c-test.org/webdriver/tests/contexts/json_serialize_windowproxy.py' target='_blank'>/webdriver/tests/contexts/json_serialize_windowproxy.py</a> <small>(3/3, 100.00%, 0.35% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_initial_window</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_window_open</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_frame</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='test' id='test-file-7'><td><a href='http://www.w3c-test.org/webdriver/tests/execute_async_script/user_prompts.py' target='_blank'>/webdriver/tests/execute_async_script/user_prompts.py</a> <small>(7/7, 100.00%, 0.81% of total)</small></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_ignore</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_default</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_twice</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-8'><td><a href='http://www.w3c-test.org/webdriver/tests/element_send_keys/scroll_into_view.py' target='_blank'>/webdriver/tests/element_send_keys/scroll_into_view.py</a> <small>(2/5, 40.00%, 0.23% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_element_outside_of_not_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_option_stays_outside_of_scrollable_viewport</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='test' id='test-file-9'><td><a href='http://www.w3c-test.org/webdriver/tests/cookies/add_cookie.py' target='_blank'>/webdriver/tests/cookies/add_cookie.py</a> <small>(4/5, 80.00%, 0.46% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_add_domain_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_add_cookie_for_ip</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_add_non_session_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='subtest'><td>test_add_session_cookie_with_leading_dot_character_in_domain</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-10'><td><a href='http://www.w3c-test.org/webdriver/tests/set_window_rect.py' target='_blank'>/webdriver/tests/set_window_rect.py</a> <small>(1/75, 1.33%, 0.12% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_fully_exit_fullscreen</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='test' id='test-file-11'><td><a href='http://www.w3c-test.org/webdriver/tests/element_send_keys/interactability.py' target='_blank'>/webdriver/tests/element_send_keys/interactability.py</a> <small>(1/10, 10.00%, 0.12% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_iframe_is_interactable</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='test' id='test-file-12'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/modifier_click.py' target='_blank'>/webdriver/tests/actions/modifier_click.py</a> <small>(2/7, 28.57%, 0.23% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_modifier_click[\ue03d-metaKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_modifier_click[\ue053-metaKey]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='test' id='test-file-13'><td><a href='http://www.w3c-test.org/webdriver/tests/execute_script/user_prompts.py' target='_blank'>/webdriver/tests/execute_script/user_prompts.py</a> <small>(7/7, 100.00%, 0.81% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_dismiss_and_notify</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_accept_and_notify</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_ignore</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_default</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='subtest'><td>test_handle_prompt_twice</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td></tr>
+<tr class='test' id='test-file-14'><td><a href='http://www.w3c-test.org/webdriver/tests/actions/special_keys.py' target='_blank'>/webdriver/tests/actions/special_keys.py</a> <small>(29/70, 41.43%, 3.36% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWRIGHT-expected4]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[ESCAPE-expected5]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_PAGEUP-expected7]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[UP-expected8]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[DOWN-expected9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[META-expected11]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[MULTIPLY-expected13]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[NULL-expected15]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[SUBTRACT-expected16]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_META-expected19]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[SPACE-expected21]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[RIGHT-expected23]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[DECIMAL-expected27]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[LEFT-expected28]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_DELETE-expected29]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[DIVIDE-expected33]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWUP-expected34]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWLEFT-expected37]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_PAGEDOWN-expected39]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[ADD-expected40]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_INSERT-expected42]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[ENTER-expected43]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[CANCEL-expected44]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_END-expected48]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_HOME-expected63]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[ZENKAKUHANKAKU-expected64]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[SEPARATOR-expected66]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[R_ARROWDOWN-expected68]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_webdriver_special_key_sends_keydown[DELETE-expected69]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='test' id='test-file-15'><td><a href='http://www.w3c-test.org/webdriver/tests/cookies/delete_cookie.py' target='_blank'>/webdriver/tests/cookies/delete_cookie.py</a> <small>(1/7, 14.29%, 0.12% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_unknown_cookie</td><td class='ERROR'>ERROR</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td></tr>
+<tr class='test' id='test-file-16'><td><a href='http://www.w3c-test.org/webdriver/tests/interaction/element_clear.py' target='_blank'>/webdriver/tests/interaction/element_clear.py</a> <small>(21/80, 26.25%, 2.44% of total)</small></td><td class='TIMEOUT'>TIMEOUT</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_connected_element</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[number-42-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[range-42-50]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[email-foo@example.com-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[password-password-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[search-search-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[tel-999-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[text-text-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[url-https://example.com/-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[color-#ff0000-#000000]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[date-2017-12-26-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[datetime-2017-12-26T19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[datetime-local-2017-12-26T19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[time-19:48-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[month-2017-11-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_input[week-2017-W52-]</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_textarea</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_button_with_subtree</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_contenteditable</td><td class='undefined'>-</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_designmode</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='subtest'><td>test_resettable_element_focus_when_empty</td><td class='undefined'>-</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='undefined'>-</td></tr>
+<tr class='test' id='test-file-17'><td><a href='http://www.w3c-test.org/webdriver/tests/sessions/new_session/merge.py' target='_blank'>/webdriver/tests/sessions/new_session/merge.py</a> <small>(1/9, 11.11%, 0.12% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_merge_platformName</td><td class='FAIL'>FAIL</td><td class='FAIL'>FAIL</td><td class='PASS'>PASS</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='test' id='test-file-18'><td><a href='http://www.w3c-test.org/webdriver/tests/state/get_element_attribute.py' target='_blank'>/webdriver/tests/state/get_element_attribute.py</a> <small>(2/27, 7.41%, 0.23% of total)</small></td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td><td class='OK'>OK</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[menuitem-attrs9]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
+<tr class='subtest'><td>test_boolean_attribute[object-attrs10]</td><td class='ERROR'>ERROR</td><td class='PASS'>PASS</td><td class='FAIL'>FAIL</td><td class='XFAIL'>XFAIL</td></tr>
 
       </table>
     </div>
     <script src='jquery.min.js'></script>
     <script src='sticky-headers.js'></script>
-    <script type='application/javascript'>
-
-    </script>
   </body>
 </html>

--- a/results/ie11.json
+++ b/results/ie11.json
@@ -1,1 +1,4685 @@
-{"results": [{"test": "/webdriver/tests/document_handling/page_source.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_source_matches_outer_html"}]}, {"test": "/webdriver/tests/state/is_element_selected.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_dismiss"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_missing_value"}, {"status": "PASS", "message": null, "name": "test_element_stale"}, {"status": "PASS", "message": null, "name": "test_element_checked"}, {"status": "PASS", "message": null, "name": "test_checkbox_not_selected"}, {"status": "PASS", "message": null, "name": "test_element_selected"}, {"status": "PASS", "message": null, "name": "test_element_not_selected"}]}, {"test": "/webdriver/tests/actions/mouse.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_click_at_coordinates"}, {"status": "PASS", "message": null, "name": "test_context_menu_at_coordinates"}, {"status": "PASS", "message": null, "name": "test_click_element_center"}, {"status": "PASS", "message": null, "name": "test_click_navigation"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[20-0-0]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[20-0-300]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[20-0-800]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[0-15-0]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[0-15-300]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[0-15-800]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[10-15-0]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[10-15-300]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[10-15-800]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[-20-0-0]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[-20-0-300]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[-20-0-800]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[10--15-0]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[10--15-300]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[10--15-800]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[-10--15-0]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[-10--15-300]"}, {"status": "PASS", "message": null, "name": "test_drag_and_drop[-10--15-800]"}]}, {"test": "/webdriver/tests/contexts/maximize_window.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_dismiss_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_accept_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_ignore"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_missing_value"}, {"status": "FAIL", "message": null, "name": "test_fully_exit_fullscreen"}, {"status": "PASS", "message": null, "name": "test_restore_the_window"}, {"status": "PASS", "message": null, "name": "test_maximize"}, {"status": "PASS", "message": null, "name": "test_payload"}, {"status": "PASS", "message": null, "name": "test_maximize_twice_is_idempotent"}]}, {"test": "/webdriver/tests/user_prompts/send_alert_text.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_invalid_input[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_input[text1]"}, {"status": "PASS", "message": null, "name": "test_invalid_input[text2]"}, {"status": "PASS", "message": null, "name": "test_invalid_input[42]"}, {"status": "PASS", "message": null, "name": "test_invalid_input[True]"}, {"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "PASS", "message": null, "name": "test_no_user_prompt"}, {"status": "PASS", "message": null, "name": "test_alert_element_not_interactable"}, {"status": "PASS", "message": null, "name": "test_confirm_element_not_interactable"}, {"status": "PASS", "message": null, "name": "test_send_alert_text"}, {"status": "PASS", "message": null, "name": "test_send_alert_text_with_whitespace"}]}, {"test": "/webdriver/tests/user_prompts/get_alert_text.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "PASS", "message": null, "name": "test_no_user_prompt"}, {"status": "PASS", "message": null, "name": "test_get_alert_text"}, {"status": "PASS", "message": null, "name": "test_get_confirm_text"}, {"status": "PASS", "message": null, "name": "test_get_prompt_text"}]}, {"test": "/webdriver/tests/sessions/status.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_get_status_no_session"}, {"status": "PASS", "message": null, "name": "test_status_with_session_running_on_endpoint_node"}]}, {"test": "/webdriver/tests/interaction/send_keys_content_editable.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_sets_insertion_point_to_end"}, {"status": "PASS", "message": null, "name": "test_sets_insertion_point_to_after_last_text_node"}]}, {"test": "/webdriver/tests/minimize_window.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_dismiss_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_accept_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_ignore"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_missing_value"}, {"status": "FAIL", "message": null, "name": "test_fully_exit_fullscreen"}, {"status": "PASS", "message": null, "name": "test_minimize"}, {"status": "PASS", "message": null, "name": "test_payload"}, {"status": "PASS", "message": null, "name": "test_minimize_twice_is_idempotent"}]}, {"test": "/webdriver/tests/element_retrieval/find_elements_from_element.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_invalid_using_argument[a]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[True]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[1]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[using4]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[using5]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[value1]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[value2]"}, {"status": "PASS", "message": null, "name": "test_closed_context"}, {"status": "PASS", "message": null, "name": "test_find_elements[css selector-#linkText]"}, {"status": "PASS", "message": null, "name": "test_find_elements[link text-full link text]"}, {"status": "PASS", "message": null, "name": "test_find_elements[partial link text-link text]"}, {"status": "PASS", "message": null, "name": "test_find_elements[tag name-a]"}, {"status": "PASS", "message": null, "name": "test_find_elements[xpath-//a]"}, {"status": "PASS", "message": null, "name": "test_no_element[css selector-#wontExist]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[css selector-#linkText]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[link text-full link text]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[partial link text-link text]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[tag name-a]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[xpath-//*[name()='a']]"}, {"status": "FAIL", "message": null, "name": "test_parent_htmldocument"}]}, {"test": "/webdriver/tests/get_window_rect.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_dismiss_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_accept_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_ignore"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_missing_value"}, {"status": "PASS", "message": null, "name": "test_payload"}]}, {"test": "/webdriver/tests/sessions/new_session/default_values.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_basic"}, {"status": "FAIL", "message": null, "name": "test_repeat_new_session"}, {"status": "PASS", "message": null, "name": "test_no_capabilites"}, {"status": "PASS", "message": null, "name": "test_missing_first_match"}, {"status": "PASS", "message": null, "name": "test_missing_always_match"}, {"status": "PASS", "message": null, "name": "test_desired"}, {"status": "PASS", "message": null, "name": "test_ignore_non_spec_fields_in_capabilities"}, {"status": "PASS", "message": null, "name": "test_valid_but_unmatchable_key"}]}, {"test": "/webdriver/tests/state/get_element_property.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_dismiss"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_missing_value"}, {"status": "PASS", "message": null, "name": "test_element_not_found"}, {"status": "PASS", "message": null, "name": "test_element_stale"}, {"status": "PASS", "message": null, "name": "test_element_non_existent"}, {"status": "FAIL", "message": null, "name": "test_element"}]}, {"test": "/webdriver/tests/user_prompts/dismiss_alert.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "PASS", "message": null, "name": "test_no_user_prompt"}, {"status": "PASS", "message": null, "name": "test_dismiss_alert"}, {"status": "PASS", "message": null, "name": "test_dismiss_confirm"}, {"status": "PASS", "message": null, "name": "test_dismiss_prompt"}]}, {"test": "/webdriver/tests/fullscreen_window.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_dismiss_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_accept_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_ignore"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_missing_value"}, {"status": "FAIL", "message": null, "name": "test_fullscreen"}, {"status": "PASS", "message": null, "name": "test_payload"}, {"status": "FAIL", "message": null, "name": "test_fullscreen_twice_is_idempotent"}]}, {"test": "/webdriver/tests/actions/key.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_lone_keyup_sends_no_events"}, {"status": "PASS", "message": null, "name": "test_single_printable_key_sends_correct_events[a-KeyA0]"}, {"status": "PASS", "message": null, "name": "test_single_printable_key_sends_correct_events[a-KeyA1]"}, {"status": "FAIL", "message": null, "name": "test_single_printable_key_sends_correct_events[\"-Quote]"}, {"status": "PASS", "message": null, "name": "test_single_printable_key_sends_correct_events[,-Comma]"}, {"status": "PASS", "message": null, "name": "test_single_printable_key_sends_correct_events[\\xe0-]"}, {"status": "PASS", "message": null, "name": "test_single_printable_key_sends_correct_events[\\u0416-]"}, {"status": "FAIL", "message": null, "name": "test_single_printable_key_sends_correct_events[@-Digit2]"}, {"status": "PASS", "message": null, "name": "test_single_printable_key_sends_correct_events[\\u2603-]"}, {"status": "PASS", "message": null, "name": "test_single_printable_key_sends_correct_events[\\uf6c2-]"}, {"status": "FAIL", "message": null, "name": "test_single_emoji_records_correct_key[\\U0001f604]"}, {"status": "FAIL", "message": null, "name": "test_single_emoji_records_correct_key[\\U0001f60d]"}, {"status": "PASS", "message": null, "name": "test_single_modifier_key_sends_correct_events[\\ue050-ShiftRight-Shift]"}, {"status": "FAIL", "message": null, "name": "test_single_modifier_key_sends_correct_events[\\ue053-OSRight-Meta]"}, {"status": "PASS", "message": null, "name": "test_single_modifier_key_sends_correct_events[\\ue009-ControlLeft-Control]"}, {"status": "FAIL", "message": null, "name": "test_single_nonprintable_key_sends_events[\\ue00c-Escape-Escape]"}, {"status": "FAIL", "message": null, "name": "test_single_nonprintable_key_sends_events[\\ue014-ArrowRight-ArrowRight]"}, {"status": "PASS", "message": null, "name": "test_sequence_of_keydown_printable_keys_sends_events"}, {"status": "PASS", "message": null, "name": "test_sequence_of_keydown_character_keys"}, {"status": "PASS", "message": null, "name": "test_backspace_erases_keys"}]}, {"test": "/webdriver/tests/state/text/get_text.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_getting_text_of_a_non_existant_element_is_an_error"}, {"status": "PASS", "message": null, "name": "test_read_element_text"}]}, {"test": "/webdriver/tests/actions/key_shortcuts.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_mod_a_and_backspace_deletes_all_text"}, {"status": "FAIL", "message": null, "name": "test_mod_a_mod_c_right_mod_v_pastes_text"}, {"status": "PASS", "message": null, "name": "test_mod_a_mod_x_deletes_all_text"}]}, {"test": "/webdriver/tests/sessions/new_session/create_firstMatch.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_valid[acceptInsecureCerts-False]"}, {"status": "PASS", "message": null, "name": "test_valid[acceptInsecureCerts-None]"}, {"status": "PASS", "message": null, "name": "test_valid[browserName-None]"}, {"status": "PASS", "message": null, "name": "test_valid[browserVersion-None]"}, {"status": "PASS", "message": null, "name": "test_valid[platformName-None]"}, {"status": "PASS", "message": null, "name": "test_valid[pageLoadStrategy-none]"}, {"status": "PASS", "message": null, "name": "test_valid[pageLoadStrategy-eager]"}, {"status": "PASS", "message": null, "name": "test_valid[pageLoadStrategy-normal]"}, {"status": "PASS", "message": null, "name": "test_valid[pageLoadStrategy-None]"}, {"status": "PASS", "message": null, "name": "test_valid[proxy-None]"}, {"status": "PASS", "message": null, "name": "test_valid[timeouts-value10]"}, {"status": "PASS", "message": null, "name": "test_valid[timeouts-value11]"}, {"status": "PASS", "message": null, "name": "test_valid[timeouts-value12]"}, {"status": "FAIL", "message": null, "name": "test_valid[timeouts-value13]"}, {"status": "PASS", "message": null, "name": "test_valid[unhandledPromptBehavior-dismiss]"}, {"status": "PASS", "message": null, "name": "test_valid[unhandledPromptBehavior-accept]"}, {"status": "PASS", "message": null, "name": "test_valid[unhandledPromptBehavior-None]"}, {"status": "FAIL", "message": null, "name": "test_valid[test:extension-True]"}, {"status": "FAIL", "message": null, "name": "test_valid[test:extension-abc]"}, {"status": "FAIL", "message": null, "name": "test_valid[test:extension-123]"}, {"status": "FAIL", "message": null, "name": "test_valid[test:extension-value20]"}, {"status": "FAIL", "message": null, "name": "test_valid[test:extension-value21]"}, {"status": "PASS", "message": null, "name": "test_valid[test:extension-None]"}]}, {"test": "/webdriver/tests/contexts/json_serialize_windowproxy.py", "status": "OK", "message": null, "subtests": [{"status": "FAIL", "message": null, "name": "test_initial_window"}, {"status": "FAIL", "message": null, "name": "test_window_open"}, {"status": "FAIL", "message": null, "name": "test_frame"}]}, {"test": "/webdriver/tests/execute_async_script/user_prompts.py", "status": "OK", "message": null, "subtests": [{"status": "FAIL", "message": null, "name": "test_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_dismiss"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_dismiss_and_notify"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept_and_notify"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_ignore"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_default"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_twice"}]}, {"test": "/webdriver/tests/execute_script/cyclic.py", "status": "OK", "message": null, "subtests": [{"status": "FAIL", "message": null, "name": "test_array"}, {"status": "ERROR", "message": "teardown error", "name": "test_array"}, {"status": "FAIL", "message": null, "name": "test_object"}, {"status": "ERROR", "message": "teardown error", "name": "test_object"}, {"status": "FAIL", "message": null, "name": "test_array_in_object"}, {"status": "ERROR", "message": "teardown error", "name": "test_array_in_object"}, {"status": "FAIL", "message": null, "name": "test_object_in_array"}, {"status": "ERROR", "message": "teardown error", "name": "test_object_in_array"}]}, {"test": "/webdriver/tests/user_prompts/accept_alert.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "PASS", "message": null, "name": "test_no_user_prompt"}, {"status": "PASS", "message": null, "name": "test_accept_alert"}, {"status": "PASS", "message": null, "name": "test_accept_confirm"}, {"status": "PASS", "message": null, "name": "test_accept_prompt"}]}, {"test": "/webdriver/tests/switch_to_parent_frame.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_stale_element_from_iframe"}]}, {"test": "/webdriver/tests/state/get_element_tag_name.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_dismiss"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_missing_value"}, {"status": "PASS", "message": null, "name": "test_element_not_found"}, {"status": "PASS", "message": null, "name": "test_element_stale"}, {"status": "PASS", "message": null, "name": "test_get_element_tag_name"}]}, {"test": "/webdriver/tests/element_send_keys/scroll_into_view.py", "status": "OK", "message": null, "subtests": [{"status": "FAIL", "message": null, "name": "test_element_outside_of_not_scrollable_viewport"}, {"status": "PASS", "message": null, "name": "test_element_outside_of_scrollable_viewport"}, {"status": "FAIL", "message": null, "name": "test_option_select_container_outside_of_scrollable_viewport"}, {"status": "FAIL", "message": null, "name": "test_option_stays_outside_of_scrollable_viewport"}, {"status": "PASS", "message": null, "name": "test_contenteditable_element_outside_of_scrollable_viewport"}]}, {"test": "/webdriver/tests/actions/sequence.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_actions_send_no_events"}, {"status": "PASS", "message": null, "name": "test_release_char_sequence_sends_keyup_events_in_reverse"}, {"status": "PASS", "message": null, "name": "test_release_no_actions_sends_no_events"}]}, {"test": "/webdriver/tests/cookies/add_cookie.py", "status": "OK", "message": null, "subtests": [{"status": "FAIL", "message": null, "name": "test_add_domain_cookie"}, {"status": "FAIL", "message": null, "name": "test_add_cookie_for_ip"}, {"status": "FAIL", "message": null, "name": "test_add_non_session_cookie"}, {"status": "FAIL", "message": null, "name": "test_add_session_cookie"}, {"status": "FAIL", "message": null, "name": "test_add_session_cookie_with_leading_dot_character_in_domain"}]}, {"test": "/webdriver/tests/set_window_rect.py", "status": "OK", "message": null, "subtests": [{"status": "ERROR", "message": "setup error", "name": "test_current_top_level_browsing_context_no_longer_open"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_dismiss"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_accept"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_dismiss_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_accept_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_ignore"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_missing_value"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect0]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect1]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect2]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect3]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect4]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect5]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect6]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect7]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect8]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect9]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect10]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect11]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect12]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect13]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect14]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect15]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect16]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect17]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect18]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect19]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect20]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect21]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect22]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect23]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect24]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect25]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect26]"}, {"status": "PASS", "message": null, "name": "test_invalid_types[rect27]"}, {"status": "PASS", "message": null, "name": "test_out_of_bounds[rect0]"}, {"status": "PASS", "message": null, "name": "test_out_of_bounds[rect1]"}, {"status": "PASS", "message": null, "name": "test_out_of_bounds[rect2]"}, {"status": "PASS", "message": null, "name": "test_width_height_floats"}, {"status": "PASS", "message": null, "name": "test_x_y_floats"}, {"status": "PASS", "message": null, "name": "test_no_change[rect0]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect1]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect2]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect3]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect4]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect5]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect6]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect7]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect8]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect9]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect10]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect11]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect12]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect13]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect14]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect15]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect16]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect17]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect18]"}, {"status": "PASS", "message": null, "name": "test_no_change[rect19]"}, {"status": "FAIL", "message": null, "name": "test_fully_exit_fullscreen"}, {"status": "PASS", "message": null, "name": "test_restore_from_minimized"}, {"status": "PASS", "message": null, "name": "test_restore_from_maximized"}, {"status": "PASS", "message": null, "name": "test_height_width"}, {"status": "PASS", "message": null, "name": "test_height_width_larger_than_max"}, {"status": "PASS", "message": null, "name": "test_height_width_as_current"}, {"status": "PASS", "message": null, "name": "test_x_y"}, {"status": "PASS", "message": null, "name": "test_negative_x_y"}, {"status": "PASS", "message": null, "name": "test_move_to_same_position"}, {"status": "PASS", "message": null, "name": "test_move_to_same_x"}, {"status": "PASS", "message": null, "name": "test_move_to_same_y"}, {"status": "PASS", "message": null, "name": "test_resize_to_same_size"}, {"status": "PASS", "message": null, "name": "test_resize_to_same_width"}, {"status": "PASS", "message": null, "name": "test_resize_to_same_height"}, {"status": "PASS", "message": null, "name": "test_payload"}]}, {"test": "/webdriver/tests/element_send_keys/interactability.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_body_is_interactable"}, {"status": "PASS", "message": null, "name": "test_document_element_is_interactable"}, {"status": "FAIL", "message": null, "name": "test_iframe_is_interactable"}, {"status": "PASS", "message": null, "name": "test_transparent_element"}, {"status": "PASS", "message": null, "name": "test_readonly_element"}, {"status": "PASS", "message": null, "name": "test_obscured_element"}, {"status": "FAIL", "message": null, "name": "test_not_a_focusable_element"}, {"status": "PASS", "message": null, "name": "test_not_displayed_element"}, {"status": "PASS", "message": null, "name": "test_hidden_element"}, {"status": "FAIL", "message": null, "name": "test_disabled_element"}]}, {"test": "/webdriver/tests/contexts/resizing_and_positioning.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_window_resize"}]}, {"test": "/webdriver/tests/element_click/select.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_click_option"}, {"status": "PASS", "message": null, "name": "test_click_multiple_option"}, {"status": "PASS", "message": null, "name": "test_click_preselected_option"}, {"status": "PASS", "message": null, "name": "test_click_preselected_multiple_option"}, {"status": "PASS", "message": null, "name": "test_click_deselects_others"}, {"status": "PASS", "message": null, "name": "test_click_multiple_does_not_deselect_others"}, {"status": "PASS", "message": null, "name": "test_click_selected_option"}, {"status": "PASS", "message": null, "name": "test_click_selected_multiple_option"}, {"status": "PASS", "message": null, "name": "test_out_of_view_dropdown"}, {"status": "PASS", "message": null, "name": "test_out_of_view_multiple"}, {"status": "FAIL", "message": null, "name": "test_option_disabled"}]}, {"test": "/webdriver/tests/element_retrieval/find_element.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_invalid_using_argument[a]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[True]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[1]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[using4]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[using5]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[value1]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[value2]"}, {"status": "PASS", "message": null, "name": "test_closed_context"}, {"status": "PASS", "message": null, "name": "test_find_element[css selector-#linkText]"}, {"status": "PASS", "message": null, "name": "test_find_element[link text-full link text]"}, {"status": "PASS", "message": null, "name": "test_find_element[partial link text-link text]"}, {"status": "PASS", "message": null, "name": "test_find_element[tag name-a]"}, {"status": "PASS", "message": null, "name": "test_find_element[xpath-//a]"}, {"status": "PASS", "message": null, "name": "test_no_element[css selector-#wontExist]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[css selector-#linkText]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[link text-full link text]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[partial link text-link text]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[tag name-a]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[xpath-//*[name()='a']]"}, {"status": "PASS", "message": null, "name": "test_htmldocument[css selector-:root]"}, {"status": "PASS", "message": null, "name": "test_htmldocument[tag name-html]"}, {"status": "PASS", "message": null, "name": "test_htmldocument[xpath-/html]"}]}, {"test": "/webdriver/tests/sessions/get_timeouts.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_get_timeouts"}, {"status": "PASS", "message": null, "name": "test_get_default_timeouts"}, {"status": "PASS", "message": null, "name": "test_get_new_timeouts"}]}, {"test": "/webdriver/tests/actions/modifier_click.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_modifier_click[\\ue00a-altKey]"}, {"status": "PASS", "message": null, "name": "test_modifier_click[\\ue052-altKey]"}, {"status": "FAIL", "message": null, "name": "test_modifier_click[\\ue03d-metaKey]"}, {"status": "FAIL", "message": null, "name": "test_modifier_click[\\ue053-metaKey]"}, {"status": "PASS", "message": null, "name": "test_modifier_click[\\ue008-shiftKey]"}, {"status": "PASS", "message": null, "name": "test_modifier_click[\\ue050-shiftKey]"}, {"status": "PASS", "message": null, "name": "test_many_modifiers_click"}]}, {"test": "/webdriver/tests/element_retrieval/find_elements.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_invalid_using_argument[a]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[True]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[1]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[using4]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[using5]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[value1]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[value2]"}, {"status": "PASS", "message": null, "name": "test_closed_context"}, {"status": "PASS", "message": null, "name": "test_find_elements[css selector-#linkText]"}, {"status": "PASS", "message": null, "name": "test_find_elements[link text-full link text]"}, {"status": "PASS", "message": null, "name": "test_find_elements[partial link text-link text]"}, {"status": "PASS", "message": null, "name": "test_find_elements[tag name-a]"}, {"status": "PASS", "message": null, "name": "test_find_elements[xpath-//a]"}, {"status": "PASS", "message": null, "name": "test_no_element[css selector-#wontExist]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[css selector-#linkText]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[link text-full link text]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[partial link text-link text]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[tag name-a]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[xpath-//*[name()='a']]"}, {"status": "PASS", "message": null, "name": "test_htmldocument[css selector-:root]"}, {"status": "PASS", "message": null, "name": "test_htmldocument[tag name-html]"}, {"status": "PASS", "message": null, "name": "test_htmldocument[xpath-/html]"}]}, {"test": "/webdriver/tests/actions/mouse_dblclick.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_dblclick_at_coordinates[0]"}, {"status": "PASS", "message": null, "name": "test_dblclick_at_coordinates[200]"}, {"status": "PASS", "message": null, "name": "test_dblclick_with_pause_after_second_pointerdown"}, {"status": "PASS", "message": null, "name": "test_no_dblclick"}]}, {"test": "/webdriver/tests/element_click/bubbling.py", "status": "OK", "message": null, "subtests": [{"status": "FAIL", "message": null, "name": "test_click_event_bubbles_to_parents"}, {"status": "FAIL", "message": null, "name": "test_spin_event_loop"}, {"status": "PASS", "message": null, "name": "test_element_disappears_during_click"}]}, {"test": "/webdriver/tests/navigation/get_title.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_title_from_closed_context"}, {"status": "FAIL", "message": null, "name": "test_title_handle_prompt_dismiss"}, {"status": "FAIL", "message": null, "name": "test_title_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_title_handle_prompt_missing_value"}, {"status": "PASS", "message": null, "name": "test_title_from_top_context"}, {"status": "PASS", "message": null, "name": "test_title_with_duplicate_element"}, {"status": "PASS", "message": null, "name": "test_title_without_element"}, {"status": "PASS", "message": null, "name": "test_title_after_modification"}, {"status": "PASS", "message": null, "name": "test_title_strip_and_collapse"}, {"status": "PASS", "message": null, "name": "test_title_from_frame"}]}, {"test": "/webdriver/tests/sessions/new_session/response.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_resp_sessionid"}, {"status": "PASS", "message": null, "name": "test_resp_capabilites"}, {"status": "PASS", "message": null, "name": "test_resp_data"}, {"status": "PASS", "message": null, "name": "test_timeouts"}, {"status": "PASS", "message": null, "name": "test_pageLoadStrategy"}]}, {"test": "/webdriver/tests/element_retrieval/find_element_from_element.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_invalid_using_argument[a]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[True]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[1]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[using4]"}, {"status": "PASS", "message": null, "name": "test_invalid_using_argument[using5]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[value1]"}, {"status": "PASS", "message": null, "name": "test_invalid_selector_argument[value2]"}, {"status": "PASS", "message": null, "name": "test_closed_context"}, {"status": "PASS", "message": null, "name": "test_find_element[css selector-#linkText]"}, {"status": "PASS", "message": null, "name": "test_find_element[link text-full link text]"}, {"status": "PASS", "message": null, "name": "test_find_element[partial link text-link text]"}, {"status": "PASS", "message": null, "name": "test_find_element[tag name-a]"}, {"status": "PASS", "message": null, "name": "test_find_element[xpath-//a]"}, {"status": "PASS", "message": null, "name": "test_no_element[css selector-#wontExist]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[css selector-#linkText]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[link text-full link text]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[partial link text-link text]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[tag name-a]"}, {"status": "PASS", "message": null, "name": "test_xhtml_namespace[xpath-//*[name()='a']]"}, {"status": "FAIL", "message": null, "name": "test_parent_htmldocument"}]}, {"test": "/webdriver/tests/sessions/new_session/invalid_capabilities.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_invalid_capabilites[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_capabilites[1]"}, {"status": "PASS", "message": null, "name": "test_invalid_capabilites[{}]"}, {"status": "PASS", "message": null, "name": "test_invalid_capabilites[value3]"}, {"status": "PASS", "message": null, "name": "test_invalid_always_match[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_always_match[1]"}, {"status": "PASS", "message": null, "name": "test_invalid_always_match[{}]"}, {"status": "PASS", "message": null, "name": "test_invalid_always_match[value3]"}, {"status": "PASS", "message": null, "name": "test_invalid_first_match[None]"}, {"status": "PASS", "message": null, "name": "test_invalid_first_match[1]"}, {"status": "PASS", "message": null, "name": "test_invalid_first_match[[]]"}, {"status": "PASS", "message": null, "name": "test_invalid_first_match[value3]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[acceptInsecureCerts-1-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[acceptInsecureCerts-1-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[acceptInsecureCerts-value1-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[acceptInsecureCerts-value1-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[acceptInsecureCerts-value2-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[acceptInsecureCerts-value2-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[acceptInsecureCerts-false-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[acceptInsecureCerts-false-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserName-1-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserName-1-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserName-value5-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserName-value5-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserName-value6-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserName-value6-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserName-False-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserName-False-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserVersion-1-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserVersion-1-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserVersion-value9-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserVersion-value9-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserVersion-value10-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserVersion-value10-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserVersion-False-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[browserVersion-False-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[platformName-1-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[platformName-1-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[platformName-value13-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[platformName-value13-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[platformName-value14-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[platformName-value14-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[platformName-False-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[platformName-False-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-1-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-1-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-value17-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-value17-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-value18-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-value18-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-False-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-False-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-invalid-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-invalid-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-NONE-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-NONE-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-Eager-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-Eager-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-eagerblah-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-eagerblah-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-interactive-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-interactive-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy- eager-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy- eager-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-eager -body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[pageLoadStrategy-eager -body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-1-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-1-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value28-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value28-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-{}-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-{}-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value30-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value30-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value31-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value31-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value32-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value32-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value33-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value33-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value34-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value34-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value35-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value35-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value36-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value36-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value37-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value37-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value38-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value38-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value39-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value39-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value40-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value40-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value41-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value41-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value42-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value42-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value43-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value43-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value44-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[proxy-value44-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-1-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-1-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value46-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value46-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-{}-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-{}-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-False-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-False-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value49-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value49-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value50-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value50-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value51-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value51-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value52-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value52-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value53-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value53-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value54-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value54-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value55-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value55-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value56-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value56-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value57-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value57-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value58-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value58-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value59-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value59-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value60-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value60-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value61-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[timeouts-value61-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-1-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-1-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-value63-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-value63-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-value64-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-value64-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-False-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-False-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-DISMISS-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-DISMISS-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-dismissABC-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-dismissABC-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-Accept-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-Accept-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior- dismiss-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior- dismiss-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-dismiss -body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_values[unhandledPromptBehavior-dismiss -body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[firefox-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[firefox-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[firefox_binary-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[firefox_binary-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[firefoxOptions-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[firefoxOptions-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[chromeOptions-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[chromeOptions-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[automaticInspection-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[automaticInspection-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[automaticProfiling-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[automaticProfiling-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[platform-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[platform-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[version-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[version-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[browser-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[browser-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[platformVersion-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[platformVersion-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[javascriptEnabled-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[javascriptEnabled-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[nativeEvents-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[nativeEvents-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[seleniumProtocol-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[seleniumProtocol-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[profile-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[profile-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[trustAllSSLCertificates-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[trustAllSSLCertificates-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[initialBrowserUrl-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[initialBrowserUrl-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[requireWindowFocus-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[requireWindowFocus-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[logFile-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[logFile-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[logLevel-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[logLevel-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[safari.options-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[safari.options-body1]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[ensureCleanSession-body0]"}, {"status": "PASS", "message": null, "name": "test_invalid_extensions[ensureCleanSession-body1]"}]}, {"test": "/webdriver/tests/execute_script/user_prompts.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_handle_prompt_accept"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_dismiss"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_dismiss_and_notify"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept_and_notify"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_ignore"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_default"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_twice"}]}, {"test": "/webdriver/tests/interface.html", "status": "ERROR", "message": "Message: Page reload detected during async script\n", "subtests": []}, {"test": "/webdriver/tests/cookies/get_named_cookie.py", "status": "OK", "message": null, "subtests": [{"status": "FAIL", "message": null, "name": "test_get_named_session_cookie"}, {"status": "FAIL", "message": null, "name": "test_get_named_cookie"}, {"status": "FAIL", "message": null, "name": "test_duplicated_cookie"}]}, {"test": "/webdriver/tests/actions/special_keys.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[NUMPAD9-expected0]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[RETURN-expected1]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[HELP-expected2]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[SHIFT-expected3]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_ARROWRIGHT-expected4]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[ESCAPE-expected5]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[PAGE_UP-expected6]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_PAGEUP-expected7]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[UP-expected8]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[DOWN-expected9]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F12-expected10]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[META-expected11]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[BACKSPACE-expected12]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[MULTIPLY-expected13]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[HOME-expected14]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[NULL-expected15]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[SUBTRACT-expected16]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[CONTROL-expected17]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[INSERT-expected18]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_META-expected19]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[SEMICOLON-expected20]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[SPACE-expected21]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[NUMPAD4-expected22]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[RIGHT-expected23]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[TAB-expected24]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_ALT-expected25]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[NUMPAD0-expected26]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[DECIMAL-expected27]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[LEFT-expected28]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_DELETE-expected29]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[PAGE_DOWN-expected30]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[PAUSE-expected31]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[END-expected32]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[DIVIDE-expected33]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_ARROWUP-expected34]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[NUMPAD3-expected35]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[CLEAR-expected36]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_ARROWLEFT-expected37]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[EQUALS-expected38]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_PAGEDOWN-expected39]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[ADD-expected40]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[NUMPAD1-expected41]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_INSERT-expected42]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[ENTER-expected43]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[CANCEL-expected44]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[NUMPAD6-expected45]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F10-expected46]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F11-expected47]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_END-expected48]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[NUMPAD7-expected49]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[NUMPAD2-expected50]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F1-expected51]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F2-expected52]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F3-expected53]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F4-expected54]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F5-expected55]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F6-expected56]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F7-expected57]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F8-expected58]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[F9-expected59]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[NUMPAD8-expected60]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[NUMPAD5-expected61]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_CONTROL-expected62]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_HOME-expected63]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[ZENKAKUHANKAKU-expected64]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_SHIFT-expected65]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[SEPARATOR-expected66]"}, {"status": "PASS", "message": null, "name": "test_webdriver_special_key_sends_keydown[ALT-expected67]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[R_ARROWDOWN-expected68]"}, {"status": "FAIL", "message": null, "name": "test_webdriver_special_key_sends_keydown[DELETE-expected69]"}]}, {"test": "/webdriver/tests/cookies/delete_cookie.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_dismiss_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_accept_and_notify"}, {"status": "PASS", "message": null, "name": "test_handle_prompt_ignore"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_missing_value"}, {"status": "FAIL", "message": null, "name": "test_unknown_cookie"}]}, {"test": "/webdriver/tests/element_click/stale.py", "status": "OK", "message": null, "subtests": [{"status": "FAIL", "message": null, "name": "test_is_stale"}]}, {"test": "/webdriver/tests/interaction/element_clear.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_closed_context"}, {"status": "FAIL", "message": null, "name": "test_connected_element"}, {"status": "FAIL", "message": null, "name": "test_pointer_interactable"}, {"status": "PASS", "message": null, "name": "test_keyboard_interactable"}, {"status": "PASS", "message": null, "name": "test_input[number-42-]"}, {"status": "FAIL", "message": null, "name": "test_input[range-42-50]"}, {"status": "PASS", "message": null, "name": "test_input[email-foo@example.com-]"}, {"status": "PASS", "message": null, "name": "test_input[password-password-]"}, {"status": "PASS", "message": null, "name": "test_input[search-search-]"}, {"status": "PASS", "message": null, "name": "test_input[tel-999-]"}, {"status": "PASS", "message": null, "name": "test_input[text-text-]"}, {"status": "PASS", "message": null, "name": "test_input[url-https://example.com/-]"}, {"status": "FAIL", "message": null, "name": "test_input[color-#ff0000-#000000]"}, {"status": "PASS", "message": null, "name": "test_input[date-2017-12-26-]"}, {"status": "PASS", "message": null, "name": "test_input[datetime-2017-12-26T19:48-]"}, {"status": "PASS", "message": null, "name": "test_input[datetime-local-2017-12-26T19:48-]"}, {"status": "PASS", "message": null, "name": "test_input[time-19:48-]"}, {"status": "PASS", "message": null, "name": "test_input[month-2017-11-]"}, {"status": "PASS", "message": null, "name": "test_input[week-2017-W52-]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[number]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[range]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[email]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[password]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[search]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[tel]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[text]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[url]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[color]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[date]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[datetime]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[datetime-local]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[time]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[month]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[week]"}, {"status": "PASS", "message": null, "name": "test_input_disabled[file]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[number]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[range]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[email]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[password]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[search]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[tel]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[text]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[url]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[color]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[date]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[datetime]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[datetime-local]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[time]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[month]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[week]"}, {"status": "PASS", "message": null, "name": "test_input_readonly[file]"}, {"status": "PASS", "message": null, "name": "test_textarea"}, {"status": "PASS", "message": null, "name": "test_textarea_disabled"}, {"status": "PASS", "message": null, "name": "test_textarea_readonly"}, {"status": "PASS", "message": null, "name": "test_input_file"}, {"status": "PASS", "message": null, "name": "test_input_file_multiple"}, {"status": "PASS", "message": null, "name": "test_select"}, {"status": "PASS", "message": null, "name": "test_button"}, {"status": "FAIL", "message": null, "name": "test_button_with_subtree"}, {"status": "FAIL", "message": null, "name": "test_contenteditable"}, {"status": "FAIL", "message": null, "name": "test_contenteditable_focus"}, {"status": "FAIL", "message": null, "name": "test_designmode"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_focus"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_focus_when_empty"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_does_not_satisfy_validation_constraints[number-foo]"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_does_not_satisfy_validation_constraints[range-foo]"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_does_not_satisfy_validation_constraints[email-foo]"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_does_not_satisfy_validation_constraints[url-foo]"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_does_not_satisfy_validation_constraints[color-foo]"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_does_not_satisfy_validation_constraints[date-foo]"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_does_not_satisfy_validation_constraints[datetime-foo]"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_does_not_satisfy_validation_constraints[datetime-local-foo]"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_does_not_satisfy_validation_constraints[time-foo]"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_does_not_satisfy_validation_constraints[month-foo]"}, {"status": "FAIL", "message": null, "name": "test_resettable_element_does_not_satisfy_validation_constraints[week-foo]"}, {"status": "PASS", "message": null, "name": "test_non_editable_inputs[checkbox]"}, {"status": "PASS", "message": null, "name": "test_non_editable_inputs[radio]"}, {"status": "PASS", "message": null, "name": "test_non_editable_inputs[hidden]"}, {"status": "PASS", "message": null, "name": "test_non_editable_inputs[submit]"}, {"status": "PASS", "message": null, "name": "test_non_editable_inputs[button]"}, {"status": "PASS", "message": null, "name": "test_non_editable_inputs[image]"}, {"status": "FAIL", "message": null, "name": "test_scroll_into_view"}]}, {"test": "/webdriver/tests/sessions/new_session/create_alwaysMatch.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_valid[acceptInsecureCerts-False]"}, {"status": "PASS", "message": null, "name": "test_valid[acceptInsecureCerts-None]"}, {"status": "PASS", "message": null, "name": "test_valid[browserName-None]"}, {"status": "PASS", "message": null, "name": "test_valid[browserVersion-None]"}, {"status": "PASS", "message": null, "name": "test_valid[platformName-None]"}, {"status": "PASS", "message": null, "name": "test_valid[pageLoadStrategy-none]"}, {"status": "PASS", "message": null, "name": "test_valid[pageLoadStrategy-eager]"}, {"status": "PASS", "message": null, "name": "test_valid[pageLoadStrategy-normal]"}, {"status": "PASS", "message": null, "name": "test_valid[pageLoadStrategy-None]"}, {"status": "PASS", "message": null, "name": "test_valid[proxy-None]"}, {"status": "PASS", "message": null, "name": "test_valid[timeouts-value10]"}, {"status": "PASS", "message": null, "name": "test_valid[timeouts-value11]"}, {"status": "PASS", "message": null, "name": "test_valid[timeouts-value12]"}, {"status": "FAIL", "message": null, "name": "test_valid[timeouts-value13]"}, {"status": "PASS", "message": null, "name": "test_valid[unhandledPromptBehavior-dismiss]"}, {"status": "PASS", "message": null, "name": "test_valid[unhandledPromptBehavior-accept]"}, {"status": "PASS", "message": null, "name": "test_valid[unhandledPromptBehavior-None]"}, {"status": "FAIL", "message": null, "name": "test_valid[test:extension-True]"}, {"status": "FAIL", "message": null, "name": "test_valid[test:extension-abc]"}, {"status": "FAIL", "message": null, "name": "test_valid[test:extension-123]"}, {"status": "FAIL", "message": null, "name": "test_valid[test:extension-value20]"}, {"status": "FAIL", "message": null, "name": "test_valid[test:extension-value21]"}, {"status": "PASS", "message": null, "name": "test_valid[test:extension-None]"}]}, {"test": "/webdriver/tests/element_retrieval/get_active_element.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_closed_context"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_dismiss"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_missing_value"}, {"status": "PASS", "message": null, "name": "test_success_document"}, {"status": "PASS", "message": null, "name": "test_sucess_input"}, {"status": "PASS", "message": null, "name": "test_sucess_input_non_interactable"}, {"status": "PASS", "message": null, "name": "test_success_explicit_focus"}, {"status": "PASS", "message": null, "name": "test_success_iframe_content"}, {"status": "FAIL", "message": null, "name": "test_missing_document_element"}]}, {"test": "/webdriver/tests/sessions/new_session/merge.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_platform_name[body0]"}, {"status": "PASS", "message": null, "name": "test_platform_name[body1]"}, {"status": "PASS", "message": null, "name": "test_merge_invalid[acceptInsecureCerts-value0]"}, {"status": "PASS", "message": null, "name": "test_merge_invalid[unhandledPromptBehavior-value1]"}, {"status": "PASS", "message": null, "name": "test_merge_invalid[unhandledPromptBehavior-value2]"}, {"status": "PASS", "message": null, "name": "test_merge_invalid[timeouts-value3]"}, {"status": "PASS", "message": null, "name": "test_merge_invalid[timeouts-value4]"}, {"status": "PASS", "message": null, "name": "test_merge_platformName"}, {"status": "PASS", "message": null, "name": "test_merge_browserName"}]}, {"test": "/webdriver/tests/state/get_element_attribute.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_no_browsing_context"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_dismiss"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_accept"}, {"status": "FAIL", "message": null, "name": "test_handle_prompt_missing_value"}, {"status": "PASS", "message": null, "name": "test_element_not_found"}, {"status": "PASS", "message": null, "name": "test_element_stale"}, {"status": "PASS", "message": null, "name": "test_normal"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[audio-attrs0]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[button-attrs1]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[details-attrs2]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[dialog-attrs3]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[fieldset-attrs4]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[form-attrs5]"}, {"status": "FAIL", "message": null, "name": "test_boolean_attribute[iframe-attrs6]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[img-attrs7]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[input-attrs8]"}, {"status": "FAIL", "message": null, "name": "test_boolean_attribute[menuitem-attrs9]"}, {"status": "FAIL", "message": null, "name": "test_boolean_attribute[object-attrs10]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[ol-attrs11]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[optgroup-attrs12]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[option-attrs13]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[script-attrs14]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[select-attrs15]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[textarea-attrs16]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[track-attrs17]"}, {"status": "PASS", "message": null, "name": "test_boolean_attribute[video-attrs18]"}, {"status": "PASS", "message": null, "name": "test_global_boolean_attributes"}]}, {"test": "/webdriver/tests/navigation/current_url.py", "status": "OK", "message": null, "subtests": [{"status": "PASS", "message": null, "name": "test_get_current_url_no_browsing_context"}, {"status": "PASS", "message": null, "name": "test_get_current_url_alert_prompt"}, {"status": "PASS", "message": null, "name": "test_get_current_url_matches_location"}, {"status": "PASS", "message": null, "name": "test_get_current_url_payload"}, {"status": "PASS", "message": null, "name": "test_get_current_url_special_pages"}, {"status": "FAIL", "message": null, "name": "test_get_current_url_file_protocol"}, {"status": "PASS", "message": null, "name": "test_set_malformed_url"}, {"status": "PASS", "message": null, "name": "test_get_current_url_after_modified_location"}, {"status": "PASS", "message": null, "name": "test_get_current_url_nested_browsing_context"}, {"status": "PASS", "message": null, "name": "test_get_current_url_nested_browsing_contexts"}]}]}
+{
+  "results": [
+    {
+      "test": "/webdriver/tests/document_handling/page_source.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_source_matches_outer_html"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/state/is_element_selected.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_missing_value"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_stale"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_checked"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_checkbox_not_selected"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_selected"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_not_selected"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/actions/mouse.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_at_coordinates"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_context_menu_at_coordinates"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_element_center"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_navigation"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[20-0-0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[20-0-300]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[20-0-800]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[0-15-0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[0-15-300]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[0-15-800]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[10-15-0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[10-15-300]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[10-15-800]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[-20-0-0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[-20-0-300]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[-20-0-800]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[10--15-0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[10--15-300]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[10--15-800]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[-10--15-0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[-10--15-300]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_drag_and_drop[-10--15-800]"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/contexts/maximize_window.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_ignore"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_missing_value"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_fully_exit_fullscreen"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_restore_the_window"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_maximize"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_payload"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_maximize_twice_is_idempotent"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/user_prompts/send_alert_text.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_input[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_input[text1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_input[text2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_input[42]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_input[True]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_user_prompt"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_alert_element_not_interactable"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_confirm_element_not_interactable"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_send_alert_text"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_send_alert_text_with_whitespace"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/user_prompts/get_alert_text.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_user_prompt"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_alert_text"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_confirm_text"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_prompt_text"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/sessions/status.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_status_no_session"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_status_with_session_running_on_endpoint_node"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/interaction/send_keys_content_editable.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_sets_insertion_point_to_end"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_sets_insertion_point_to_after_last_text_node"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/minimize_window.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_ignore"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_missing_value"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_fully_exit_fullscreen"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_minimize"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_payload"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_minimize_twice_is_idempotent"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/element_retrieval/find_elements_from_element.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[True]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[using4]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[using5]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[value1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[value2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_closed_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_elements[css selector-#linkText]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_elements[link text-full link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_elements[partial link text-link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_elements[tag name-a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_elements[xpath-//a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_element[css selector-#wontExist]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[css selector-#linkText]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[link text-full link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[partial link text-link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[tag name-a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[xpath-//*[name()='a']]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_parent_htmldocument"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/get_window_rect.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_ignore"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_missing_value"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_payload"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/sessions/new_session/default_values.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_basic"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_repeat_new_session"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_capabilites"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_missing_first_match"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_missing_always_match"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_desired"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_ignore_non_spec_fields_in_capabilities"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid_but_unmatchable_key"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/state/get_element_property.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_missing_value"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_not_found"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_stale"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_non_existent"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/user_prompts/dismiss_alert.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_user_prompt"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_dismiss_alert"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_dismiss_confirm"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_dismiss_prompt"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/fullscreen_window.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_ignore"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_missing_value"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_fullscreen"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_payload"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_fullscreen_twice_is_idempotent"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/actions/key.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_lone_keyup_sends_no_events"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_single_printable_key_sends_correct_events[a-KeyA0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_single_printable_key_sends_correct_events[a-KeyA1]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_single_printable_key_sends_correct_events[\"-Quote]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_single_printable_key_sends_correct_events[,-Comma]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_single_printable_key_sends_correct_events[\\xe0-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_single_printable_key_sends_correct_events[\\u0416-]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_single_printable_key_sends_correct_events[@-Digit2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_single_printable_key_sends_correct_events[\\u2603-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_single_printable_key_sends_correct_events[\\uf6c2-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_single_emoji_records_correct_key[\\U0001f604]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_single_emoji_records_correct_key[\\U0001f60d]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_single_modifier_key_sends_correct_events[\\ue050-ShiftRight-Shift]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_single_modifier_key_sends_correct_events[\\ue053-OSRight-Meta]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_single_modifier_key_sends_correct_events[\\ue009-ControlLeft-Control]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_single_nonprintable_key_sends_events[\\ue00c-Escape-Escape]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_single_nonprintable_key_sends_events[\\ue014-ArrowRight-ArrowRight]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_sequence_of_keydown_printable_keys_sends_events"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_sequence_of_keydown_character_keys"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_backspace_erases_keys"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/state/text/get_text.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_getting_text_of_a_non_existant_element_is_an_error"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_read_element_text"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/actions/key_shortcuts.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_mod_a_and_backspace_deletes_all_text"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_mod_a_mod_c_right_mod_v_pastes_text"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_mod_a_mod_x_deletes_all_text"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/sessions/new_session/create_firstMatch.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[acceptInsecureCerts-False]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[acceptInsecureCerts-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[browserName-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[browserVersion-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[platformName-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[pageLoadStrategy-none]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[pageLoadStrategy-eager]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[pageLoadStrategy-normal]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[pageLoadStrategy-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[proxy-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[timeouts-value10]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[timeouts-value11]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[timeouts-value12]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[timeouts-value13]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[unhandledPromptBehavior-dismiss]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[unhandledPromptBehavior-accept]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[unhandledPromptBehavior-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-True]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-abc]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-123]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-value20]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-value21]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-None]"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/contexts/json_serialize_windowproxy.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_initial_window"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_window_open"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_frame"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/execute_async_script/user_prompts.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_dismiss"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_dismiss_and_notify"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_accept_and_notify"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_ignore"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_default"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_twice"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/execute_script/cyclic.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_array"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_object"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_array_in_object"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_object_in_array"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/user_prompts/accept_alert.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_user_prompt"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_accept_alert"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_accept_confirm"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_accept_prompt"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/switch_to_parent_frame.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_stale_element_from_iframe"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/state/get_element_tag_name.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_missing_value"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_not_found"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_stale"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_element_tag_name"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/element_send_keys/scroll_into_view.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_element_outside_of_not_scrollable_viewport"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_outside_of_scrollable_viewport"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_option_select_container_outside_of_scrollable_viewport"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_option_stays_outside_of_scrollable_viewport"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_contenteditable_element_outside_of_scrollable_viewport"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/actions/sequence.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_actions_send_no_events"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_release_char_sequence_sends_keyup_events_in_reverse"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_release_no_actions_sends_no_events"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/cookies/add_cookie.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_add_domain_cookie"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_add_cookie_for_ip"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_add_non_session_cookie"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_add_session_cookie"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_add_session_cookie_with_leading_dot_character_in_domain"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/set_window_rect.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_current_top_level_browsing_context_no_longer_open"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_ignore"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_missing_value"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect3]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect4]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect5]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect6]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect7]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect8]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect9]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect10]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect11]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect12]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect13]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect14]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect15]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect16]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect17]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect18]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect19]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect20]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect21]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect22]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect23]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect24]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect25]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect26]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_types[rect27]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_out_of_bounds[rect0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_out_of_bounds[rect1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_out_of_bounds[rect2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_width_height_floats"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_x_y_floats"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect3]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect4]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect5]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect6]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect7]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect8]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect9]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect10]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect11]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect12]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect13]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect14]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect15]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect16]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect17]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect18]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_change[rect19]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_fully_exit_fullscreen"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_restore_from_minimized"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_restore_from_maximized"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_height_width"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_height_width_larger_than_max"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_height_width_as_current"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_x_y"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_negative_x_y"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_move_to_same_position"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_move_to_same_x"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_move_to_same_y"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resize_to_same_size"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resize_to_same_width"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resize_to_same_height"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_payload"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/element_send_keys/interactability.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_body_is_interactable"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_document_element_is_interactable"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_iframe_is_interactable"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_transparent_element"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_readonly_element"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_obscured_element"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_not_a_focusable_element"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_not_displayed_element"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_hidden_element"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_disabled_element"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/contexts/resizing_and_positioning.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_window_resize"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/element_click/select.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_option"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_multiple_option"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_preselected_option"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_preselected_multiple_option"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_deselects_others"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_multiple_does_not_deselect_others"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_selected_option"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_selected_multiple_option"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_out_of_view_dropdown"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_out_of_view_multiple"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_option_disabled"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/element_retrieval/find_element.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[True]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[using4]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[using5]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[value1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[value2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_closed_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_element[css selector-#linkText]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_element[link text-full link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_element[partial link text-link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_element[tag name-a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_element[xpath-//a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_element[css selector-#wontExist]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[css selector-#linkText]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[link text-full link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[partial link text-link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[tag name-a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[xpath-//*[name()='a']]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_htmldocument[css selector-:root]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_htmldocument[tag name-html]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_htmldocument[xpath-/html]"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/sessions/get_timeouts.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_timeouts"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_default_timeouts"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_new_timeouts"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/actions/modifier_click.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_modifier_click[\\ue00a-altKey]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_modifier_click[\\ue052-altKey]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_modifier_click[\\ue03d-metaKey]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_modifier_click[\\ue053-metaKey]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_modifier_click[\\ue008-shiftKey]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_modifier_click[\\ue050-shiftKey]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_many_modifiers_click"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/element_retrieval/find_elements.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[True]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[using4]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[using5]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[value1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[value2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_closed_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_elements[css selector-#linkText]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_elements[link text-full link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_elements[partial link text-link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_elements[tag name-a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_elements[xpath-//a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_element[css selector-#wontExist]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[css selector-#linkText]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[link text-full link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[partial link text-link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[tag name-a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[xpath-//*[name()='a']]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_htmldocument[css selector-:root]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_htmldocument[tag name-html]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_htmldocument[xpath-/html]"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/actions/mouse_dblclick.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_dblclick_at_coordinates[0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_dblclick_at_coordinates[200]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_dblclick_with_pause_after_second_pointerdown"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_dblclick"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/element_click/bubbling.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_click_event_bubbles_to_parents"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_spin_event_loop"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_disappears_during_click"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/navigation/get_title.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_title_from_closed_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_title_handle_prompt_dismiss"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_title_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_title_handle_prompt_missing_value"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_title_from_top_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_title_with_duplicate_element"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_title_without_element"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_title_after_modification"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_title_strip_and_collapse"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_title_from_frame"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/sessions/new_session/response.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resp_sessionid"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resp_capabilites"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resp_data"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_timeouts"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_pageLoadStrategy"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/element_retrieval/find_element_from_element.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[True]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[using4]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_using_argument[using5]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[value1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_selector_argument[value2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_closed_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_element[css selector-#linkText]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_element[link text-full link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_element[partial link text-link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_element[tag name-a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_find_element[xpath-//a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_element[css selector-#wontExist]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[css selector-#linkText]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[link text-full link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[partial link text-link text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[tag name-a]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_xhtml_namespace[xpath-//*[name()='a']]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_parent_htmldocument"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/sessions/new_session/invalid_capabilities.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_capabilites[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_capabilites[1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_capabilites[{}]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_capabilites[value3]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_always_match[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_always_match[1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_always_match[{}]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_always_match[value3]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_first_match[None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_first_match[1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_first_match[[]]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_first_match[value3]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[acceptInsecureCerts-1-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[acceptInsecureCerts-1-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[acceptInsecureCerts-value1-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[acceptInsecureCerts-value1-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[acceptInsecureCerts-value2-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[acceptInsecureCerts-value2-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[acceptInsecureCerts-false-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[acceptInsecureCerts-false-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserName-1-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserName-1-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserName-value5-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserName-value5-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserName-value6-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserName-value6-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserName-False-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserName-False-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserVersion-1-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserVersion-1-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserVersion-value9-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserVersion-value9-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserVersion-value10-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserVersion-value10-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserVersion-False-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[browserVersion-False-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[platformName-1-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[platformName-1-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[platformName-value13-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[platformName-value13-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[platformName-value14-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[platformName-value14-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[platformName-False-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[platformName-False-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-1-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-1-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-value17-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-value17-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-value18-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-value18-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-False-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-False-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-invalid-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-invalid-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-NONE-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-NONE-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-Eager-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-Eager-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-eagerblah-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-eagerblah-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-interactive-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-interactive-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy- eager-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy- eager-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-eager -body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[pageLoadStrategy-eager -body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-1-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-1-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value28-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value28-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-{}-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-{}-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value30-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value30-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value31-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value31-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value32-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value32-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value33-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value33-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value34-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value34-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value35-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value35-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value36-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value36-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value37-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value37-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value38-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value38-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value39-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value39-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value40-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value40-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value41-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value41-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value42-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value42-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value43-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value43-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value44-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[proxy-value44-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-1-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-1-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value46-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value46-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-{}-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-{}-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-False-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-False-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value49-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value49-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value50-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value50-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value51-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value51-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value52-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value52-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value53-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value53-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value54-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value54-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value55-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value55-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value56-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value56-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value57-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value57-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value58-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value58-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value59-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value59-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value60-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value60-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value61-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[timeouts-value61-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-1-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-1-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-value63-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-value63-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-value64-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-value64-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-False-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-False-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-DISMISS-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-DISMISS-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-dismissABC-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-dismissABC-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-Accept-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-Accept-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior- dismiss-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior- dismiss-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-dismiss -body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_values[unhandledPromptBehavior-dismiss -body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[firefox-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[firefox-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[firefox_binary-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[firefox_binary-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[firefoxOptions-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[firefoxOptions-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[chromeOptions-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[chromeOptions-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[automaticInspection-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[automaticInspection-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[automaticProfiling-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[automaticProfiling-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[platform-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[platform-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[version-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[version-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[browser-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[browser-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[platformVersion-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[platformVersion-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[javascriptEnabled-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[javascriptEnabled-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[nativeEvents-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[nativeEvents-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[seleniumProtocol-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[seleniumProtocol-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[profile-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[profile-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[trustAllSSLCertificates-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[trustAllSSLCertificates-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[initialBrowserUrl-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[initialBrowserUrl-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[requireWindowFocus-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[requireWindowFocus-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[logFile-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[logFile-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[logLevel-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[logLevel-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[safari.options-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[safari.options-body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[ensureCleanSession-body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_invalid_extensions[ensureCleanSession-body1]"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/execute_script/user_prompts.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_dismiss"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_dismiss_and_notify"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_accept_and_notify"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_ignore"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_default"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_handle_prompt_twice"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/cookies/get_named_cookie.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_named_session_cookie"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_named_cookie"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_duplicated_cookie"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/actions/special_keys.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[NUMPAD9-expected0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[RETURN-expected1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[HELP-expected2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[SHIFT-expected3]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_ARROWRIGHT-expected4]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[ESCAPE-expected5]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[PAGE_UP-expected6]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_PAGEUP-expected7]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[UP-expected8]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[DOWN-expected9]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F12-expected10]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[META-expected11]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[BACKSPACE-expected12]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[MULTIPLY-expected13]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[HOME-expected14]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[NULL-expected15]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[SUBTRACT-expected16]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[CONTROL-expected17]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[INSERT-expected18]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_META-expected19]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[SEMICOLON-expected20]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[SPACE-expected21]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[NUMPAD4-expected22]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[RIGHT-expected23]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[TAB-expected24]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_ALT-expected25]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[NUMPAD0-expected26]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[DECIMAL-expected27]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[LEFT-expected28]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_DELETE-expected29]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[PAGE_DOWN-expected30]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[PAUSE-expected31]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[END-expected32]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[DIVIDE-expected33]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_ARROWUP-expected34]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[NUMPAD3-expected35]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[CLEAR-expected36]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_ARROWLEFT-expected37]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[EQUALS-expected38]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_PAGEDOWN-expected39]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[ADD-expected40]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[NUMPAD1-expected41]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_INSERT-expected42]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[ENTER-expected43]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[CANCEL-expected44]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[NUMPAD6-expected45]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F10-expected46]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F11-expected47]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_END-expected48]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[NUMPAD7-expected49]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[NUMPAD2-expected50]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F1-expected51]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F2-expected52]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F3-expected53]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F4-expected54]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F5-expected55]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F6-expected56]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F7-expected57]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F8-expected58]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[F9-expected59]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[NUMPAD8-expected60]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[NUMPAD5-expected61]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_CONTROL-expected62]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_HOME-expected63]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[ZENKAKUHANKAKU-expected64]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_SHIFT-expected65]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[SEPARATOR-expected66]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[ALT-expected67]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[R_ARROWDOWN-expected68]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_webdriver_special_key_sends_keydown[DELETE-expected69]"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/cookies/delete_cookie.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept_and_notify"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_ignore"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_missing_value"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_unknown_cookie"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/element_click/stale.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_is_stale"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/interaction/element_clear.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_closed_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_connected_element"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_pointer_interactable"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_keyboard_interactable"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[number-42-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[range-42-50]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[email-foo@example.com-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[password-password-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[search-search-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[tel-999-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[text-text-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[url-https://example.com/-]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_input[color-#ff0000-#000000]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[date-2017-12-26-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[datetime-2017-12-26T19:48-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[datetime-local-2017-12-26T19:48-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[time-19:48-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[month-2017-11-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input[week-2017-W52-]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[number]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[range]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[email]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[password]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[search]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[tel]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[url]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[color]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[date]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[datetime]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[datetime-local]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[time]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[month]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[week]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_disabled[file]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[number]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[range]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[email]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[password]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[search]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[tel]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[text]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[url]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[color]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[date]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[datetime]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[datetime-local]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[time]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[month]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[week]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_readonly[file]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_textarea"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_textarea_disabled"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_textarea_readonly"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_file"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_input_file_multiple"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_select"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_button"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_button_with_subtree"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_contenteditable"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_designmode"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_resettable_element_focus_when_empty"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resettable_element_does_not_satisfy_validation_constraints[number-foo]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resettable_element_does_not_satisfy_validation_constraints[range-foo]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resettable_element_does_not_satisfy_validation_constraints[email-foo]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resettable_element_does_not_satisfy_validation_constraints[url-foo]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resettable_element_does_not_satisfy_validation_constraints[color-foo]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resettable_element_does_not_satisfy_validation_constraints[date-foo]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resettable_element_does_not_satisfy_validation_constraints[datetime-foo]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resettable_element_does_not_satisfy_validation_constraints[datetime-local-foo]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resettable_element_does_not_satisfy_validation_constraints[time-foo]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resettable_element_does_not_satisfy_validation_constraints[month-foo]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_resettable_element_does_not_satisfy_validation_constraints[week-foo]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_non_editable_inputs[checkbox]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_non_editable_inputs[radio]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_non_editable_inputs[hidden]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_non_editable_inputs[submit]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_non_editable_inputs[button]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_non_editable_inputs[image]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_scroll_into_view"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/sessions/new_session/create_alwaysMatch.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[acceptInsecureCerts-False]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[acceptInsecureCerts-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[browserName-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[browserVersion-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[platformName-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[pageLoadStrategy-none]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[pageLoadStrategy-eager]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[pageLoadStrategy-normal]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[pageLoadStrategy-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[proxy-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[timeouts-value10]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[timeouts-value11]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[timeouts-value12]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[timeouts-value13]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[unhandledPromptBehavior-dismiss]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[unhandledPromptBehavior-accept]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[unhandledPromptBehavior-None]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-True]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-abc]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-123]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-value20]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-value21]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_valid[test:extension-None]"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/element_retrieval/get_active_element.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_closed_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_missing_value"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_success_document"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_sucess_input"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_sucess_input_non_interactable"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_success_explicit_focus"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_success_iframe_content"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_missing_document_element"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/sessions/new_session/merge.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_platform_name[body0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_platform_name[body1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_merge_invalid[acceptInsecureCerts-value0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_merge_invalid[unhandledPromptBehavior-value1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_merge_invalid[unhandledPromptBehavior-value2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_merge_invalid[timeouts-value3]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_merge_invalid[timeouts-value4]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_merge_platformName"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_merge_browserName"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/state/get_element_attribute.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_dismiss"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_accept"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_handle_prompt_missing_value"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_not_found"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_element_stale"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_normal"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[audio-attrs0]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[button-attrs1]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[details-attrs2]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[dialog-attrs3]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[fieldset-attrs4]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[form-attrs5]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_boolean_attribute[iframe-attrs6]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[img-attrs7]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[input-attrs8]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_boolean_attribute[menuitem-attrs9]"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_boolean_attribute[object-attrs10]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[ol-attrs11]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[optgroup-attrs12]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[option-attrs13]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[script-attrs14]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[select-attrs15]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[textarea-attrs16]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[track-attrs17]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_boolean_attribute[video-attrs18]"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_global_boolean_attributes"
+        }
+      ]
+    },
+    {
+      "test": "/webdriver/tests/navigation/current_url.py",
+      "status": "OK",
+      "message": null,
+      "subtests": [
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_current_url_no_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_current_url_alert_prompt"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_current_url_matches_location"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_current_url_payload"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_current_url_special_pages"
+        },
+        {
+          "status": "FAIL",
+          "message": null,
+          "name": "test_get_current_url_file_protocol"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_set_malformed_url"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_current_url_after_modified_location"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_current_url_nested_browsing_context"
+        },
+        {
+          "status": "PASS",
+          "message": null,
+          "name": "test_get_current_url_nested_browsing_contexts"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This change updates the ie11.json file to include the results from
https://gist.github.com/jimevans/2f8e6b3138bd771647cc711848d0609b,
and updates the https://w3c.github.io/webdriver/results/html content
(regenerated from running wptreport with the updated ie11.json file).