### PR TITLE
Trivial grammatical fix (missing preposition)

### DIFF
--- a/index.html
+++ b/index.html
@@ -676,7 +676,7 @@ dl.subcategories { margin-left: 2em }
  it has a wide range of expected functionality.
  This specification uses these expectations to inform its design.
  Where improvements or clarifications have been made,
- they have been made with care to allow existing users Selenium WebDriver
+ they have been made with care to allow existing users of Selenium WebDriver
  to avoid unexpected breakages.
 </section>
 
@@ -9496,6 +9496,7 @@ that evaluates to false, the <a>element</a> will not be <a>scrolled into view</a
  Lukas Tetzlaff,
  Malcolm Rowe,
  Michael[tm] Smith,
+ Nathan Bloomfield,
  Philippe Le Hégaret,
  Robin Berjon,
  Ross Patterson,


### PR DESCRIPTION
Change "existing users Selenium WebDriver" to "existing users of Selenium WebDriver".