### PR TITLE
matching is not defined for strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -630,7 +630,7 @@ when it receives a particular <a>command</a>.
 
  <li><p>Remove each entry in <var>endpoints</var>
   for which the <i>method</i> column
-  is not an exact case-sensitive match for <var>method</var>.
+  is not equal to <var>method</var>.
 
  <li><p>If there are no entries in <var>endpoints</var>,
   return <a>error</a> with <a>error code</a> <a>unknown method</a>.
@@ -3904,7 +3904,7 @@ corresponding to the <a>current top-level browsing context</a>.
 <ol>
  <li>Let <var>element</var> be the item in the <a>current browsing
  context</a>’s <a>list of known elements</a> for which the <a>web
- element reference</a> matches <var>reference</var>, if such an
+ element reference</a> is equal to <var>reference</var>, if such an
  element exists. Otherwise return <a>error</a> with <a>error
  code</a> <a>no such element</a>.
  <li>If <var>element</var> <a>is stale</a>, return
@@ -5494,7 +5494,7 @@ an <a>element not interactable</a> <a>error</a> is returned.
 
   <ol>
    <li><p>Let <var>action</var> be the value of <var>undo actions</var>
-    matching key <var>entry key</var>.
+    equal to the key <var>entry key</var>.
 
    <li><p>If <var>action</var> is not an <a>action object</a>
     of <code>type</code> "<code>key</code>"
@@ -6495,7 +6495,7 @@ The first argument provided to the function will be serialized to JSON and retur
  <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
 
  <li><p>If the <a>url variable</a> <var>name</var>
-  matches a <a>cookie</a>’s <a>cookie name</a>
+  is equal to a <a>cookie</a>’s <a>cookie name</a>
   amongst <a>all associated cookies</a>
   of the <a>current browsing context</a>’s <a>active document</a>,
   return <a>success</a> with the <a>serialized cookie</a> as data.
@@ -7129,7 +7129,7 @@ from a machine utilisation perspective.
  <li><p>Let <var>source</var> be the <a>input source</a>
   in the list of <a>active input sources</a>
   where that <a>input source</a>’s <a>input id</a>
-  matches <var>id</var>,
+  is equal to <var>id</var>,
   or <a>undefined</a> if there is no matching <a>input source</a>.
 
  <li><p>If <var>source</var> is <a>undefined</a>:
@@ -7159,12 +7159,12 @@ from a machine utilisation perspective.
     on <var>source</var>’s <a>input id</a>.
   </ol>
 
- <li><p>If <var>source</var>’s <a>source type</a> does not
-  match <var>type</var> return an <a>error</a> with <a>error
+ <li><p>If <var>source</var>’s <a>source type</a> is not equal to
+  <var>type</var> return an <a>error</a> with <a>error
   code</a> <a>invalid argument</a>.
 
  <li><p>If <var>parameters</var> is not <a>undefined</a>,
-  then if its <code>pointerType</code> property does not match
+  then if its <code>pointerType</code> property is not equal to
   <var>source</var>’s <a>pointer type</a>,
   return an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
@@ -7587,7 +7587,7 @@ Return <a>success</a> with data <var>action</var>.
 
    <li><p>Let <var>algorithm</var> be the value of the column
     <i>dispatch action algorithm</i> from the following table of
-    <dfn>dispatch action algorithms</dfn> that matches the
+    <dfn>dispatch action algorithms</dfn> that is equal to the
     <var>source type</var> and the <var>action object</var>’s
     <code>subtype</code> property, to a dispatch action algorithm.
 


### PR DESCRIPTION
@andreastt based on your comment in #1445 I went through and looked for all of the times "matching" was used to refer to Strings. Let me know if any of these shouldn't be changed. Also, I'm unsure about https://github.com/w3c/webdriver/blob/master/index.html#L7133 but I think it is ok as is.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/titusfortner/webdriver/pull/1451.html" title="Last updated on Oct 15, 2019, 7:38 PM UTC (7066cca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1451/3216584...titusfortner:7066cca.html" title="Last updated on Oct 15, 2019, 7:38 PM UTC (7066cca)">Diff</a>