### PR TITLE
Fix collection serialization and support collection types found in the wild

### DIFF
--- a/index.html
+++ b/index.html
@@ -6376,28 +6376,13 @@ of the <a>current browsing context</a> <a>active document</a>.
  <dt>type <a>String</a>
  <dd><p><a>Success</a> with data <var>value</var>.
 
- <dt>instance of <a>element</a>
- <dd><p>If the <var>element</var> <a>is stale</a>,
-  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
-
   <p>Otherwise, return <a>success</a>
    with the <a data-lt="JSON serialization of an element">serialization to JSON</a>
    of the <a>web element</a> <var>value</var>.
 
- <dt>a <a><code>WindowProxy</code></a> object
- <dd><p>If the associated <a>browsing context</a>
-  of the <a><code>WindowProxy</code></a> object
-  in <var>value</var> has been <a>discarded</a>,
-  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
-
-  <p>Otherwise return <a>success</a>
-   with the <a>JSON serialization of the <code>WindowProxy</code> object</a>
-   of <var>value</var>.
-
  <dt>instance of <a>NodeList</a>
  <dt>instance of <a>HTMLCollection</a>
  <dt>instance of <a>Array</a>
- <dt>instance of <a>Object</a>
  <dd>
   <ol>
    <li><p>If <var>value</var> is in <var>seen</var>,
@@ -6414,7 +6399,24 @@ of the <a>current browsing context</a> <a>active document</a>.
 
    <li><p>Return <var>result</var>.
   </ol>
- </dd>
+
+ <dt>instance of <a>element</a>
+ <dd><p>If the <var>element</var> <a>is stale</a>,
+  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
+
+  <p>Otherwise return <a>success</a>
+   with the <a data-lt="JSON serialization of an element">JSON serialization</a>
+   of <var>value</var>.
+
+ <dt>a <a><code>WindowProxy</code></a> object
+ <dd><p>If the associated <a>browsing context</a>
+  of the <a><code>WindowProxy</code></a> object
+  in <var>value</var> has been <a>discarded</a>,
+  return <a>error</a> with <a>error code</a> <a>stale element reference</a>.
+
+  <p>Otherwise return <a>success</a>
+   with the <a data-lt="JSON serialization of the WindowProxy object">JSON serialization</a>
+   of <var>value</var>.
 
  <dt>has an <a>own property</a> named "<code>toJSON</code>" that is
   a <a>Function</a>
@@ -6422,7 +6424,22 @@ of the <a>current browsing context</a> <a>active document</a>.
   <a>Call</a>(<code>toJSON</code>).
 
  <dt>Otherwise</dt>
- <dd><p><a>Error</a> with <a>error code</a> <a>javascript error</a>.
+ <dd>
+  <ol>
+   <li><p>If <var>value</var> is in <var>seen</var>,
+    return <a>error</a> with <a>error code</a> <a>javascript error</a>.
+
+   <li><p>Append <var>value</var> to <var>seen</var>.
+
+   <li><p>Let <var>result</var> be the value of running the
+    <a>clone an object</a> algorithm with arguments <var>value</var> and
+    <var>seen</var>, and the <a>internal JSON clone algorithm</a> as the
+    <var>clone algorithm</var>.
+
+   <li><p>Remove the last element of <var>seen</var>.
+
+   <li><p>Return <var>result</var>.
+  </ol>
 </dl>
 
 <p>To <dfn>clone an object</dfn>,

--- a/index.html
+++ b/index.html
@@ -6385,19 +6385,15 @@ of the <a>current browsing context</a> <a>active document</a>.
  <dt>instance of <a>Array</a>
  <dd>
   <ol>
-   <li><p>If <var>value</var> is in <var>seen</var>,
-    return <a>error</a> with <a>error code</a> <a>javascript error</a>.
+   <li><p>Let <var>result list</var> be an empty list.
 
-   <li><p>Append <var>value</var> to <var>seen</var>.
+   <li><p>For each <var>item</var> of <var>value</var>,
+    add the result of <a>trying</a> to <a>clone an object</a>
+    with arguments <var>item</var> and <var>seen</var>
+    and the <a>internal JSON clone algorithm</a> as the <var>clone algorithm</var>
+    to <var>result list</var>.
 
