### PR TITLE
collection: check for "Arguments" string

### DIFF
--- a/index.html
+++ b/index.html
@@ -5792,7 +5792,7 @@ that implements the <a>Iterable</a> interface,
 and whose:
 
 <ul>
-<li><a>initial value</a> of the <code>toString</code> <a>own property</a> is <code>Arguments</code>
+<li><a>initial value</a> of the <code>toString</code> <a>own property</a> is "<code>Arguments</code>"
 <li>instance of <a>Array</a>
 <li>instance of <a><code>FileList</code></a>
 <li>instance of <a><code>HTMLAllCollection</code></a>


### PR DESCRIPTION
Arguments is technically not a prototype, and the test is for the
toString result.

Relates to https://github.com/w3c/webdriver/issues/1347.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1352.html" title="Last updated on Nov 22, 2018, 1:17 PM GMT (9757c87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1352/8dc9cc7...andreastt:9757c87.html" title="Last updated on Nov 22, 2018, 1:17 PM GMT (9757c87)">Diff</a>