### PR TITLE
Actions pointer additional properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -6908,20 +6908,56 @@ and "<code>touch</code>",
 a <code>pressed</code> property which is a set of unsigned integers,
 an <code>x</code> property which is an unsigned integer,
 and a <code>y</code> property which is an unsigned integer.
-Additionally, it also contains optional properties
-<code>width</code>, <code>height</code>, <code>pressure</code>, and
-<code>tangentialPressure</code> which are floating-point numbers, and
-<code>tiltX</code>, <code>tiltY</code>, and <code>twist</code> which
-are integers in accordance with the requirements of [[!POINTER-EVENTS]].
+
+<p>Additionally, a <a>pointer input state</a> object also contains
+<dfn>optional pointer properties</dfn> as shown in the table below
+in accordance with the requirements of [[!POINTER-EVENTS]].
+
+<table class=simple>
+ <thead>
+  <tr>
+   <th>Property
+   <th>Type
+  </tr>
+ </thead>
+ <tr>
+  <td><code>width</code>
+  <td><a>floating-point number</a>
+ </tr>
+ <tr>
+  <td><code>height</code>
+  <td><a>floating-point number</a>
+ </tr>
+ <tr>
+  <td><code>pressure</code>
+  <td><a>floating-point number</a>
+ </tr>
+ <tr>
+  <td><code>tangentialPressure</code>
+  <td><a>floating-point number</a>
+ </tr>
+ <tr>
+  <td><code>tiltX</code>
+  <td><a>integer</a>
+ </tr>
+ <tr>
+  <td><code>tiltY</code>
+  <td><a>integer</a>
+ </tr>
+ <tr>
+  <td><code>twist</code>
+  <td><a>integer</a>
+ </tr>
+</table>
 
 <p>When required to <dfn>create a new pointer input state</dfn> object
  with arguments <var>subtype</var> an implementation must return
  a <a>pointer input state</a> object with <code>subtype</code> set
  to <var>subtype</var>, <code>pressed</code> set to an empty set,
- both <code>x</code> and <code>y</code> set to <code>0</code>, and
+ both <code>x</code> and <code>y</code> set to <code>0</code>,
  <code>width</code>, <code>height</code>, <code>pressure</code>,
  <code>tangentialPressure</code>, <code>tiltX</code>, <code>tiltY</code>,
- and <code>twist</code> are set to null.
+ and <code>twist</code> set to <a>null</a>.
 
 <p>Each <a>session</a> has an associated <dfn>input state table</dfn>.
  This is a map between <a>input id</a>
@@ -8249,6 +8285,9 @@ Return <a>success</a> with data <var>action</var>.
   <var>input state</var>’s <code>pressed</code> property, and
   let <var>buttons</var> be the resulting value of that property.
 
+ <li><p><a>Set input state optional pointer properties</a> with
+  arguments <var>action object</var>, <var>input state</var>.
+
  <li><p>Append a copy of <var>action object</var> with
   the <var>subtype</var> property changed to <var>pointerUp</var> to
   the <a>current session</a>’s <a>input cancel list</a>.
@@ -8258,7 +8297,9 @@ Return <a>success</a> with data <var>action</var>.
   numbered <var>button</var> on the pointer with ID
   <var>source id</var>, having type <var>pointerType</var> at
   viewport x coordinate <var>x</var>, viewport y
-  coordinate <var>y</var>, with buttons <var>buttons</var> depressed
+  coordinate <var>y</var>, with buttons <var>buttons</var> depressed,
+  and type specific properties set to the <var>input state</var>’s
+  <a>optional pointer properties</a> that are not <a>null</a>,
   in accordance with the requirements of [[!UI-EVENTS]] and
   [[!POINTER-EVENTS]]. The generated events must
   set <code>ctrlKey</code>, <code>shiftKey</code>, <code>altKey</code>,
@@ -8296,6 +8337,9 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Let <var>y</var> be equal to <var>input state</var>’s
   <code>y</code> property.
 
+ <li><p><a>Set input state optional pointer properties</a> with
+  arguments <var>action object</var>, <var>input state</var>.
+
  <li><p>Remove <var>button</var> from the set corresponding
   to <var>input state</var>’s <code>pressed</code> property, and
   let <var>buttons</var> be the resulting value of that