-   <li><p>Let <var>result</var> be the value of running the
-    <a>clone an object</a> algorithm with arguments <var>value</var> and
-    <var>seen</var>, and the <a>internal JSON clone algorithm</a> as the
-    <var>clone algorithm</var>.
-
-   <li><p>Remove the last element of <var>seen</var>.
-
-   <li><p>Return <var>result</var>.
+   <li><p>Return <a>success</a> with <var>result list</var>.
   </ol>
 
  <dt>instance of <a>element</a>

--- a/index.html
+++ b/index.html
@@ -214,23 +214,24 @@ dl.subcategories { margin-left: 2em }
  <dt>ECMAScript
  <dd><p>The following terms are defined in the ECMAScript Language Specification: [[!ECMA-262]]
   <ul>
+    <!-- Iterable --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-iterable-interface>Iterable</a></dfn>
    <!-- Completion --> <li><dfn><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">Completion</a></dfn>
    <!-- CreateResolvingFunctions --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-createresolvingfunctions>CreateResolvingFunctions</a></dfn>
    <!-- Directive prologue --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-14.1>Directive prologue</a></dfn>
    <!-- Early error --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-16>Early error</a></dfn>
    <!-- Function --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.24>Function</a></dfn>
-   <!-- FunctionCreate --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-functioncreate>FunctionCreate</a></dfn>
    <!-- FunctionBody --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-13>FunctionBody</a></dfn>
+   <!-- FunctionCreate --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-functioncreate>FunctionCreate</a></dfn>
    <!-- Get --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-get-o-p>Get</a></dfn>
    <!-- Global environment --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-10.2.3>Global environment</a></dfn>
    <!-- IsCallable --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-iscallable>IsCallable</a></dfn>
    <!-- Own property --> <li><dfn data-lt="own properties"><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.30>Own property</a></dfn>
-   <!-- parseFloat --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.3>parseFloat</a></dfn>
    <!-- Promise --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-promise-constructor>Promise</a></dfn>
    <!-- PromiseResolve --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-promise-resolve>PromiseResolve</a></dfn>
-   <!-- realm --> <li><dfn><a href="https://tc39.github.io/ecma262/#sec-code-realms">realm</a></dfn>
    <!-- Type --> <li><dfn data-lt="ecmascript type" data-lt-noDefault><a href=https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values>Type</a></dfn>
    <!-- Use strict directive --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-14.1>Use strict directive</a></dfn>
+   <!-- parseFloat --> <li><dfn><a href=http://www.ecma-international.org/ecma-262/5.1/#sec-15.1.2.3>parseFloat</a></dfn>
+   <!-- realm --> <li><dfn><a href="https://tc39.github.io/ecma262/#sec-code-realms">realm</a></dfn>
   </ul>
 
  <dd>This specification also presumes that you are able to call
@@ -278,6 +279,12 @@ dl.subcategories { margin-left: 2em }
    <!-- Set Header --> <li><dfn><a href="https://fetch.spec.whatwg.org/#concept-header-list-set">Set Header</a></dfn>
    <!-- Status --> <li><dfn><a href=https://fetch.spec.whatwg.org/#concept-response-status>HTTP Status</a></dfn>
    <!-- Status message --> <li><dfn><a href=https://fetch.spec.whatwg.org/#concept-response-status-message>Status message</a></dfn>
+  </ul>
+
+ <dt>File
+ <dd><p>The following interfaces are defined in the W3C File API specification: [[!FILEAPI]]
+  <ul>
+   <!-- FileList --> <li><dfn><a href=https://w3c.github.io/FileAPI/#dfn-filelist><code>FileList</code></a></dfn>
   </ul>
 
  <dt>Fullscreen
@@ -331,6 +338,9 @@ dl.subcategories { margin-left: 2em }
    <!-- Focusing steps --> <li><dfn><a href="https://html.spec.whatwg.org/#focusing-steps">Focusing steps</a></dfn>
    <!-- Fousable area --><li><dfn><a href=https://html.spec.whatwg.org/#focusable-area>Focusable area</a></dfn>
    <!-- GetOwnProperty of a Window object --> <li><dfn data-lt="window.[[\getOwnProperty]]"><a href=https://html.spec.whatwg.org/#windowproxy-getownproperty><code>[[\GetOwnProperty]]</code> of a <code>Window</code> object</a></dfn>
