### PR TITLE
terminology: reduce number of normative references to RFC4122

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,11 +178,12 @@ produces the largest integer, closest to positive infinity,
 that is not larger than <var>value</var>.
 
 <p>
-A <dfn data-lt=uuid>Universally Unique IDentifier (UUID)</dfn> is
-a 128 bits long URN that requires no central registration process. [[!RFC4122]].
-<dfn>Generating a UUID</dfn> means Creating a
-<a>UUID</a> From Truly Random or Pseudo-Random Numbers [[!RFC4122]],
-and converting it to the string representation [[!RFC4122]].
+A <dfn data-lt=uuid>Universally Unique IDentifier (UUID)</dfn>
+is a 128 bits long URN that requires no central registration process.
+<dfn>Generating a UUID</dfn> means
+<i>Creating a UUID From Truly Random or Pseudo-Random Numbers</i>,
+and converting it to the string representation.
+[[!RFC4122]]
 
 <p>
 The <dfn data-lt="Unix timestamp">Unix Epoch</dfn>


### PR DESCRIPTION
We don't have to reference RFC4122 three times in one paragraph.
Once at the end lends much better readability.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1365.html" title="Last updated on Nov 20, 2018, 1:14 PM GMT (b3484b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1365/12589b5...andreastt:b3484b5.html" title="Last updated on Nov 20, 2018, 1:14 PM GMT (b3484b5)">Diff</a>