@@ -8307,6 +8351,8 @@ Return <a>success</a> with data <var>action</var>.
   <var>source id</var> having type <var>pointerType</var> at
   viewport x coordinate <var>x</var>, viewport y
   coordinate <var>y</var>, with buttons <var>buttons</var> depressed,
+  and type specific properties set to the <var>input state</var>’s
+  <a>optional pointer properties</a> that are not <a>null</a>,
   in accordance with the requirements of [[!UI-EVENTS]] and
   [[!POINTER-EVENTS]].  The generated events must
   set <code>ctrlKey</code>, <code>shiftKey</code>, <code>altKey</code>,
@@ -8384,6 +8430,9 @@ Return <a>success</a> with data <var>action</var>.
   return <a>error</a> with error code <a>move target out of
   bounds</a>.
 
+ <li><p><a>Set input state optional pointer properties</a> with
+  arguments <var>action object</var>, <var>input state</var>.
+
  <li><p>Let <var>duration</var> be equal to
   <var>action object</var>’s <code>duration</code> property if it
   is not <a>undefined</a>, or <var>tick duration</var>
@@ -8455,7 +8504,9 @@ Return <a>success</a> with data <var>action</var>.
     viewport x coordinate <var>current x</var>, viewport y
     coordinate <var>y</var> to viewport x coordinate <var>x</var> and
     viewport y coordinate <var>y</var>, with
-    buttons <var>buttons</var> depressed, in accordance with the
+    buttons <var>buttons</var> depressed, and type specific properties
+    set to the <var>input state</var>’s <a>optional pointer properties</a>
+    that are not <a>null</a>, in accordance with the
     requirements of [[!UI-EVENTS]] and [[!POINTER-EVENTS]]. The
     generated events must set <code>ctrlKey</code>, <code>shiftKey</code>,
     <code>altKey</code>, and <code>metaKey</code> from the
@@ -8506,6 +8557,54 @@ Return <a>success</a> with data <var>action</var>.
     <var>target y</var>.
  </ol>
 
+</ol>
+
+<p>When required to <dfn>set input state optional pointer properties</dfn>
+ with arguments <var>action object</var>, <var>input state</var>,
+ an implementation must run the following steps:
+
+<ol>
+ <li><p>Let <var>width</var> be equal to
+  <var>action object</var>’s <code>width</code> property.
+
+ <li><p>If <var>width</var> is not <a>undefined</a>, let <var>input state</var>’s
+  <code>width</code> property equal <var>width</var>.
+
+ <li><p>Let <var>height</var> be equal to
+  <var>action object</var>’s <code>height</code> property.
+
+ <li><p>If <var>height</var> is not <a>undefined</a>, let <var>input state</var>’s
+  <code>height</code> property equal <var>height</var>.
+
+ <li><p>Let <var>pressure</var> be equal to
+  <var>action object</var>’s <code>pressure</code> property.
+
+ <li><p>If <var>pressure</var> is not <a>undefined</a>, let <var>input state</var>’s
+  <code>pressure</code> property equal <var>pressure</var>.
+
+ <li><p>Let <var>tangentialPressure</var> be equal to
+  <var>action object</var>’s <code>tangentialPressure</code> property.
+
+ <li><p>If <var>tangentialPressure</var> is not <a>undefined</a>, let <var>input state</var>’s
+  <code>tangentialPressure</code> property equal <var>tangentialPressure</var>.
+
+ <li><p>Let <var>tiltX</var> be equal to
+  <var>action object</var>’s <code>tiltX</code> property.
+
+ <li><p>If <var>tiltX</var> is not <a>undefined</a>, let <var>input state</var>’s
+  <code>tiltX</code> property equal <var>tiltX</var>.
+
+ <li><p>Let <var>tiltY</var> be equal to
+  <var>action object</var>’s <code>tiltY</code> property.
+
+ <li><p>If <var>tiltY</var> is not <a>undefined</a>, let <var>input state</var>’s
+  <code>tiltY</code> property equal <var>tiltY</var>.
+
+ <li><p>Let <var>twist</var> be equal to
+  <var>action object</var>’s <code>twist</code> property.
+
+ <li><p>If <var>twist</var> is not <a>undefined</a>, let <var>input state</var>’s
+  <code>twist</code> property equal <var>twist</var>.
 </ol>
 
 <p>When required to <dfn>dispatch a pointerCancel action</dfn> with

