### PR TITLE
 Add new Dispatching Action "Wheel" #1409

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-doctype html>
+<!doctype html>
 <html
  data-issue-url="https://github.com/w3c/webdriver/"
  data-issue-param-milestone="Level 1">
@@ -8397,7 +8397,7 @@ Return <a>success</a> with data <var>action</var>.
   set <code>ctrlKey</code>, <code>shiftKey</code>, <code>altKey</code>,
   and <code>metaKey</code> from the <a>calculated global key state</a>.
   Type specific properties for the pointer that are not 
-  exposed through the webdriver API must be set to the default value
+  exposed through the WebDriver API must be set to the default value
   specified for hardware that doesn't support that property.
 
  <li><p>Return <a>success</a> with data <a>null</a>.

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+doctype html>
 <html
  data-issue-url="https://github.com/w3c/webdriver/"
  data-issue-param-milestone="Level 1">
@@ -7612,6 +7612,7 @@ Return <a>success</a> with data <var>action</var>.
 <tr><td>"<code>pointer</code>"	<td>"<code>pointerDown</code>"		<td><a>Dispatch a pointerDown action</a>
 <tr><td>"<code>pointer</code>"	<td>"<code>pointerUp</code>"		<td><a>Dispatch a pointerUp action</a>
 <tr><td>"<code>pointer</code>"	<td>"<code>pointerMove</code>		<td><a>Dispatch a pointerMove action</a>
+<tr><td>"<code>pointer</code>"	<td>"<code>pointerWheel</code>		<td><a>Dispatch a pointerWheel action</a>
 <tr><td>"<code>pointer</code>"	<td>"<code>pointerCancel</code>		<td><a>Dispatch a pointerCancel action</a>
 </table>
 
@@ -8364,6 +8365,42 @@ Return <a>success</a> with data <var>action</var>.
     <var>target y</var>.
  </ol>
 
+</ol>
+
+<p>When required to <dfn>dispatch a pointerWheel action</dfn> with
+ arguments <var>source id</var>, <var>action object</var>,
+ <var>input state</var> and <var>tick duration</var> a
+ <a>remote end</a> must run the following steps:
+
+<ol>
+ <li><p>Let <var>delta x</var> be equal to the <code>x</code>
+  property of <var>action object</var>.
+
+ <li><p>Let <var>delta y</var> be equal to the <code>y</code>
+  property of <var>action object</var>.
+
+ <li><p>Let <var>delta z</var> be equal to the <code>z</code>
+  property of <var>action object</var>.
+
+ <li><p>Let <var>mode</var> be equal to the <code>mode</code>
+  property of <var>action object</var>.
+
+ <li><p><a data-lt=perform-actions>Perform implementation-specific 
+  action dispatch steps</a> equivalent to spinning a wheel with
+  vector magnitude (<var>delta x</var>, <var>delta y</var>, 
+  <var>delta z</var>) for one tick on the pointer of ID
+  <var>source id</var> having type <var>pointerType</var> at
+  viewport x coordinate <var>x</var>, viewport y
+  coordinate <var>y</var>, with buttons <var>buttons</var> depressed,
+  in accordance with the requirements of [[!UI-EVENTS]] and
+  [[!POINTER-EVENTS]].  The generated events must
+  set <code>ctrlKey</code>, <code>shiftKey</code>, <code>altKey</code>,
+  and <code>metaKey</code> from the <a>calculated global key state</a>.
+  Type specific properties for the pointer that are not 
+  exposed through the webdriver API must be set to the default value
+  specified for hardware that doesn't support that property.
+
+ <li><p>Return <a>success</a> with data <a>null</a>.
 </ol>
 
 <p>When required to <dfn>dispatch a pointerCancel action</dfn> with


### PR DESCRIPTION
When testing websites a developer may wish to test a WheelEvent. I propose that we add a new "pointerWheel" subtype to the "pointer" action. Then there would be a "pointer wheel" action with arguments "action item" and "action". We could then let "delta_x", "delta_y", and "delta_z" be the results of getting the properties delta_x, delta_y, and delta_z from "action item".

One alternative would be to create a new source type "wheel" alongside "none", "key", and "pointer". The only issue I see with this alternative is "wheel" would only have one subtype, "scroll" (and pause but that's irrelevant). Other than that problem, this seems almost entirely a bikeshed argument. Do we want more source types or more subtypes?

Copied from #1409


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/robert-snakard/webdriver/pull/1410.html" title="Last updated on May 8, 2019, 9:10 PM UTC (76c136b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1410/b7c6791...robert-snakard:76c136b.html" title="Last updated on May 8, 2019, 9:10 PM UTC (76c136b)">Diff</a>