### PR TITLE
Swap Design and Conformance chapters

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,23 +89,6 @@ Use <a href=https://github.com/w3c/webdriver>GitHub w3c/webdriver</a> for commen
 </section>
 
 
-<section>
-<h2>Conformance</h2>
-
-<p>
-All diagrams, examples, and notes in this specification are non-normative,
-as are all sections explicitly marked non-normative.
-Everything else in this specification is normative.
-
-<p>
-Conformance requirements phrased as algorithms
-or specific steps may be implemented in any manner,
-so long as the end result is equivalent.
-Algorithms in this document are typically written with readability,
-rather than performance, in mind.
-</section>
-
-
 <section class=informative>
 <h2>Design</h2>
 
@@ -151,6 +134,23 @@ web standards to support the automation of new platform features. It also
 allows vendors to expose functionality that is specific to their browser.
 </section>
 </section> <!-- /Design Notes -->
+
+
+<section>
+<h2>Conformance</h2>
+
+<p>
+All diagrams, examples, and notes in this specification are non-normative,
+as are all sections explicitly marked non-normative.
+Everything else in this specification is normative.
+
+<p>
+Conformance requirements phrased as algorithms
+or specific steps may be implemented in any manner,
+so long as the end result is equivalent.
+Algorithms in this document are typically written with readability,
+rather than performance, in mind.
+</section>
 
 
 <section>


### PR DESCRIPTION
This swaps the Conformance and Design chapters, so that Design comes
before defining the remainder of the specification.  This harmonises
better with how other specifications are written.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1364.html" title="Last updated on Nov 20, 2018, 3:17 PM GMT (11c7cd2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1364/9053e5a...andreastt:11c7cd2.html" title="Last updated on Nov 20, 2018, 3:17 PM GMT (11c7cd2)">Diff</a>