### PR TITLE
Fix: Fixed Broken link to irc channel

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ var respecConfig = {
   otherLinks: [{
     key: "Channel",
     data: [
-      {value: "#webdriver on irc.w3.org", href: "irc://irc.w3.org/"},
+      {value: "#webdriver on irc.w3.org", href: "http://irc.w3.org/"},
     ]
   }],
 


### PR DESCRIPTION
I have observed a broken to irc channel in webdriver doc. Fixed and created a PR. Now it opens/navigates to http://irc.w3.org/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Harsha509/webdriver/pull/1465.html" title="Last updated on Dec 6, 2019, 5:22 PM UTC (b1375b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1465/ac8cecd...Harsha509:b1375b8.html" title="Last updated on Dec 6, 2019, 5:22 PM UTC (b1375b8)">Diff</a>