### PR TITLE
Editorial: Enable MDN annotations

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@ var respecConfig = {
   wgPublicList: "public-browser-tools-testing",
   wgPatentURI: "https://www.w3.org/2004/01/pp-impl/49799/status",
   noIDLSorting: true,
+  mdn: true,
 };
 </script>
 <script src=issue.js></script>


### PR DESCRIPTION
Enable the Respec feature for automatic injection of MDN annotations, as documented at https://github.com/w3c/respec/wiki/mdn

Currently, this causes MDN annotations to be added for the following: CloseWindow, GetElementAttribute, GetElementProperty, GetElementTagName, GetTimeouts, GetWindowHandles, GetWindowRect, SetTimeouts, SetWindowRect, navigator.webdriver


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1446.html" title="Last updated on Sep 27, 2019, 3:15 AM UTC (4f61fb0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1446/3216584...4f61fb0.html" title="Last updated on Sep 27, 2019, 3:15 AM UTC (4f61fb0)">Diff</a>