### PR TITLE
modify spec to account for editible content that already has focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -8951,8 +8951,6 @@ sets the text field of a <a>window.<code>prompt</code></a>
  <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
- <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
-
  <li><p>When the user agent is next to <a>run the animation frame callbacks</a>:
   <ol>
    <li><p>Let <var>root rect</var> be the <a>current top-level browsing context</a>’s

--- a/index.html
+++ b/index.html
@@ -9002,6 +9002,7 @@ that evaluates to false, the <a>element</a> will not be <a>scrolled into view</a
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
  
+  
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
  
  <li><p>Let <var>element</var> be the result of

--- a/index.html
+++ b/index.html
@@ -5800,20 +5800,24 @@ If an <a>error</a> is returned, return that <a>error</a>
    </dd>
 
    <dt><var><a>element</a></var> is <a>content editable</a>
-   <dd>Set the text insertion caret after any child content.
-
-   <dt>Otherwise
-   <dd>
-    <ol>
-     <li><p>Let <var>current text length</var> be the <a>JavaScript
-      string’s length</a> of <var><a>element</a></var>’s <a>API value</a>.
-
-     <li><p>Set the text insertion caret using <a>set selection range</a>
-      using <var>current text length</var> for both the <code>start</code>
-      and <code>end</code> parameters.
+    <dd><ol><li><p>If <var>element</var> has focus, do not modify the 
+     text insertion caret.
+     <li><p>Else, set the text insertion caret after any child content.
     </ol>
-   </dd>
-  </dl>
+    <dt>Otherwise
+    <dd>
+     <ol>
+       <li><p>If <var>element</var> has focus, do not modify the
+         text insertion caret.
+      <li><p>Else, let <var>current text length</var> be the <a>JavaScript
+       string’s length</a> of <var><a>element</a></var>’s <a>API value</a>.
+ 
+      <li><p>Set the text insertion caret using <a>set selection range</a>
+       using <var>current text length</var> for both the <code>start</code>
+       and <code>end</code> parameters.
+     </ol>
+    </dd>
+   </dl>
 
  <li><p>Let <var>keyboard</var> be a new <a>key input source</a>.
 

--- a/index.html
+++ b/index.html
@@ -8946,6 +8946,8 @@ sets the text field of a <a>window.<code>prompt</code></a>
  <li><p>If the <a>current top-level browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
+ <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
+
  <li><p>When the user agent is next to <a>run the animation frame callbacks</a>:
   <ol>
    <li><p>Let <var>root rect</var> be the <a>current top-level browsing context</a>’s
@@ -8999,7 +9001,9 @@ that evaluates to false, the <a>element</a> will not be <a>scrolled into view</a
 
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
-
+ 
+ <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
+ 
  <li><p>Let <var>element</var> be the result of
   <a>trying</a> to <a>get a known connected element</a>
   with <a>url variable</a> <var>element id</var>.

--- a/index.html
+++ b/index.html
@@ -5800,16 +5800,13 @@ If an <a>error</a> is returned, return that <a>error</a>
    </dd>
 
    <dt><var><a>element</a></var> is <a>content editable</a>
-    <dd><ol><li><p>If <var>element</var> has focus, do not modify the 
-     text insertion caret.
-     <li><p>Else, set the text insertion caret after any child content.
-    </ol>
+    <dd>If <var><a>element</a></var> does not currently have focus,
+      set the text insertion caret after any child content.
     <dt>Otherwise
     <dd>
      <ol>
-       <li><p>If <var>element</var> has focus, do not modify the
-         text insertion caret.
-      <li><p>Else, let <var>current text length</var> be the <a>JavaScript
+       <li><p>If <var>element</var> does not currently have focus, 
+        let <var>current text length</var> be the <a>JavaScript
        string’s length</a> of <var><a>element</a></var>’s <a>API value</a>.
  
       <li><p>Set the text insertion caret using <a>set selection range</a>

--- a/index.html
+++ b/index.html
@@ -9001,10 +9001,7 @@ that evaluates to false, the <a>element</a> will not be <a>scrolled into view</a
 
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
- 
-  
- <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
- 
+
  <li><p>Let <var>element</var> be the result of
   <a>trying</a> to <a>get a known connected element</a>
   with <a>url variable</a> <var>element id</var>.


### PR DESCRIPTION
https://github.com/w3c/webdriver/issues/1430 indicates that we missed the case where contentEditible and form elements may already have focus when we sendkeys() to them. We need to leave the caret where it is in those cases.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/thejohnjansen/webdriver/pull/1442.html" title="Last updated on Sep 23, 2019, 9:11 PM UTC (8af8ccd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1442/ab946e6...thejohnjansen:8af8ccd.html" title="Last updated on Sep 23, 2019, 9:11 PM UTC (8af8ccd)">Diff</a>