--- a/index.html
+++ b/index.html
@@ -196,6 +196,10 @@ An <dfn>integer</dfn> is a <a>Number</a> that is unchanged
 under the <a>ToInteger</a> operation.
 
 <p>
+A <dfn>floating-point number</dfn> is a <a>Number</a> that is
+produced by the <a>parseFloat</a> operation.
+
+<p>
 The <dfn>initial value</dfn> of an ECMAScript property
 is the value defined by the platform for that property,
 i.e. the value it would have in the absence of any shadowing by content script.
@@ -6894,8 +6898,7 @@ describe the state associated with each <a>input source</a>.
  and <code>alt</code>, <code>shift</code>, <code>ctrl</code>,
  and <code>meta</code> all set to <code>false</code>.
 
-<p>
-A <a>pointer input source</a>’s <a>input source state</a>
+<p>A <a>pointer input source</a>’s <a>input source state</a>
 is a <dfn>pointer input state</dfn> object.
 This consists of a <code>subtype</code> property,
 which has the possible values
@@ -6905,12 +6908,20 @@ and "<code>touch</code>",
 a <code>pressed</code> property which is a set of unsigned integers,
 an <code>x</code> property which is an unsigned integer,
 and a <code>y</code> property which is an unsigned integer.
+Additionally, it also contains optional properties
+<code>width</code>, <code>height</code>, <code>pressure</code>, and
+<code>tangentialPressure</code> which are floating-point numbers, and
+<code>tiltX</code>, <code>tiltY</code>, and <code>twist</code> which
+are integers in accordance with the requirements of [[!POINTER-EVENTS]].
 
 <p>When required to <dfn>create a new pointer input state</dfn> object
  with arguments <var>subtype</var> an implementation must return
  a <a>pointer input state</a> object with <code>subtype</code> set
- to <var>subtype</var>, <code>pressed</code> set to an empty set and
- both <code>x</code> and <code>y</code> set to <code>0</code>.
+ to <var>subtype</var>, <code>pressed</code> set to an empty set,
+ both <code>x</code> and <code>y</code> set to <code>0</code>, and
+ <code>width</code>, <code>height</code>, <code>pressure</code>,
+ <code>tangentialPressure</code>, <code>tiltX</code>, <code>tiltY</code>,
+ and <code>twist</code> are set to null.
 
 <p>Each <a>session</a> has an associated <dfn>input state table</dfn>.
  This is a map between <a>input id</a>
@@ -7032,7 +7043,7 @@ In particular, the dispatched events
 will have the <a><code>isTrusted</code></a> attribute set to true.
 
 <p>
-The most robust way to despatch these events
+The most robust way to dispatch these events
 is by creating them in the browser implementation itself.
 Sending operating system specific input messages to the browser’s window
 has the disadvantage that the browser being automated
@@ -7393,6 +7404,12 @@ If <var>subtype</var> is "<code>pointerMove</code>"
 If doing so results in an <a>error</a>, return that <a>error</a>.
 
 <li><p>
+If <var>subtype</var> is "<code>pointerUp</code>" or "<code>pointerDown</code>"
+or "<code>pointerMove</code>", <a>process optional pointer properties</a> with
+arguments <var>action item</var> and <var>action</var>.
+If doing so results in an <a>error</a>, return that <a>error</a>.
+
+<li><p>
 If <var>subtype</var> is "<code>pointerCancel</code>"
 <span class=issue>process a pointer cancel action</span>.
 If doing so results in an <a>error</a>, return that <a>error</a>.
@@ -7491,6 +7508,132 @@ Return <a>success</a> with data <var>action</var>.
 
  <li><p>Set the <code>y</code> property of <var>action</var>
   to <var>y</var>.
