### PR TITLE
Update String reference to match WHATWG infra spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -5838,8 +5838,8 @@ If an <a>error</a> is returned, return that <a>error</a>
     <dd>
      <ol>
        <li><p>If <var>element</var> does not currently have focus, 
-        let <var>current text length</var> be the <a>JavaScript
-       string’s length</a> of <var><a>element</a></var>’s <a>API value</a>.
+        let <var>current text length</var> be the
+       <a>string length</a> of <var><a>element</a></var>’s <a>API value</a>.
  
       <li><p>Set the text insertion caret using <a>set selection range</a>
        using <var>current text length</var> for both the <code>start</code>
@@ -9913,7 +9913,7 @@ to automatically sort each list alphabetically.
   in the Infra standard: [[INFRA]]
    <ul>
     <!-- ASCII lowercase --> <li><dfn data-lt="lowercase"><a href=https://infra.spec.whatwg.org/#ascii-lowercase>ASCII lowercase</a></dfn>
-    <!-- Javascript String's length --> <li><dfn><a href="https://infra.spec.whatwg.org/#javascript-string-length">JavaScript string’s length</a></dfn>
+    <!-- string length --> <li><dfn><a href="https://infra.spec.whatwg.org/#string-length">string length</a></dfn>
     <!-- queue --> <li><dfn><a href=https://infra.spec.whatwg.org/#queues>queue</a></dfn>
     <!-- set --> <li><dfn><a href=https://infra.spec.whatwg.org/#sets>Set</a></dfn>
    </ul>


### PR DESCRIPTION
The Infra Spec has started calling JavaScript Strings Strings in
https://github.com/whatwg/infra/pull/292 and this aligns the webdriver
spec with that. Fixes #1486


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1492.html" title="Last updated on Mar 27, 2020, 10:41 AM UTC (fcfacc2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1492/4265381...fcfacc2.html" title="Last updated on Mar 27, 2020, 10:41 AM UTC (fcfacc2)">Diff</a>