### PR TITLE
"Switch To Frame" has to raise "invalid argument" error for invalid frame id types (#1387)

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@ that have elapsed since the Epoch,
 as described by The Open Group Base Specifications Issue 7
 <a href=https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_15>section 4.15</a> (IEEE Std 1003.1).
 
-<p> 
+<p>
 An <dfn>integer</dfn> is a <a>Number</a> that is unchanged
 under the <a>ToInteger</a> operation.
 
@@ -3335,7 +3335,7 @@ make the tab containing the <a>browsing context</a> the selected tab.
  <li><p>If <var>id</var> is not <a>null</a>,
   a <code>Number</code> object,
   or an <a>Object</a> that <a>represents a web element</a>,
-  return <a>error</a> with <a>error code</a> <a>no such frame</a>.
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.


### PR DESCRIPTION
Fixes #1387.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1388.html" title="Last updated on Jan 7, 2019, 7:52 PM UTC (820c2a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1388/31483b0...whimboo:820c2a6.html" title="Last updated on Jan 7, 2019, 7:52 PM UTC (820c2a6)">Diff</a>