### PR TITLE
Make in-view center point CSS pixel aware

### DIFF
--- a/index.html
+++ b/index.html
@@ -708,11 +708,13 @@ dl.subcategories { margin-left: 2em }
 <section>
 <h2>Terminology</h2>
 
-<p>In equations, all numbers are integers,
- addition is represented by “+”,
- subtraction is represented by “−”,
- and bitwise OR by “|”.
- The characters “(” and “)” are used to provide logical grouping in these contexts.
+<p>
+In equations, all numbers are integers,
+addition is represented by “+”,
+subtraction by “−”,
+division by “÷”,
+and bitwise OR by “|”.
+The characters “(” and “)” are used to provide logical grouping in these contexts.
 
 <p>The shorthand
  <dfn>min</dfn>(<var>value</var>, <var>value</var>[, <var>value</var>])

--- a/index.html
+++ b/index.html
@@ -724,6 +724,10 @@ Conversely, the function
 <dfn>max</dfn>(<var>value</var>, <var>value</var>[, <var>value</var>])
 returns the largest item of two or more values.
 
+<p>
+The mathematical function <dfn>floor</dfn>(<var>value</var>)
+produces the largest integer, closest to positive infinity,
+that is not larger than <var>value</var>.
 
 <p>A <dfn data-lt=uuid>Universally Unique IDentifier (UUID)</dfn> is
  a 128 bits long URN that requires no central registration process. [[!RFC4122]].

--- a/index.html
+++ b/index.html
@@ -4501,26 +4501,26 @@ argument <var>reference</var>, run the following steps:
   returned by calling <a>getClientRects</a> on <a><var>element</var></a>.
 
  <li><p>Let <var>left</var> be
-  (<a>max</a>(0, <a>min</a>(<a>x coordinate</a>,
-  <a>x coordinate</a> + <a>width dimension</a>))).
+  <a>max</a>(0, <a>min</a>(<a>x coordinate</a>,
+  <a>x coordinate</a> + <a>width dimension</a>)).
 
  <li><p>Let <var>right</var> be
-  (<a>min</a>(<a>innerWidth</a>,
+  <a>min</a>(<a>innerWidth</a>,
   <a>max</a>(<a>x coordinate</a>,
-  <a>x coordinate</a> + <a>width dimension</a>))).
+  <a>x coordinate</a> + <a>width dimension</a>)).
 
  <li><p>Let <var>top</var> be
-  (<a>max</a>(0, <a>min</a>(<a>y coordinate</a>,
-  <a>y coordinate</a> + <a>height dimension</a>))).
+  <a>max</a>(0, <a>min</a>(<a>y coordinate</a>,
+  <a>y coordinate</a> + <a>height dimension</a>)).
 
  <li><p>Let <var>bottom</var> be
-  (<a>min</a>(<a>innerHeight</a>,
+  <a>min</a>(<a>innerHeight</a>,
   <a>max</a>(<a>y coordinate</a>,
-  <a>y coordinate</a> + <a>height dimension</a>))).
+  <a>y coordinate</a> + <a>height dimension</a>)).
 
- <li><p>Let <var>x</var> be (0.5 × (<var>left</var> + <var>right</var>)).
+ <li><p>Let <var>x</var> be 0.5 × (<var>left</var> + <var>right</var>).
 
- <li><p>Let <var>y</var> be (0.5 × (<var>top</var> + <var>bottom</var>)).
+ <li><p>Let <var>y</var> be 0.5 × (<var>top</var> + <var>bottom</var>).
 
  <li><p>Return <var>x</var> and <var>y</var> as a pair.
 </ol>

--- a/index.html
+++ b/index.html
@@ -716,12 +716,14 @@ division by “÷”,
 and bitwise OR by “|”.
 The characters “(” and “)” are used to provide logical grouping in these contexts.
 
-<p>The shorthand
- <dfn>min</dfn>(<var>value</var>, <var>value</var>[, <var>value</var>])
- returns the smallest item of two or more values.
- Conversely, the shorthand
- <dfn>max</dfn>(<var>value</var>, <var>value</var>[, <var>value</var>])
- returns the largest item of two or more values.
+<p>
+The mathematical function
+<dfn>min</dfn>(<var>value</var>, <var>value</var>[, <var>value</var>])
+returns the smallest item of two or more values.
+Conversely, the function
+<dfn>max</dfn>(<var>value</var>, <var>value</var>[, <var>value</var>])
+returns the largest item of two or more values.
+
 
 <p>A <dfn data-lt=uuid>Universally Unique IDentifier (UUID)</dfn> is
  a 128 bits long URN that requires no central registration process. [[!RFC4122]].

--- a/index.html
+++ b/index.html
@@ -4526,11 +4526,11 @@ argument <var>reference</var>, run the following steps:
   <a>max</a>(<a>y coordinate</a>,
   <a>y coordinate</a> + <a>height dimension</a>)).
 
- <li><p>Let <var>x</var> be (<var>left</var> + <var>right</var>) ÷ 2.0.
+ <li><p>Let <var>x</var> be <a>floor</a>((<var>left</var> + <var>right</var>) ÷ 2.0).
 
- <li><p>Let <var>y</var> be (<var>top</var> + <var>bottom</var>) ÷ 2.0.
+ <li><p>Let <var>y</var> be <a>floor</a>((<var>top</var> + <var>bottom</var>) ÷ 2.0).
 
- <li><p>Return <var>x</var> and <var>y</var> as a pair.
+ <li><p>Return the pair of (<var>x</var>, <var>y</var>).
 </ol>
 
 <p>An <a>element</a> is <dfn>in view</dfn>

--- a/index.html
+++ b/index.html
@@ -4518,9 +4518,9 @@ argument <var>reference</var>, run the following steps:
   <a>max</a>(<a>y coordinate</a>,
   <a>y coordinate</a> + <a>height dimension</a>)).
 
- <li><p>Let <var>x</var> be 0.5 × (<var>left</var> + <var>right</var>).
+ <li><p>Let <var>x</var> be (<var>left</var> + <var>right</var>) ÷ 2.0.
 
- <li><p>Let <var>y</var> be 0.5 × (<var>top</var> + <var>bottom</var>).
+ <li><p>Let <var>y</var> be (<var>top</var> + <var>bottom</var>) ÷ 2.0.
 
  <li><p>Return <var>x</var> and <var>y</var> as a pair.
 </ol>


### PR DESCRIPTION
Quoting the commit message of the last patch:

> Calculating the centre point of a square may produce a decimal
> precision number.  Given a 1x1 px square the center point will be
> (0.5,0.5), but the DOM operates in integer CSS pixels.
> 
> Rounding the number would get us the closest positive integer, or 1. 
> However, the coordinate (1,1) is beyond the bounding box of the
> square.
> 
> This means we need to floor the number to ensure we always get a
> click point that is within the client rect of the element.
> 
> An additional complexity is that not all web platform APIs treat
> floating point numbers the same way.  DOMElement.elementsFromPoint,
> which we use for getting the paint tree to determine if the web
> element is interactable, will floor the number which deems the
> element interactable.  However, in Gecko, nsIDOMUtils.sendMouseEvent
> ceils the number, causing the actual click point to fall beyond the
> square.

Tests will be provided as part of https://bugzilla.mozilla.org/show_bug.cgi?id=1499360, which implements this in geckodriver.