### PR TITLE
reinstate living document subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ var respecConfig = {
   specStatus: "ED",
   prEnd: "2018-05-24",
   shortName: "webdriver",
-  // subtitle:  "Living Document",
+  subtitle:  "Living Document",
   // publishDate: "2009-08-06",
   // copyrightStart: "2005"
   previousPublishDate: "2018-05-24",


### PR DESCRIPTION
We commented this out before publishing, but forgot to reinstate it.