### PR TITLE
Correct specification of parallel operations

### DIFF
--- a/index.html
+++ b/index.html
@@ -6066,12 +6066,13 @@ a <a>remote end</a> must run the following steps:
   and <var>arguments</var>.
 </ol>
 
-<p>The rules to <dfn>execute a function body</dfn> are as follows.
- The algorithm returns <a data-lt="completion">an ECMASCript completion record</a>.
+<p>When required to <dfn>execute a function body</dfn> with arguments
+ <var>body</var>, <var>arguments</var>, and <var>async</var>, the
+ implementation must:
 
 <p>If at any point during the algorithm a <a>user prompt</a> appears,
  abort all subsequent substeps of this algorithm, and return
- <a>Completion</a> { [[\Type]]: <code>normal</code>, [[\Value]]: <a><code>null</code></a>, [[\Target]]: <code>empty</code> }.
+ <a>success</a> with data <a><code>null</code></a>.
 
 <ol>
  <li><p>Let <var>window</var> be the <a>associated window</a>
@@ -6086,8 +6087,7 @@ a <a>remote end</a> must run the following steps:
 
  <li><p>If <var>body</var> is not parsable as a <a>FunctionBody</a>
   or if parsing detects an <a>early error</a>,
-  return
-  <a>Completion</a> { [[\Type]]: <code>normal</code>, [[\Value]]: <a><code>null</code></a>, [[\Target]]: <code>empty</code> }.
+  return <a>error</a> with <a>error code</a> <a>javascript error</a>.
 
  <li><p>If <var>body</var> begins with a <a>directive prologue</a>
   that contains a <a>use strict directive</a>
@@ -6097,6 +6097,17 @@ a <a>remote end</a> must run the following steps:
  <li><p><a>Prepare to run a script</a> with <var>environment settings</var>.
 
  <li><p><a>Prepare to run a callback</a> with <var>environment settings</var>.
+
+ <li><p>Let <var>promise</var> be <a>a new Promise</a>.
+
+ <li><p>If <var>async</var> is <code>true</code>:
+
+ <ol>
+  <li><p>Let <var>resolvingFunctions</var> be <a>CreateResolvingFunctions</a>(<var>promise</var>).
+
+  <li><p>Append <var>resolvingFunctions</var><code>.[[\Resolve]]</code></var>
+   to <var>arguments</var>.
+ </ol>
 
  <li><p>Let <var>function</var> be the result of
   calling <a>FunctionCreate</a>, with arguments:
@@ -6121,7 +6132,37 @@ a <a>remote end</a> must run the following steps:
  <li><p>Let <var>completion</var> be
   <a>Call</a>(<var>function</var>,
   <var>window</var>,
-  <var>parameters</var>).
+  <var>arguments</var>).
+
+ <li><p>If <var>completion</var>.[[\Type]] is <code>throw</code>,
+  <a>reject</a> <var>promise</var> with <var>completion</var>.[[\Value]].
+
+ <li><p>Otherwise, if <var>async</var> is <code>false</code>,
+  <a>resolve</a> <var>promise</var> with <var>completion</var>.[[\Value]].
+
+ <li><p>Otherwise,
+
+ <ol>
+  <p class=note>Prior revisions of this specification did not recognize the
+    return value of the provided script. In order to preserve legacy behavior,
+    the return value only influences this algorithm if it is a "thenable" object or
+    if determining this produces an exception.
+
+  <li><p>If <a data-lt="ecmascript type">Type</a>(<var>completion</var>.[[\Value]])
+    is <a>Object</a>:
+
+  <ol>
+   <li><p>Let <var>then</var> be <a>Get</a>(<var>completion</var>.[[\Value]], "then").
+
+   <li><p>If <var>then</var>.[[\Type]] is not <code>normal</code>, then <a>reject</a>
+     <var>promise</var> with value <var>then</var>.[[\Value]].
+
+   <li><p>Otherwise, if <a>IsCallable</a>(<var>then</var>.[[\Value]]) is
+    <code>true</code>, then <a>resolve</a> <var>promise</var> with <var>completion</var>.[[\Value]].
+  </ol>
+ </ol>
+
+ <li><p>Wait for <var>promise</var> to settle.
 
  <li><p><a>Clean up after running a callback</a>
   with <var>environment settings</var>.
@@ -6129,7 +6170,20 @@ a <a>remote end</a> must run the following steps:
  <li><p><a>Clean up after running a script</a>
   with <var>environment settings</var>.
 
