### PR TITLE
Remove extra "or" from beforeunload handler section

### DIFF
--- a/webdriver-spec.html
+++ b/webdriver-spec.html
@@ -5342,7 +5342,7 @@ The <a>remote end steps</a> are:
     is obtained from <a>url variables</a>.
 
    <dt>Otherwise
-   <dd> "" (empty string) 
+   <dd> "" (empty string)
   </dl>
 
  <li>Return <a>success</a> with data <var>computed value</var>.
@@ -8814,7 +8814,7 @@ It also clears all the internal state of the virtual devices.
 
 <p><a>User prompts</a> that are spawned
  from <a><code>beforeunload</code></a> event handlers,
- are <a>dismissed</a> implicitly upon <a data-lt=go>navigation</a> or
+ are <a>dismissed</a> implicitly upon <a data-lt=go>navigation</a>
  or <a>close window</a>,
  regardless of the defined <a>user prompt handler</a>.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1254.html" title="Last updated on Apr 19, 2018, 8:04 AM GMT (6251332)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1254/da5f9e8...whimboo:6251332.html" title="Last updated on Apr 19, 2018, 8:04 AM GMT (6251332)">Diff</a>