### PR TITLE
shifted character: fix mixup of ] and }

### DIFF
--- a/index.html
+++ b/index.html
@@ -8092,11 +8092,12 @@ is also removed.
    <th>Alternate Key
    <th>code
  </tr>
+
  <tr><td><code>"`"</code></td><td><code>"~"</code></td><td><code>"Backquote"</code></td></tr>
  <tr><td><code>"\"</code></td><td><code>"|"</code></td><td><code>"Backslash"</code></td></tr>
  <tr><td><code>"\uE003"</code></td><td><code></code></td><td><code>"Backspace"</code></td></tr>
  <tr><td><code>"["</code></td><td><code>"{"</code></td><td><code>"BracketLeft"</code></td></tr>
- <tr><td><code>"}"</code></td><td><code>"]"</code></td><td><code>"BracketRight"</code></td></tr>
+ <tr><td><code>"]"</code></td><td><code>"}"</code></td><td><code>"BracketRight"</code></td></tr>
  <tr><td><code>","</code></td><td><code>"&lt;"</code></td><td><code>"Comma"</code></td></tr>
  <tr><td><code>"0"</code></td><td><code>")"</code></td><td><code>"Digit0"</code></td></tr>
  <tr><td><code>"1"</code></td><td><code>"!"</code></td><td><code>"Digit1"</code></td></tr>


### PR DESCRIPTION
The characters "}" and "]" appears to be mixed up in the table of
shifted characters.

Thanks-to: @pyfisch
Fixes: https://github.com/w3c/webdriver/issues/1313