### PR TITLE
Fix HTTP Method for Create Window

### DIFF
--- a/index.html
+++ b/index.html
@@ -3245,7 +3245,7 @@ make the tab containing the <a>browsing context</a> the selected tab.
   <th>URI Template</th>
  </tr>
  <tr>
-  <td>GET</td>
+  <td>POST</td>
   <td>/session/{<var>session id</var>}/window/new</td>
  </tr>
 </table>


### PR DESCRIPTION
The HTTP Method for Create Window command was specified
as POST at https://w3c.github.io/webdriver/#endpoints,
but as GET at https://w3c.github.io/webdriver/#create-window.
Since this command takes a parameter, it needs to use POST method.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JohnChen0/webdriver/pull/1377.html" title="Last updated on Dec 5, 2018, 3:46 PM GMT (ee20967)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1377/de3aadf...JohnChen0:ee20967.html" title="Last updated on Dec 5, 2018, 3:46 PM GMT (ee20967)">Diff</a>