### PR TITLE
Change JSON key for Cookie same site property

### DIFF
--- a/index.html
+++ b/index.html
@@ -6394,7 +6394,7 @@ The first argument provided to the function will be serialized to JSON and retur
  <tr>
   <td><dfn>Cookie same site</dfn>
   <td><code>samesite</code>
-  <td>"<code>samesite</code>"
+  <td>"<code>sameSite</code>"
   <td>"<code>SameSite</code>"
   <td>✓
   <td>Whether the cookie applies to a SameSite policy.


### PR DESCRIPTION
Change spelling from samesite to sameSite, to be more consistent with
other property keys.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JohnChen0/webdriver/pull/1477.html" title="Last updated on Dec 23, 2019, 8:28 PM UTC (7fe8848)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1477/146f63b...JohnChen0:7fe8848.html" title="Last updated on Dec 23, 2019, 8:28 PM UTC (7fe8848)">Diff</a>