- <li><p>Return <var>completion</var>.
+ <li><p>If <var>promise</var> rejected:
+
+ <ol>
+  <li><p>Let <var>result</var> be the result of <a>trying</a> to
+   <a>JSON clone</a> the rejection value of <var>promise</var>.
+
+  <li><p>Return <a>error</a> with <a>error code</a> <a>javascript error</a>
+   and data <var>result</var>.
+ </ol>
+
+ <li><p>Let <var>result</var> be the result of <a>trying</a> to
+  <a>JSON clone</a> the fulfillment value of <var>promise</var>.
+
+ <li><p>Return <a>success</a> with data <var>result</var>.
 </ol>
 
 <p class="note">The above algorithm is not associated
@@ -6162,33 +6216,32 @@ a <a>remote end</a> must run the following steps:
 
  <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
 
- <li><p>Let <var>promise</var> be <a>a new Promise</a>.
+ <li><p>Let <var>results</var> be a new <a>queue</a>.
 
  <li><p>Run the following substeps <a>in parallel</a>:
-   <ol>
-     <li><p>Let <var>scriptPromise</var> be the result of <a>promise-calling</a>
-        <a>execute a function body</a>, with arguments
-        <var>body</var> and <var>arguments</var>.
 
-    <li><p>Upon fulfillment of <var>scriptPromise</var> with value <var>v</var>,
-      <a>resolve</a> <var>promise</var> with value <var>v</var>.
+ <ol>
+  <li><p>Let <var>script result</var> be the result of calling
+   <a>execute a function body</a>, with arguments
+   <var>body</var>, <var>arguments</var>, and <code>false</code>.
 
-    <li><p>Upon rejection of <var>scriptPromise</var> with value <var>r</var>,
-      <a>reject</a> <var>promise</var> with value <var>r</var>.
-   </ol>
+  <li><p>Enqueue <var>script result</var> in <var>results</var>.
+ </ol>
 
-  <li><p>If <var>promise</var> is still pending and
-    the <a>session script timeout</a> is reached,
-    return <a>error</a> with <a>error code</a> <a data-lt="script timeout error">script timeout</a>.
+ <li><p>Run the following substeps <a>in parallel</a>:
 
-  <li><p>Upon fulfillment of <var>promise</var> with value <var>v</var>,
-      let <var>result</var> be a <a>JSON clone</a> of <var>v</var>, and
-      return <a>success</a> with data <var>result</var>.
+ <ol>
+  <li><p>Wait <a>session script timeout</a> milliseconds.
 
-  <li><p>Upon rejection of <var>promise</var> with reason <var>r</var>,
-      let <var>result</var> be a <a>JSON clone</a> of <var>r</var>, and
-      return <a>error</a> with <a>error code</a> <a>javascript error</a>
-      and data <var>result</var>.
+  <li><p>Enqueue <a>error</a> with <a>error code</a>
+    <a data-lt="script timeout error">script timeout</a> in <var>results</var>.
+ </ol>
+
+ <li><p>Wait for the size of <var>results</var> to be greater than 0.
+
+ <li><p>Dequeue <var>result</var> from <var>results</var>.
+
+ <li><p>Return <var>result</var>.
 </ol>
 </section> <!-- /Execute Script -->
 
@@ -6216,69 +6269,41 @@ The first argument provided to the function will be serialized to JSON and retur
 <p>The <a>remote end steps</a> are:
 
 <ol>
-  <li><p>Let <var>body</var> and <var>arguments</var> by the result of <a>trying</a> to
-     <a>extract the script arguments from a request</a> with
-     argument <var>parameters</var>.
+ <li><p>Let <var>body</var> and <var>arguments</var> be the result of
+  <a>trying</a> to <a>extract the script arguments from a request</a>
+  with argument <var>parameters</var>.
 
-  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
-   return <a>error</a> with <a>error code</a> <a>no such window</a>.
+ <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
+  return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
-   <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
+ <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
 
-  <li><p>Let <var>promise</var> be <a>a new Promise</a>.
+ <li><p>Let <var>results</var> be a new <a>queue</a>.
 
-  <li><p>Run the following substeps <a>in parallel</a>:
-  <ol>
-    <li><p>Let <var>resolvingFunctions</var> be <a>CreateResolvingFunctions</a>(<var>promise</var>).
+ <li><p>Run the following substeps <a>in parallel</a>:
 
-    <li><p>Append <var>resolvingFunctions</var><code>.[[\Resolve]]</code> to
-      <var>arguments</var>.
+ <ol>
+  <li><p>Let <var>script result</var> be the result of calling
+   <a>execute a function body</a>, with arguments
+   <var>body</var>, <var>arguments</var>, and <code>true</code>.
 
