### PR TITLE
Fix link to fragment serializing algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -9301,7 +9301,7 @@ to automatically sort each list alphabetically.
  <dt>DOM Parsing
  <dd><p>The following terms are defined in the DOM Parsing and Serialization Specification: [[!DOMPARSING]]
   <ul>
-   <li><!-- Fragment serializing algorithm --><dfn><a href="https://w3c.github.io/DOM-Parsing/#dfn-fragment-parsing-algorithm">Fragment serializing algorithm</a></dfn>
+   <li><!-- Fragment serializing algorithm --><dfn><a href="https://w3c.github.io/DOM-Parsing/#dfn-fragment-serializing-algorithm">Fragment serializing algorithm</a></dfn>
   </ul>
  </dd>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JohnChen0/webdriver/pull/1397.html" title="Last updated on Feb 9, 2019, 12:12 AM UTC (30b3525)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1397/b16bbbd...JohnChen0:30b3525.html" title="Last updated on Feb 9, 2019, 12:12 AM UTC (30b3525)">Diff</a>