### PR TITLE
clear algorithm: value sanitization should be done when type attribute is defined

### DIFF
--- a/index.html
+++ b/index.html
@@ -5583,8 +5583,8 @@ Width of the <a>web element</a>’s
  set the <a>checkedness</a> of the element to true
  if the element has a <a><code>checked</code></a> content attribute and false if it does not,
  empty the list of <a>selected files</a>,
- and then invoke the <a>value sanitization algorithm</a>,
- if the <a><code>type</code></a> attribute’s current state defines one.
+ and then invoke the <a>value sanitization algorithm</a>
+ iff the <a><code>type</code></a> attribute’s current state defines one.
 
 <p>The <a>clear algorithm</a> for <a><code>textarea</code></a> elements
  is to set the <a>dirty value flag</a> back to false,


### PR DESCRIPTION
The clear algorithm for <input> uses a list to tell the drivers what
to do.  The last condition, "if the type attribute's current state
defines one" seems like another item to this list but is actually
a logic condition for the preceding sentence, "and then invoke the
value sanitization algorithm".

This turns it into a logical condition using "if-and-only-if".