### PR TITLE
errors: change timeout errors from 408 to 500 HTTP status code

### DIFF
--- a/index.html
+++ b/index.html
@@ -1726,7 +1726,7 @@ It is acknowledged that this is complementary to the Evil Bit [[!RFC3514]].
 
  <tr>
   <td><dfn>script timeout</dfn>
-  <td>408
+  <td>500
   <td><code>script timeout</code>
   <td>A script did not complete before its timeout expired.
  </tr>
@@ -1748,7 +1748,7 @@ It is acknowledged that this is complementary to the Evil Bit [[!RFC3514]].
 
  <tr>
   <td><dfn>timeout</dfn>
-  <td>408
+  <td>500
   <td><code>timeout</code>
   <td>An operation did not complete before its timeout expired.
  </tr>


### PR DESCRIPTION
Whilst it is logically correct to use 408 for the timeout and script
timeout errors, it causes a collision with HTTP semantics implement
in HTTP clients.  To support Keep-Alive we allow retries in HTTP
clients and if a client sees code 408 it thinks that the server has
gone away and retries the request.

This causes Execute Script, Navigate To, and Refresh commands to
be sent twice with some HTTP clients.

This is a backwards incompatible change to WebDriver in order to
not break HTTP/1.1 Keep-Alive.

Fixes: https://github.com/w3c/webdriver/issues/1287