### PR TITLE
Fix inconsistency in key code table

### DIFF
--- a/index.html
+++ b/index.html
@@ -7787,8 +7787,8 @@ Return <a>success</a> with data <var>action</var>.
  <tr><td><code>"\uE002"</code></td><td><code></code></td><td><code>"Help"</code></td></tr>
  <tr><td><code>"\uE011"</code></td><td><code></code></td><td><code>"Home"</code></td></tr>
  <tr><td><code>"\uE016"</code></td><td><code></code></td><td><code>"Insert"</code></td></tr>
- <tr><td><code>"\uE01E"</code></td><td><code></code></td><td><code>"PageDown"</code></td></tr>
- <tr><td><code>"\uE01F"</code></td><td><code></code></td><td><code>"PageUp"</code></td></tr>
+ <tr><td><code>"\uE00F"</code></td><td><code></code></td><td><code>"PageDown"</code></td></tr>
+ <tr><td><code>"\uE00E"</code></td><td><code></code></td><td><code>"PageUp"</code></td></tr>
  <tr><td><code>"\uE015"</code></td><td><code></code></td><td><code>"ArrowDown"</code></td></tr>
  <tr><td><code>"\uE012"</code></td><td><code></code></td><td><code>"ArrowLeft"</code></td></tr>
  <tr><td><code>"\uE014"</code></td><td><code></code></td><td><code>"ArrowRight"</code></td></tr>
@@ -7816,13 +7816,13 @@ Return <a>success</a> with data <var>action</var>.
  <tr><td><code>"\uE021"</code></td><td><code>"\uE057"</code></td><td><code>"Numpad7"</code></td></tr>
  <tr><td><code>"\uE022"</code></td><td><code>"\uE059"</code></td><td><code>"Numpad8"</code></td></tr>
  <tr><td><code>"\uE023"</code></td><td><code>"\uE054"</code></td><td><code>"Numpad9"</code></td></tr>
- <tr><td><code>"\uE024"</code></td><td><code></code></td><td><code>"NumpadAdd"</code></td></tr>
+ <tr><td><code>"\uE025"</code></td><td><code></code></td><td><code>"NumpadAdd"</code></td></tr>
  <tr><td><code>"\uE026"</code></td><td><code></code></td><td><code>"NumpadComma"</code></td></tr>
  <tr><td><code>"\uE028"</code></td><td><code>"\uE05D"</code></td><td><code>"NumpadDecimal"</code></td></tr>
  <tr><td><code>"\uE029"</code></td><td><code></code></td><td><code>"NumpadDivide"</code></td></tr>
  <tr><td><code>"\uE007"</code></td><td><code></code></td><td><code>"NumpadEnter"</code></td></tr>
  <tr><td><code>"\uE024"</code></td><td><code></code></td><td><code>"NumpadMultiply"</code></td></tr>
- <tr><td><code>"\uE026"</code></td><td><code></code></td><td><code>"NumpadSubtract"</code></td></tr>
+ <tr><td><code>"\uE027"</code></td><td><code></code></td><td><code>"NumpadSubtract"</code></td></tr>
 </table>
 
 <p>The <dfn>key location</dfn> for <var>key</var> is the value in the


### PR DESCRIPTION
Several key values in key code table are inconsistent with other tables,
and also are in conflict with other entries in the same table.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JohnChen0/webdriver/pull/1384.html" title="Last updated on Dec 27, 2018, 11:29 PM UTC (90af629)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1384/6f4ce2c...JohnChen0:90af629.html" title="Last updated on Dec 27, 2018, 11:29 PM UTC (90af629)">Diff</a>