### PR TITLE
Minor wording fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -3720,7 +3720,7 @@ make the tab containing the <a>browsing context</a> the selected tab.
   from the user selecting the <a>current browsing context</a> for
   interaction, without altering OS-level focus.
 
- <li><p>Return <a>success</a> with date <a>null</a>.
+ <li><p>Return <a>success</a> with data <a>null</a>.
 </ol>
 </section> <!-- /Switch To Window -->
 


### PR DESCRIPTION
## Current Wording

In chapter 10. Command Contexts, section 10.3 Switch To Window:

> Return success with date null.

## Expected Wording

Return success with data null.