### PR TITLE
add support for pinning scripts in remote endpoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -6198,13 +6198,17 @@ a <a>remote end</a> must run the following steps:
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{<var>session id</var>}/execute/sync/{?<var>name</var>}</td>
+  <td>/session/{<var>session id</var>}/execute/sync</td>
  </tr>
 </table>
 
 <p>The <a>remote end steps</a> are:
 
 <ol>
+ <li><p>Let <var>name</var> be the result of
+  <a>getting a property</a> named <var>name</var>
+  from the <var>parameters</var>.
+
  <li><p>Let <var>body</var> and <var>arguments</var> be the result of
   <a>trying</a> to <a>extract the script arguments from a request</a>
   with argument <var>parameters</var>.
@@ -6254,7 +6258,7 @@ a <a>remote end</a> must run the following steps:
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{<var>session id</var>}/execute/async/{?<var>name</var>}</td>
+  <td>/session/{<var>session id</var>}/execute/async</td>
  </tr>
 </table>
 
@@ -6268,6 +6272,10 @@ The first argument provided to the function will be serialized to JSON and retur
 <p>The <a>remote end steps</a> are:
 
 <ol>
+  <li><p>Let <var>name</var> be the result of
+     <a>getting a property</a> named <var>name</var>
+     from the <var>parameters</var>.
+
   <li><p>Let <var>body</var> and <var>arguments</var> by the result of <a>trying</a> to
      <a>extract the script arguments from a request</a> with
      argument <var>parameters</var>.
@@ -6343,18 +6351,25 @@ The first argument provided to the function will be serialized to JSON and retur
   </tr>
   <tr>
    <td>POST</td>
-   <td>/session/{<var>session id</var>}/execute/pin/{<var>name</var>}</td>
+   <td>/session/{<var>session id</var>}/execute/pin</td>
   </tr>
  </table>
 
  <p>The <a>remote end steps</a> are:
 
  <ol>
+  <li><p>Let <var>name</var> be the result of
+  <a>getting a property</a> named <var>name</var>
+  from the <var>parameters</var>.
+
   <li><p>Let <var>script</var> be the result of
  <a>getting a property</a> named <var>script</var>
  from the <var>parameters</var>.
 
    <li><p>If <var>script</var> is <a>undefined</a> or is not a <a>String</a>,
+ return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+  <li><p>If <var>name</var> is <a>undefined</a> or is not a <a>String</a>,
  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
   <li><p>If <var>name</var> matches an <a>executable script name</a>

--- a/index.html
+++ b/index.html
@@ -5919,9 +5919,6 @@ of the <a>current browsing context</a> <a>active document</a>.
  associated with <var>name</var> in the <a>executable script table</a>.
 </ol>
 
-<section>
-<h3><dfn>Executing Script</dfn></h3>
-
 <p>
 A <dfn>collection</dfn> is an <a>Object</a>
 that implements the <a>Iterable</a> interface,
@@ -6190,7 +6187,6 @@ a <a>remote end</a> must run the following steps:
 <p class="note">The above algorithm is not associated
  with any particular element,
  and is therefore not subject to the document CSP <a>directives</a>.
-</section> <!-- /Executing Script -->
 
 <section>
 <h3><dfn>Execute Script</dfn></h3>

--- a/index.html
+++ b/index.html
@@ -1190,7 +1190,8 @@ when it receives a particular <a>command</a>.
   <td><dfn>no such script</dfn>
   <td>404
   <td><code>script timeout</code>
-  <td>No script matching the given script name was found amongst the list of known scripts of the current session.
+  <td>No script matching the given script name was found amongst the
+  <a>list of known scripts</a> of the current session.
  </tr>
 
  <tr>
@@ -5890,7 +5891,7 @@ of the <a>current browsing context</a> <a>active document</a>.
   <a href="#protocol">protocol</a>, between <a>remote</a> and
   <a>local</a> ends.
 
-  Each script has an associated <dfn>executable script name</dfn>
+  Each script may include an optional associated <dfn>executable script name</dfn>
   that uniquely identifies the script within the <a>current session</a>.
 
   Each <a>session</a> maintains a <dfn>list of known scripts</dfn>.
@@ -5908,8 +5909,8 @@ of the <a>current browsing context</a> <a>active document</a>.
   <a>list of known scripts</a>.
 
 
- To <dfn>get a known script</dfn> with
- argument <var>name</var>, run the following steps:
+ To <dfn>get a script</dfn> with argument <var>name</var>,
+ run the following steps:
  <ol>
  <li>If <var>name</var> does not match an <a>executable script name</a>
   in the <a>list of known scripts</a> for the <a>current session</a>,
@@ -6097,14 +6098,14 @@ a <a>remote end</a> must run the following steps:
   <a>getting a property</a> named <code>script</code>
   from the <var>parameters</var>.
 
