### PR TITLE
design: use respec informative builtin

### DIFF
--- a/index.html
+++ b/index.html
@@ -673,10 +673,8 @@ rather than performance, in mind.
 </section> <!-- /Dependencies -->
 </section> <!-- /Conformance -->
 
-<section>
+<section class=informative>
 <h2>Design</h2>
-
-<i>This section is non-normative</i>
 
 <p>The WebDriver standard attempts to follow a number of design goals:
 


### PR DESCRIPTION
We can mark a section with the "informative" CSS class to have
ReSpec automatically mark it as non-normative.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1358.html" title="Last updated on Nov 19, 2018, 10:08 AM GMT (17c1195)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1358/d494784...andreastt:17c1195.html" title="Last updated on Nov 19, 2018, 10:08 AM GMT (17c1195)">Diff</a>