### PR TITLE
Element Send Keys for "<input type=file>" has to also send a change event.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6145,7 +6145,11 @@ must run the following steps:
       If <var>multiple</var> is <code>true</code>
       <var>files</var> are be appended to <var>element</var>’s <a>selected files</a>.
 
-     <li><p><a>Fire</a> an <a><code>input</code></a> event.
+     <li><p><a>Fire</a> these events in order on <var>element<var>:
+      <ol>
+       <li><a><code>input</code></a>
+       <li><a><code>change</code></a>
+      </ol>
 
      <li><p>Return <a>success</a> with data <a>null</a>.
     </ol>


### PR DESCRIPTION
As given by the HTML spec the `<input type=file>` element sends both the `input` and `change` event. The spec currently only requires to fire the `input` event.

https://html.spec.whatwg.org/#file-upload-state-(type=file):event-input-3
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file

Testcase: https://output.jsbin.com/vijukozuro/1