### PR TITLE
drop subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@ var respecConfig = {
   specStatus: "LD",
   prEnd: "2018-05-24",
   shortName: "webdriver",
-  subtitle:  "Living Document",
   // publishDate: "2009-08-06",
   // copyrightStart: "2005"
   previousPublishDate: "2018-05-24",


### PR DESCRIPTION
As ReSpec now recognises the Living Document status and correctly
marks it as "W3C Living Document", we can drop our own custom
subtitle.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1367.html" title="Last updated on Nov 22, 2018, 12:01 PM GMT (95fcf30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1367/caec5c9...andreastt:95fcf30.html" title="Last updated on Nov 22, 2018, 12:01 PM GMT (95fcf30)">Diff</a>