- <li><p>If <var>script</var> is not a <a>String</a>,
-  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
-
  <li><p>If <var>script</var> is set and <var>name</var> is set,
  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
+ <li><p>If <var>script</var> is not a <a>String</a>,
+  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
  <li><p>If <var>name</var> is set let <var>script</var> be the result
- of <a>trying</a> to <a>get a known script</a> with argument <var>name</var>
+ of <a>trying</a> to <a>get a script</a> with argument <var>name</var>
 
  <li><p>Let <var>args</var> be the result of
   <a>getting a property</a> named <code>args</code>
@@ -6128,9 +6129,6 @@ a <a>remote end</a> must run the following steps:
  <a>Completion</a> { [[\Type]]: <code>normal</code>, [[\Value]]: <a><code>null</code></a>, [[\Target]]: <code>empty</code> }.
 
 <ol>
- <li><p>Let <var>window</var> be the <a>associated window</a>
-  of the <a>current browsing context</a>’s <a>active document</a>.
-
  <li><p>Let <var>environment settings</var> be
   the <a>environment settings object</a> for <var>window</var>.
 

--- a/index.html
+++ b/index.html
@@ -6129,6 +6129,9 @@ a <a>remote end</a> must run the following steps:
  <a>Completion</a> { [[\Type]]: <code>normal</code>, [[\Value]]: <a><code>null</code></a>, [[\Target]]: <code>empty</code> }.
 
 <ol>
+ <li><p>Let <var>window</var> be the <a>associated window</a>
+  of the <a>current browsing context</a>’s <a>active document</a>.
+
  <li><p>Let <var>environment settings</var> be
   the <a>environment settings object</a> for <var>window</var>.
 
@@ -6357,10 +6360,6 @@ The first argument provided to the function will be serialized to JSON and retur
 
    <li><p>If <var>script</var> is <a>undefined</a> or is not a <a>String</a>,
  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
-
-   <li><p>If the <a>current browsing context</a> is <a>no longer
- open</a>, return <a>error</a> with <a>error code</a> <a>no such
- window</a>.
 
   <li><p>If <var>name</var> matches an <a>executable script name</a>
  in the <a>list of known scripts</a> for the <a>current session</a>,

--- a/index.html
+++ b/index.html
@@ -5912,7 +5912,7 @@ of the <a>current browsing context</a> <a>active document</a>.
  To <dfn>get a script</dfn> with argument <var>name</var>,
  run the following steps:
  <ol>
- <li>If <var>name</var> does not match an <a>executable script name</a>
+ <li>If <var>name</var> is not equal to an <a>executable script name</a>
   in the <a>list of known scripts</a> for the <a>current session</a>,
   return <a>error</a> with <a>error code</a> <a>no such script</a>.
  <li>Let <var>script</var> be the <a>executable script</a>

--- a/index.html
+++ b/index.html
@@ -1187,6 +1187,13 @@ when it receives a particular <a>command</a>.
  </tr>
 
  <tr>
+  <td><dfn>no such script</dfn>
+  <td>404
+  <td><code>script timeout</code>
+  <td>No script matching the given script name was found amongst the list of known scripts of the current session.
+ </tr>
+
+ <tr>
   <td><dfn>script timeout error</dfn>
   <td>500
   <td><code>script timeout</code>
@@ -2110,6 +2117,10 @@ and <a href=#elements>element retrieval</a>.
 <p>
 A <a>session</a> has an associated <a>user prompt handler</a>.
 Unless stated otherwise it is in the <a>dismiss and notify state</a>.
+
+<p>A <a>session</a> has an associated <a>list of known scripts</a>.
+
+<p>A <a>session</a> has an associated <a>executable script table</a>.
 
 <p>A <a>session</a> has an associated list of <a>active input sources</a>.
 
@@ -5871,7 +5882,44 @@ of the <a>current browsing context</a> <a>active document</a>.
 </section> <!-- /Get Page Source -->
 
 <section>
