### PR TITLE
Fix Respec warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -771,11 +771,11 @@ It is initially false.
 </pre>
 
 <p>
-Note that the <a><code>NavigatorAutomationInformation</code></a> interface
+Note that the <dfn>NavigatorAutomationInformation</dfn> interface
 should not be exposed on <a><code>WorkerNavigator</code></a>.
 
 <pre class=idl>
-interface mixin <dfn>NavigatorAutomationInformation</dfn> {
+interface mixin NavigatorAutomationInformation {
 	readonly attribute boolean webdriver;
 };
 </pre>


### PR DESCRIPTION
Console message about "Linter (local-refs-exist): Broken local reference
found in document" and #dom-navigatorautomationinformation