### PR TITLE
Remove old JSON web-element clone line

### DIFF
--- a/index.html
+++ b/index.html
@@ -5942,10 +5942,6 @@ a <a>remote end</a> must run the following steps:
  <dt>type <a>String</a>
  <dd><p><a>Success</a> with data <var>value</var>.
 
-  <p>Otherwise, return <a>success</a>
-   with the <a data-lt="JSON serialization of an element">serialization to JSON</a>
-   of the <a>web element</a> <var>value</var>.
-
  <dt>a <a>collection</a>
  <dd>
   <ol>


### PR DESCRIPTION
In the JSON internal clone algorithm (#dfn-internal-json-clone-algorithm),
there is an "Otherwise" statement that is not preceded by an "if".

This is likely leftover line that was not deleted when web-element
cloning was moved later in the algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rohpavone/webdriver/pull/1420.html" title="Last updated on May 3, 2019, 10:21 PM UTC (465f98a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1420/b7c6791...rohpavone:465f98a.html" title="Last updated on May 3, 2019, 10:21 PM UTC (465f98a)">Diff</a>