-<h3>Executing Script</h3>
+ <h3>Scripts</h3>
+
+ <p>
+  An <dfn>executable script</dfn> is an abstraction used to
+  identify a script when it is transported via the
+  <a href="#protocol">protocol</a>, between <a>remote</a> and
+  <a>local</a> ends.
+
+  Each script has an associated <dfn>executable script name</dfn>
+  that uniquely identifies the script within the <a>current session</a>.
+
+  Each <a>session</a> maintains a <dfn>list of known scripts</dfn>.
+  This list is initially empty. When an <a>executable script name</a>
+  is added to the <a>list of known scripts</a>, a corresponding entry
+  is made in the <a>executable script table</a> where the key is the
+  <a>executable script name</a> and the value is the <var>script</var>.
+  When an <a>executable script name</a> is removed from the
+  <a>list of known scripts</a>, the corresponding entry in
+  the <a>executable script table</a> is also removed.
+
+ <p>Each <a>session</a> has an associated <dfn>executable script table</dfn>.
+  This is a map between <a>executable script name</a>
+  and the script, with one entry for each item in the
+  <a>list of known scripts</a>.
+
+
+ To <dfn>get a known script</dfn> with
+ argument <var>name</var>, run the following steps:
+ <ol>
+ <li>If <var>name</var> does not match an <a>executable script name</a>
+  in the <a>list of known scripts</a> for the <a>current session</a>,
+  return <a>error</a> with <a>error code</a> <a>no such script</a>.
+ <li>Let <var>script</var> be the <a>executable script</a>
+ associated with <var>name</var> in the <a>executable script table</a>.
+</ol>
+
+<section>
+<h3><dfn>Executing Script</dfn></h3>
 
 <p>
 A <dfn>collection</dfn> is an <a>Object</a>
@@ -6052,6 +6100,12 @@ a <a>remote end</a> must run the following steps:
  <li><p>If <var>script</var> is not a <a>String</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
+ <li><p>If <var>script</var> is set and <var>name</var> is set,
+ return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>If <var>name</var> is set let <var>script</var> be the result
+ of <a>trying</a> to <a>get a known script</a> with argument <var>name</var>
+
  <li><p>Let <var>args</var> be the result of
   <a>getting a property</a> named <code>args</code>
   from the <var>parameters</var>.
@@ -6135,6 +6189,7 @@ a <a>remote end</a> must run the following steps:
 <p class="note">The above algorithm is not associated
  with any particular element,
  and is therefore not subject to the document CSP <a>directives</a>.
+</section> <!-- /Executing Script -->
 
 <section>
 <h3><dfn>Execute Script</dfn></h3>
@@ -6146,7 +6201,7 @@ a <a>remote end</a> must run the following steps:
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{<var>session id</var>}/execute/sync</td>
+  <td>/session/{<var>session id</var>}/execute/sync/{?<var>name</var>}</td>
  </tr>
 </table>
 
@@ -6202,7 +6257,7 @@ a <a>remote end</a> must run the following steps:
  </tr>
  <tr>
   <td>POST</td>
-  <td>/session/{<var>session id</var>}/execute/async</td>
+  <td>/session/{<var>session id</var>}/execute/async/{?<var>name</var>}</td>
  </tr>
 </table>
 
@@ -6281,7 +6336,43 @@ The first argument provided to the function will be serialized to JSON and retur
       and data <var>result</var>.
 </ol>
 </section> <!-- /Execute Async Script -->
-</section> <!-- /Executing Script -->
+<section>
+ <h3><dfn>Pin Script</dfn></h3>
+
+ <table class="simple jsoncommand">
+  <tr>
+   <th>HTTP Method</th>
+   <th>URI Template</th>
+  </tr>
+  <tr>
+   <td>POST</td>
+   <td>/session/{<var>session id</var>}/execute/pin/{<var>name</var>}</td>
+  </tr>
+ </table>
+
+ <p>The <a>remote end steps</a> are:
+
+ <ol>
+  <li><p>Let <var>script</var> be the result of
+ <a>getting a property</a> named <var>script</var>
+ from the <var>parameters</var>.
+
+   <li><p>If <var>script</var> is <a>undefined</a> or is not a <a>String</a>,
+ return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+   <li><p>If the <a>current browsing context</a> is <a>no longer
+ open</a>, return <a>error</a> with <a>error code</a> <a>no such
+ window</a>.
+
+  <li><p>If <var>name</var> matches an <a>executable script name</a>
+ in the <a>list of known scripts</a> for the <a>current session</a>,
+ remove the script <var>name</var> from the <a>list of known scripts</a>.
+
+ <li><p>Add the script <var>name</var> to the <a>list of known scripts</a>
+ for the <a>current session</a>.
+</ol>
+</section> <!-- /Pin Script -->
+</section> <!-- /Scripts -->
 </section> <!-- /Document -->
 
 

--- a/index.html
+++ b/index.html
@@ -2119,9 +2119,7 @@ and <a href=#elements>element retrieval</a>.
 A <a>session</a> has an associated <a>user prompt handler</a>.
 Unless stated otherwise it is in the <a>dismiss and notify state</a>.
 
-<p>A <a>session</a> has an associated <a>list of known scripts</a>.
-
-<p>A <a>session</a> has an associated <a>executable script table</a>.
+<p>A <a>session</a> has an associated <a>executable script map</a>.
 
 <p>A <a>session</a> has an associated list of <a>active input sources</a>.
 
@@ -5894,30 +5892,27 @@ of the <a>current browsing context</a> <a>active document</a>.
   Each script may include an optional associated <dfn>executable script name</dfn>
   that uniquely identifies the script within the <a>current session</a>.
 