+   <!-- HTMLAllCollection --> <li><dfn><a href=https://html.spec.whatwg.org/#htmlallcollection><code>HTMLAllCollection</code></a></dfn>
+   <!-- HTMLFormControlCollection --> <li><dfn><a href=https://html.spec.whatwg.org/#htmlformcontrolscollection><code>HTMLFormControlsCollection</code></a></dfn>
+   <!-- HTMLOptionsCollection --> <li><dfn><a href=https://html.spec.whatwg.org/#htmloptionscollection><code>HTMLOptionsCollection</code></a></dfn>
    <!-- Hidden --> <li><dfn><a href="https://html.spec.whatwg.org/#hidden-state-%28type=hidden%29">Hidden</a></dfn> state
    <!-- Image Button --> <li><dfn><a href="https://html.spec.whatwg.org/#image-button-state-%28type=image%29">Image Button</a></dfn> state
    <!-- In parallel --> <li><dfn><a href="https://html.spec.whatwg.org/#in-parallel">In parallel</a></dfn>
@@ -6324,10 +6334,27 @@ of the <a>current browsing context</a> <a>active document</a>.
 <section>
 <h3>Executing Script</h3>
 
-<p>When required to <dfn>JSON deserialize</dfn>
- with argument <var>value</var>
- and optional argument <var>seen</var>,
- a <a>remote end</a> must run the following steps:
+<p>
+A <dfn>collection</dfn> is an <a>Object</a>
+that implements the <a>Iterable</a> interface,
+and whose:
+
+<ul>
+<li><a>initial value</a> of the <code>toString</code> <a>own property</a> is <code>Arguments</code>
+<li>type is <a>Array</a>
+<li>type is <a><code>FileList</code></a>
+<li>type is <a><code>HTMLAllCollection</code></a>
+<li>type is <a><code>HTMLCollection</code></a>
+<li>type is <a><code>HTMLFormControlsCollection</code></a>
+<li>type is <a><code>HTMLOptionsCollection</code></a>
+<li>type is <a><code>NodeList</code></a>
+</ul>
+
+<p>
+When required to <dfn>JSON deserialize</dfn>
+with argument <var>value</var>
+and optional argument <var>seen</var>,
+a <a>remote end</a> must run the following steps:
 
 <ol>
  <li><p>If <var>seen</var> is not provided,
@@ -6380,9 +6407,7 @@ of the <a>current browsing context</a> <a>active document</a>.
    with the <a data-lt="JSON serialization of an element">serialization to JSON</a>
    of the <a>web element</a> <var>value</var>.
 
- <dt>instance of <a>NodeList</a>
- <dt>instance of <a>HTMLCollection</a>
- <dt>instance of <a>Array</a>
+ <dt>a <a>collection</a>
  <dd>
   <ol>
    <li><p>Let <var>result list</var> be an empty list.
@@ -6448,9 +6473,7 @@ of the <a>current browsing context</a> <a>active document</a>.
   matching on <var>value</var>:
 
   <dl class=switch>
-   <dt>instance of <a>NodeList</a>
-   <dt>instance of <a>HTMLCollection</a>
-   <dt>instance of <a>Array</a>
+   <dt>a <a>collection</a>
    <dd><p>A new <a>Array</a>
     which <code>length</code> property is equal
     to the result of <a>getting the property</a> <code>length</code>


### PR DESCRIPTION
WebDriver’s JSON serialisation algorithm doesn’t handle all the collection types handled by implementations found in the wild. These are:

* Arguments
* FileList
* HTMLAllCollection
* HTMLFormControlsCollection
* HTMLOptionsCollection

Whilst adding these I also discovered that the algorithm didn’t really inspect the interior of array-like collections at all, so the PR also fixes that. This is effectively mirroring how geckodriver handles JSON currently. See each commit message for more detailed information, since I also fixed a few other minor bugs along the way.

Tests for this can be found in https://github.com/web-platform-tests/wpt/blob/master/webdriver/tests/execute_script/collections.py.

This was discovered whilst reviewing https://github.com/web-platform-tests/wpt/pull/13880.