### PR TITLE
Add Access-Control-Allow-Origin to response header

### DIFF
--- a/index.html
+++ b/index.html
@@ -1132,6 +1132,9 @@ It is acknowledged that this is complementary to the Evil Bit [[!RFC3514]].
 
    <dt><code>Cache-Control</code>
    <dd>"<code>no-cache</code>"
+
+   <dt><code>Access-Control-Allow-Origin</code>
+   <dd>"<code>*</code>"
   </dl>
 
  <li><p>Let <var>response</var>’s <a>body</a> be a JSON <a>Object</a>


### PR DESCRIPTION
It should be irrelevant from which origin the webdriver request was made. Not having this header set currently prevents e.g. browser to run webdriver tests which I know is an unusual use case but definitely something that can be from value. In fact the reason I bring this up is because of a conversation I had with @jlipps at Node+JS Interactive in Vancouver this year. We are working on making WebdriverIO capable to run in the browser.

I am happy to enhance my header PR (web-platform-tests/wpt#14074) in case this is considered to get accepted. Cheers!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christian-bromann/webdriver/pull/1362.html" title="Last updated on Nov 19, 2018, 12:39 PM GMT (ad617f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1362/b1250f9...christian-bromann:ad617f6.html" title="Last updated on Nov 19, 2018, 12:39 PM GMT (ad617f6)">Diff</a>