### PR TITLE
Fix ReSpec warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1992,7 +1992,7 @@ with a "<code>moz:</code>" prefix:
   <td>"<code>setWindowRect</code>"
   <td>boolean
    <td>Indicates whether the remote end supports all of the <a>commands</a> in
-   <a href=#h-resizing-and-positioning-windows>Resizing and Positioning Windows</a>.
+   <a href=#resizing-and-positioning-windows>Resizing and Positioning Windows</a>.
  </tr>
 
  <tr>
@@ -2411,7 +2411,7 @@ with a "<code>moz:</code>" prefix:
 
    <dt>"<code>setWindowRect</code>"
    <dd>Boolean indicating whether the <a>remote end</a> supports all of the
-    <a>commands</a> in <a href=#h-resizing-and-positioning-windows>Resizing and Positioning Windows</a>.
+    <a>commands</a> in <a href=#resizing-and-positioning-windows>Resizing and Positioning Windows</a>.
   </dl>
 
  <li><p>Optionally add <a>extension capabilities</a> as entries
@@ -9454,7 +9454,7 @@ that evaluates to false, the <a>element</a> will not be <a>scrolled into view</a
 <h2>Acknowledgements</h2>
 
 <p>There have been a lot of people that have helped make
- <a href=#h-abstract>browser automation</a> possible over the years
+ <a href=#abstract>browser automation</a> possible over the years
  and thereby furthered the goals of this standard.
  In particular, thanks goes to the
  <a href=http://www.seleniumhq.org/>Selenium</a> Open Source community,


### PR DESCRIPTION
Correctly link to sections, fixing 3 messages "Linter (local-refs-exist):
Broken local reference found in document."