+
+ <li><p>Return success with data <a>null</a>.
+</ol>
+
+<p>When required to <dfn>process optional pointer properties</dfn>
+ with arguments <var>action item</var>, and <var>action</var>, a
+ <a>remote end</a> must run the following steps in accordance with
+ the requirements of [[!POINTER-EVENTS]]:</p>
+
+<ol>
+ <li><p>Let <var>width</var> be the result
+  of getting the property <code>width</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>width</var> is not <a>undefined</a>:
+
+  <ol>
+   <li><p>
+   If <var>width</var> is not a <a>Floating-Point Number</a> greater than or equal to 1,
+   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+   <li><p>
+   Set the <code>width</code> property of <var>action</var>
+   to <var>width</var>.
+  </ol>
+
+ <li><p>Let <var>height</var> be the result
+  of getting the property <code>height</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>height</var> is not <a>undefined</a>:
+
+  <ol>
+   <li><p>
+   If <var>height</var> is not a <a>Floating-Point Number</a> greater than or equal to 1,
+   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+   <li><p>
+   Set the <code>height</code> property of <var>action</var>
+   to <var>height</var>.
+  </ol>
+
+ <li><p>If <var>width</var> is not <a>undefined</a> while
+  <var>height</var> is <a>undefined</a> or vice versa
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Let <var>pressure</var> be the result
+  of getting the property <code>pressure</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>pressure</var> is not <a>undefined</a>:
+
+  <ol>
+   <li><p>
+   If <var>pressure</var> is not a <a>Floating-Point Number</a> in the range of [0, 1]
+   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+   <li><p>
+   Set the <code>pressure</code> property of <var>action</var>
+   to <var>pressure</var>.
+  </ol>
+
+ <li><p>Let <var>tangentialPressure</var> be the result
+  of getting the property <code>tangentialPressure</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>tangentialPressure</var> is not <a>undefined</a>:
+
+  <ol>
+   <li><p>
+   If <var>tangentialPressure</var> is not a <a>Floating-Point Number</a>
+   in the range of [-1, 1]
+   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+   <li><p>
+   Set the <code>tangentialPressure</code> property of <var>action</var>
+   to <var>tangentialPressure</var>.
+  </ol>
+
+ <li><p>Let <var>tiltX</var> be the result
+  of getting the property <code>tiltX</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>tiltX</var> is not <a>undefined</a>:
+
+  <ol>
+   <li><p>
+   If <var>tiltX</var> is not an <a>Integer</a> in the range of [-90, 90]
+   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+   <li><p>
+   Set the <code>tiltX</code> property of <var>action</var>
+   to <var>tiltX</var>.
+  </ol>
+
+ <li><p>Let <var>tiltY</var> be the result
+  of getting the property <code>tiltY</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>tiltY</var> is not <a>undefined</a>:
+
+  <ol>
+   <li><p>
+   If <var>tiltY</var> is not an <a>Integer</a> in the range of [-90, 90]
+   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+   <li><p>
+   Set the <code>tiltY</code> property of <var>action</var>
+   to <var>tiltY</var>.
+  </ol>
+
+ <li><p>Let <var>twist</var> be the result
+  of getting the property <code>twist</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>twist</var> is not <a>undefined</a>:
+
+  <ol>
+   <li><p>
+   If <var>twist</var> is not an <a>Integer</a> in the range of [0, 359]
+   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+   <li><p>
+   Set the <code>twist</code> property of <var>action</var>
+   to <var>twist</var>.
+  </ol>
 
  <li><p>Return success with data <a>null</a>.
 </ol>
@@ -9174,6 +9317,7 @@ This standard is authored by
 <!-- Randall Kent --> Randall Kent,
 <!-- Seva Lotoshnikov --> Seva Lotoshnikov,
 <!-- Simon Stewart --> <a href=http://www.rocketpoweredjetpants.com/>Simon Stewart</a>,
+<!-- Timotius Arya Margo --> Timotius Arya Margo,
 <!-- Titus Fortner --> Titus Fortner,
 <!-- Vangelis Katsikaros --> and Vangelis Katsikaros.
 


### PR DESCRIPTION
actions: add additional pointer properties

Add pointer additional properties such as pressure, contact geometry, tilt, etc. to the WebDriver pointer actions in accordance with the latest W3C PointerEvent interface. This additional properties enables automating/simulating new interactions with pointer devices like touch and pen.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/timotiusmargo/webdriver/pull/1396.html" title="Last updated on Feb 6, 2019, 6:34 AM UTC (ee208e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1396/b16bbbd...timotiusmargo:ee208e3.html" title="Last updated on Feb 6, 2019, 6:34 AM UTC (ee208e3)">Diff</a>