### PR TITLE
More direct links to implementation docs for Firefox and Edge

### DIFF
--- a/implementation-report.md
+++ b/implementation-report.md
@@ -7,8 +7,8 @@ A cached result of tests from multiple different vendors is stored
 
 ## Status Documents from Vendors
 
-* [Mozilla Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver/status)
-* [Microsoft Edge](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/webdriver/)
+* [Mozilla Firefox](https://bugzilla.mozilla.org/showdependencytree.cgi?id=721859&hide_resolved=1)
+* [Microsoft Edge](https://docs.microsoft.com/en-us/microsoft-edge/webdriver#w3c-webdriver)
 * [Apple Safari](https://developer.apple.com/library/content/documentation/NetworkingInternetWeb/Conceptual/WebDriverEndpointDoc/Commands/Commands.html)
 * [WebKit GTK port](http://trac.webkit.org/wiki/WebDriverStatus)
 * [Selenium IEDriverServer](https://github.com/SeleniumHQ/selenium/wiki/W3C-WebDriver-Status)


### PR DESCRIPTION
The link for Firefox was a manual "this content has moved to.." redirect to this bugzilla dependency tree page, so this just skips that.

For the link for Edge, I usually had to do some clicking around on the platform status page before I could finally get to the MS docs page with the implementation details for Webdriver in Edge, so this link just goes directly there.

Thanks!