### PR TITLE
Introduce "Accessible Name" locator strategy

### DIFF
--- a/index.html
+++ b/index.html
@@ -4267,6 +4267,11 @@ argument <var>reference</var>, run the following steps:
   <td><a>XPath selector</a>
   <td>"<code>xpath</code>"
  </tr>
+
+ <tr>
+  <td><a>Accessible name</a>
+  <td>"<code>accessible name</code>"
+ </tr>
 </table>
 
 <section>
@@ -4421,6 +4426,15 @@ argument <var>reference</var>, run the following steps:
 
 </ol>
 </section> <!-- /XPath -->
+
+<section>
+<h5>Accessible name</h5>
+
+<p>To find a <a>web element</a> with the <dfn>Accessible
+ Name</dfn> <a>strategy</a> return <a>success</a> with data set to ???.
+ <span class="issue">Can the accessibility tree be queried here? Can the result
+ be mapped back to a DOM element?</span>
+</section> <!-- /Accessible name -->
 </section> <!-- /Locator strategies -->
 
 <section>


### PR DESCRIPTION
[At TPAC 2019, folks working in ARIA and WebDriver discussed ways to extend WebDriver in order to help web developers learn and enforce best practices in accessibility.](https://www.w3.org/2019/09/16-aria-minutes.html) While discussing the prospect of new commands based on [the APG](https://w3c.github.io/aria-practices/), a more generic feature came up: the ability to select elements according to [accessible name](https://w3c.github.io/accname/).

Today, it's easy for web developers to write UI tests with a "whatever works" mindset. [Without a good amount of experience and forethought](https://bocoup.com/blog/accessibility-for-robots), the CSS selectors they choose to target elements can easily be broken by benign refactoring. In order to keep their tests passing, developers have to perform the additional maintenance work of updating selectors. Not only is this distracting and inefficient, but it's somewhat dangerous. Editing tests while refactoring diminishes developers' ability to verify equivalent functionality and increases the likelihood of regression.

Because an element's accessible name is directly exposed to end users, it is less subject to change than many of the implementation details upon which a CSS selector can rely. Web developers could use a locator strategy based on this to write tests that are more resilient to changes in their application code.

Like many accessibility best practices, web developers don't always use accessible names correctly (or at all). The promise of more resilient tests could help incentivize developers to make their applications more accessible in this way.

There are some concerns about exposing this capability to the DOM generally, both in terms of performance and security. @minorninth and @alice (the principle contributors to [the Accessibility Object Model](https://github.com/WICG/aom)) can probably speak more to that. It's my understanding that integration with WebDriver is much more feasible. At TPAC, @cookiecrook mentioned that this WebKit and/or Safari already make this available in some privileged context.

Could a "accessible name" locator strategy fit in the WebDriver specification? If so, is there some existing algorithm we can reference?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver/pull/1440.html" title="Last updated on Sep 18, 2019, 6:43 PM UTC (087d4ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1440/29c5f74...bocoup:087d4ec.html" title="Last updated on Sep 18, 2019, 6:43 PM UTC (087d4ec)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1440)
<!-- Reviewable:end -->
