### PR TITLE
navigation: extend description of Forward

### DIFF
--- a/index.html
+++ b/index.html
@@ -2948,6 +2948,8 @@ Return <a>success</a> with data <a><code>null</code></a>.
 <p class=note>This command causes the browser
  to traverse one step forwards in the <a>joint session history</a>
  of the <a>current top-level browsing context</a>.
+ This is equivalent to pressing the forward button in the browser chrome
+ or invoking <code>window.history.forward</code>.
 
 <p>The <a>remote end steps</a> are:
 
@@ -9006,9 +9008,9 @@ that evaluates to false, the <a>element</a> will not be <a>scrolled into view</a
 
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
- 
+
  <li><p><a>Handle any user prompts</a> and return its value if it is an <a>error</a>.
- 
+
  <li><p>Let <var>element</var> be the result of
   <a>trying</a> to <a>get a known connected element</a>
   with <a>url variable</a> <var>element id</var>.


### PR DESCRIPTION
There is already a similar description for Back command, so this makes them both consistent.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OndraM/webdriver/pull/1476.html" title="Last updated on Dec 21, 2019, 2:08 PM UTC (836f234)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1476/146f63b...OndraM:836f234.html" title="Last updated on Dec 21, 2019, 2:08 PM UTC (836f234)">Diff</a>