-  Each <a>session</a> maintains a <dfn>list of known scripts</dfn>.
-  This list is initially empty. When an <a>executable script name</a>
-  is added to the <a>list of known scripts</a>, a corresponding entry
-  is made in the <a>executable script table</a> where the key is the
-  <a>executable script name</a> and the value is the <var>script</var>.
-  When an <a>executable script name</a> is removed from the
-  <a>list of known scripts</a>, the corresponding entry in
-  the <a>executable script table</a> is also removed.
+  Each <a>session</a> maintains an <a>ordered map</a> <dfn>executable script map</dfn>,
+  with each entry having a key of an <a>executable script name</a>
+  and a value of an <a>exeuctable script</a>.
+  This map is initially empty.
 
- <p>Each <a>session</a> has an associated <dfn>executable script table</dfn>.
-  This is a map between <a>executable script name</a>
-  and the script, with one entry for each item in the
-  <a>list of known scripts</a>.
+  To add an <a>executable script</a> to the session,
+  for <a>executable script map</a>, key <a>executable script name</a>, and value <var>script</var>,
+  set map[key] to value.
 
+  To remove an <a>executable script</a> from the session,
+  for <a>executable script map</a>, key <a>executable script name</a>, and value <var>script</var>,
+  remove map[key].
 
- To <dfn>get a script</dfn> with argument <var>name</var>,
- run the following steps:
+  To <dfn>get a script</dfn> with argument <var>name</var>, run the following steps:
  <ol>
- <li>If <var>name</var> is not equal to an <a>executable script name</a>
-  in the <a>list of known scripts</a> for the <a>current session</a>,
-  return <a>error</a> with <a>error code</a> <a>no such script</a>.
- <li>Let <var>script</var> be the <a>executable script</a>
- associated with <var>name</var> in the <a>executable script table</a>.
-</ol>
+  <li>If <var>name</var> is not equal to a key in the <a>executable script map</a>
+   for the <a>current session</a>, return <a>error</a> with <a>error code</a>
+   <a>no such script</a>.
+  <li>Let <var>script</var> be the value in the <a>executable script map</a>
+   associated with the key <var>name</var>.
+ </ol>
 
 <p>
 A <dfn>collection</dfn> is an <a>Object</a>
@@ -6357,28 +6352,27 @@ The first argument provided to the function will be serialized to JSON and retur
 
  <p>The <a>remote end steps</a> are:
 
- <ol>
-  <li><p>Let <var>name</var> be the result of
-  <a>getting a property</a> named <var>name</var>
-  from the <var>parameters</var>.
+  <ol>
+   <li><p>Let <var>name</var> be the result of
+ <a>getting a property</a> named <var>name</var>
+ from the <var>parameters</var>.
 
-  <li><p>Let <var>script</var> be the result of
+ <li><p>Let <var>script</var> be the result of
  <a>getting a property</a> named <var>script</var>
  from the <var>parameters</var>.
 
-   <li><p>If <var>script</var> is <a>undefined</a> or is not a <a>String</a>,
+ <li><p>If <var>script</var> is <a>undefined</a> or is not a <a>String</a>,
  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
-  <li><p>If <var>name</var> is <a>undefined</a> or is not a <a>String</a>,
+ <li><p>If <var>name</var> is <a>undefined</a> or is not a <a>String</a>,
  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
-  <li><p>If <var>name</var> matches an <a>executable script name</a>
- in the <a>list of known scripts</a> for the <a>current session</a>,
- remove the script <var>name</var> from the <a>list of known scripts</a>.
+ <li><p>If <var>name</var> is equal to a key in the <a>executable script map</a>
+ remove the <a>executable script</a> from the session
 
- <li><p>Add the script <var>name</var> to the <a>list of known scripts</a>
- for the <a>current session</a>.
-</ol>
+ <li><p>add the <a>executable script</a> to the session.
+
+ </ol>
 </section> <!-- /Pin Script -->
 </section> <!-- /Scripts -->
 </section> <!-- /Document -->


### PR DESCRIPTION
This is the feature that was discussed at TPAC. What wasn't mentioned was this implementation where scripts are associated with names. The idea is that intermediary nodes (like Sauce) can provide a list of named scripts available to the user without the user needing to pin them at the beginning of their tests. If scripts were only listed with UUIDs generated by the end node, this would not be possible. 

I'm looking forward to hearing back on whether this PR works for how the rest of the group understood the feature request.

There's one spot in here that I'm not sure I've specified correctly, but the intent should be clear, so let me know what needs changing. Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/titusfortner/webdriver/pull/1445.html" title="Last updated on Oct 16, 2019, 11:59 AM UTC (accf942)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1445/3216584...titusfortner:accf942.html" title="Last updated on Oct 16, 2019, 11:59 AM UTC (accf942)">Diff</a>