### PR TITLE
Define same site cookie property

### DIFF
--- a/index.html
+++ b/index.html
@@ -6390,6 +6390,17 @@ The first argument provided to the function will be serialized to JSON and retur
    <a>adding a cookie</a>.
 
  </tr>
+
+ <tr>
+  <td><dfn>Cookie same site</dfn>
+  <td><code>samesite</code>
+  <td>"<code>samesite</code>"
+  <td>"<code>SameSite</code>"
+  <td>✓
+  <td>Whether the cookie applies to a SameSite policy.
+    Defaults to None if omitted when <a>adding a cookie</a>.
+    Can be set to either "<code>Lax</code>" or "<code>Strict</code>".
+ </tr>
 </table>
 
 <p>A <dfn>serialized cookie</dfn> is a JSON <a>Object</a>
@@ -6574,6 +6585,10 @@ The first argument provided to the function will be serialized to JSON and retur
    <dt><a>Cookie expiry time</a>
    <dd><p>The value if the entry exists, otherwise leave unset to
     indicate that this is a session cookie.
+
+   <dt><a>Cookie same site</a>
+   <dd><p>The value if the entry exists, otherwise leave unset to
+    indicate that no same site policy is defined.
   </dl>
 
   <p>If there is an <a>error</a> during this step,


### PR DESCRIPTION
This patch defines the same site property for cookies as requested in:

- https://github.com/w3c/webdriver/issues/1134
- https://github.com/w3c/webdriver/issues/1304
- https://github.com/webdriverio/webdriverio/issues/4893

I couldn't find a key for same site defined in the [RFC 6265](https://tools.ietf.org/html/rfc6265) spec but the property exist in [the spec draft](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#page-27) which will make RFC 6265 obsolete.

Chrome implements this behavior as of version 80. Firefox has them available to test and will be making them default behaviors in the future. Edge also plans to change its default behaviors.

Further read on same site cookies: https://web.dev/samesite-cookies-explained/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webdriver/webdriver/pull/1473.html" title="Last updated on Dec 17, 2019, 10:08 PM UTC (dc2feab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1473/9f12361...webdriver:dc2feab.html" title="Last updated on Dec 17, 2019, 10:08 PM UTC (dc2feab)">Diff</a>