-    <li><p>Let <var>result</var> be the result of calling
-      <a>execute a function body</a>, with arguments
-      <var>body</var> and <var>arguments</var>.
+  <li><p>Enqueue <var>script result</var> in <var>results</var>.
+ </ol>
 
-    <li><p>If <var>scriptResult</var>.[[\Type]] is not <code>normal</code>, then <a>reject</a>
-      <var>promise</var> with value <var>scriptResult</var>.[[\Value]], and abort these steps.
+ <li><p>Run the following substeps <a>in parallel</a>:
 
-      <p class=note>Prior revisions of this specification did not recognize the
-        return value of the provided script. In order to preserve legacy behavior,
-        the return value only influences the command if it is a "thenable" object or
-        if determining this produces an exception.
+ <ol>
+  <li><p>Wait <a>session script timeout</a> milliseconds.
 
-    <li><p>If <a data-lt="ecmascript type">Type</a>(<var>scriptResult</var>.[[\Value]])
-      is not <a>Object</a>, then abort these steps.
+  <li><p>Enqueue <a>error</a> with <a>error code</a>
+   <a data-lt="script timeout error">script timeout</a> in <var>results</var>.
+ </ol>
 
-    <li><p>Let <var>then</var> be <a>Get</a>(<var>scriptResult</var>.[[\Value]], "then").
+ <li><p>Wait for the size of <var>results</var> to be greater than 0.
 
-    <li><p>If <var>then</var>.[[\Type]] is not <code>normal</code>, then <a>reject</a>
-      <var>promise</var> with value <var>then</var>.[[\Value]], and abort these steps.
+ <li><p>Dequeue <var>result</var> from <var>results</var>.
 
-    <li><p>If <a>IsCallable</a>(<var>then</var>.[[\Type]]) is <code>false</code>,
-      then abort these steps.
-
-    <li><p>Let <var>scriptPromise</var> be <a>PromiseResolve</a>(<a>Promise</a>,
-      <var>scriptResult</var>.[[\Value]]).
-
-    <li><p>Upon fulfillment of <var>scriptPromise</var> with value <var>v</var>,
-      <a>resolve</a> <var>promise</var> with value <var>v</var>.
-
-    <li><p>Upon rejection of <var>scriptPromise</var> with value <var>r</var>,
-      <a>reject</a> <var>promise</var> with value <var>r</var>.
-  </ol>
-
-  <li><p>If <var>promise</var> is still pending and
-   <a>session script timeout</a> milliseconds is reached,
-   return <a>error</a> with <a>error code</a> <a data-lt="script timeout error">script timeout</a>.
-
-  <li><p>Upon fulfillment of <var>promise</var> with value <var>v</var>,
-      let <var>result</var> be a <a>JSON clone</a> of <var>v</var>, and
-      return <a>success</a> with data <var>result</var>.
-
-  <li><p>Upon rejection of <var>promise</var> with reason <var>r</var>,
-      let <var>result</var> be a <a>JSON clone</a> of <var>r</var>, and
-      return <a>error</a> with <a>error code</a> <a>javascript error</a>
-      and data <var>result</var>.
+ <li><p>Return <var>result</var>.
 </ol>
 </section> <!-- /Execute Async Script -->
 </section> <!-- /Executing Script -->
@@ -9299,7 +9324,6 @@ to automatically sort each list alphabetically.
  <dd><p>The following terms are defined in the ECMAScript Language Specification: [[ECMA-262]]
   <ul>
     <!-- Iterable --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-iterable-interface>Iterable</a></dfn>
-   <!-- Completion --> <li><dfn><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">Completion</a></dfn>
    <!-- CreateResolvingFunctions --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-createresolvingfunctions>CreateResolvingFunctions</a></dfn>
    <!-- Directive prologue --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-14.1>Directive prologue</a></dfn>
    <!-- Early error --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-16>Early error</a></dfn>


### PR DESCRIPTION
Prior to this patch, parallelism in the Execute Script and Execute Async
Script commands was expressed in terms of ECMAScript promises. This was
ambiguous because in HTML, Promises rely on an environment settings
object [1], and such an object is not generally available in the
WebDriver execution context.

Refactor the command algorithms to instead manage parallel execution
using the generic "queue" primitive from the Infra specification.
Refactor the "execute a function body" algorithm to use Promises, where
following the invocation of "prepare to run a script," an environment
settings object is available.

[1] https://html.spec.whatwg.org/#integration-with-the-javascript-job-queue


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver/pull/1431.html" title="Last updated on Jul 6, 2019, 2:04 AM UTC (8202fd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1431/29c5f74...bocoup:8202fd0.html" title="Last updated on Jul 6, 2019, 2:04 AM UTC (8202fd0)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1431)
<!-- Reviewable:end -->
