### PR TITLE
commands: correct definition of remote end steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,21 +392,24 @@ It is acknowledged that this is complementary to the Evil Bit [[!RFC3514]].
   the result of calling <code>JSON.</code><a>[[\Parse]]</a>(<var>text</var>).
 </section> <!-- /Algorithms -->
 
+
 <section>
 <h3>Commands</h3>
 
-<p>The WebDriver protocol is organised into <a>commands</a>.
- Each <a>HTTP request</a> with a method and template defined in this specification
- represents a single <dfn data-lt="commands">command</dfn>,
- and therefore each command produces a single <a>HTTP response</a>.
- In response to a <a>command</a>,
- a <a>remote end</a> will run a series of actions against the browser.
+<p>
+The WebDriver protocol is organised into <a>commands</a>.
+Each <a>HTTP request</a> with a method and template defined in this specification
+represents a single <dfn data-lt=commands>command</dfn>,
+and therefore each command produces a single <a>HTTP response</a>.
 
-<p>Each <a>command</a> defined in this specification
- has an associated list of <dfn>remote end steps</dfn>.
- This provides the sequence of actions that a <a>remote end</a> takes
- when it receives a particular <a>command</a>.
+<p>
+In response to a <a>command</a>,
+a <a>remote end</a> will run a series of actions
+known as <dfn>remote end steps</dfn>.
+These provide the sequences of actions that a <a>remote end</a> takes
+when it receives a particular <a>command</a>.
 </section>
+
 
 <section>
 <h3>Processing model</h3>


### PR DESCRIPTION
Remote ends steps are run against all types of remote ends, not
just browsers.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreastt/webdriver/pull/1369.html" title="Last updated on Nov 22, 2018, 12:10 PM GMT (7d03761)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1369/33271cb...andreastt:7d03761.html" title="Last updated on Nov 22, 2018, 12:10 PM GMT (7d03761)">Diff</a>