### PR TITLE
correct github branch meta info

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ var respecConfig = {
   previousPublishDate: "2018-05-24",
   previousMaturity: "PR",
   github: {
-    repoURL: "https://github.com/w3c/webdriver",
+    repoURL: "https://github.com/w3c/webdriver/",
     branch: "master",
   },
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@ var respecConfig = {
     branch: "master",
   },
 
-  edDraftURI: "https://w3c.github.io/webdriver/",
   editors: [
     {
       name: "Simon Stewart", url: "http://www.rocketpoweredjetpants.com/",

--- a/index.html
+++ b/index.html
@@ -16,7 +16,10 @@ var respecConfig = {
   // copyrightStart: "2005"
   previousPublishDate: "2018-05-24",
   previousMaturity: "PR",
-  github: "https://github.com/w3c/webdriver",
+  github: {
+    repoURL: "https://github.com/w3c/webdriver",
+    branch: "master",
+  },
 
   edDraftURI: "https://w3c.github.io/webdriver/",
   editors: [


### PR DESCRIPTION
ReSpec defaults to the gh-pages branch, whereas we serve ours from
master.