### PR TITLE
"Switch To Frame" has to raise "invalid argument" error for out of bounds frame id number values (#1389)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3357,7 +3357,7 @@ make the tab containing the <a>browsing context</a> the selected tab.
    <dd>
     <ol>
      <li><p>If <var>id</var> is less than 0 or greater than 2<sup>16</sup> – 1,
-      return <a>error</a> with <a>error code</a> <a>no such frame</a>.
+      return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
      <li><p>Let <var>window</var> be the <a>associated window</a>
       of the <a>current browsing context</a>’s <a>active document</a>.


### PR DESCRIPTION
Fixes #1389.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1390.html" title="Last updated on Jan 9, 2019, 11:47 AM UTC (f81dc1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1390/a56962c...whimboo:f81dc1b.html" title="Last updated on Jan 9, 2019, 11:47 AM UTC (f81dc1b)">Diff</a>