### PR TITLE
Remove superfluous 0 length check for files of element_send_keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -6124,9 +6124,6 @@ must run the following steps:
      <li><p>Let <var>files</var> be the result of splitting <var>text</var>
       on the newline (<code>\n</code>) character.
 
-     <li><p>If <var>files</var> is of 0 length,
-      return an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
-
      <li><p>Let <var>multiple</var> equal the result
       of calling <code><a>hasAttribute</a>("multiple")</code>
       on <var>element</var>.


### PR DESCRIPTION
Step 10 of [Element Send Keys](https://w3c.github.io/webdriver/#dfn-element-send-keys) contains a 0-length check for files:

> 1. Let files be the result of splitting text on the newline (\n) character.
> 2. If files is of 0 length, return an error with error code invalid argument. 

This is superfluous because splitting a string for a separator which is not part of the string, or even if it is an empty string will always result in a single-entry array which contains the original string. 