### PR TITLE
Remove scroll behavior so it uses default.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3995,9 +3995,6 @@ argument <var>reference</var>, run the following steps:
   the following <a><code>ScrollIntoViewOptions</code></a>:
 
   <dl>
-   <dt>"<code>behavior</code>"
-   <dd>"<code>instant</code>"
-
    <dt><a>Logical scroll position "<code>block</code>"</a>
    <dd>"<code>end</code>"
 


### PR DESCRIPTION
CSSOM-View has removed the behaviour from ScrollIntoView dictionary.
This change updates to remove it from our scroll and means that browsers
should default to `auto` as described in CSSOM-View. Fixes #1449


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1493.html" title="Last updated on Mar 27, 2020, 10:49 AM UTC (0e22ed1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1493/4265381...0e22ed1.html" title="Last updated on Mar 27, 2020, 10:49 AM UTC (0e22ed1)">Diff</a>