### PR TITLE
Fix tick actions variable name to correctly group

### DIFF
--- a/index.html
+++ b/index.html
@@ -7495,9 +7495,9 @@ Return <a>success</a> with data <var>action</var>.
    <li><p>Let <var>tick duration</var> be the result of <a>computing
     the tick duration</a> with argument <var>tick actions</var>.
 
-   <li><p><a>Dispatch tick actions</a> with arguments <var>tick
-    actions</var> and <var>tick duration</var>. If this results in
-    an <a>error</a> return that error.
+   <li><p><a>Dispatch tick actions</a> with arguments
+   <var>tick actions</var> and <var>tick duration</var>.
+   If this results in an <a>error</a> return that error.
 
    <li><p>Wait until the following conditions are all met:
 


### PR DESCRIPTION
The whitespace confuses the respec for the variable name.