### PR TITLE
Clarify how a response is constructed.

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,9 +582,10 @@ when it receives a particular <a>command</a>.
    <dd>"<code>no-cache</code>"
   </dl>
 
- <li><p>Let <var>response</var>’s <a>body</a> be a JSON <a>Object</a>
-  with a key "<code>value</code>"
-  set to the <a>JSON serialization</a> of <var>data</var>.
+ <li><p>Let <var>response</var>’s <a>body</a> be the UTF-8
+  encoded <a>JSON serialization</a> of a JSON <a>Object</a> with a key
+  "<code>value</code>" set to <var>data</var>. It is valid for the
+  constructed JSON <a>Object</a> to have more keys than this.
 
  <li><p>Let <var>response bytes</var> be the byte sequence resulting
   from serializing <var>response</var> according to the rules in [[!RFC7230]].

--- a/index.html
+++ b/index.html
@@ -582,10 +582,10 @@ when it receives a particular <a>command</a>.
    <dd>"<code>no-cache</code>"
   </dl>
 
- <li><p>Let <var>response</var>’s <a>body</a> be the UTF-8
-  encoded <a>JSON serialization</a> of a JSON <a>Object</a> with a key
-  "<code>value</code>" set to <var>data</var>. It is valid for the
-  constructed JSON <a>Object</a> to have more keys than this.
+ <li><p>Let <var>response</var>’s <a>body</a> be
+  the <a data-lt="utf-8 encode">UTF-8 encoded</a> <a>JSON
+  serialization</a> of a JSON <a>Object</a> with a key
+  "<code>value</code>" set to <var>data</var>.
 
  <li><p>Let <var>response bytes</var> be the byte sequence resulting
   from serializing <var>response</var> according to the rules in [[!RFC7230]].
@@ -9358,6 +9358,12 @@ to automatically sort each list alphabetically.
    <!-- Stringify --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-15.12.3>[[\Stringify]]</a></dfn>
    <!-- ToInteger --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/6.0/#sec-tointeger>ToInteger</a></dfn>
    <!-- undefined --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-4.3.9>Undefined</a></dfn>
+  </ul>
+
+ <dt>Encoding
+ <dd><p>The following terms are defined in the WHATWG Encoding specification: [[!ENCODING]]
+  <ul>
+   <!-- UTF-8 Encode --> <li><dfn><a href="https://encoding.spec.whatwg.org/#utf-8-encode">UTF-8 Encode</a></dfn>
   </ul>
 
  <dt>Fetch


### PR DESCRIPTION
As currently worded, the response's value may be double
JSON-encoded, which is far from ideal. We also fail to
state that the bytes must be UTF-8 encoded.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shs96c/webdriver-1/pull/1404.html" title="Last updated on Mar 21, 2019, 12:04 AM UTC (c41c371)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1404/4280c91...shs96c:c41c371.html" title="Last updated on Mar 21, 2019, 12:04 AM UTC (c41c371)">Diff</a>