### PR TITLE
Define RFC6265bis in `localBiblio`

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,18 @@ var respecConfig = {
       {value: "#webdriver on irc.w3.org", href: "https://www.w3.org/wiki/IRC"},
     ]
   }],
-
+  localBiblio: {
+    "RFC6265bis": {
+      "authors": [
+        "M. West",
+        "J. Wilander"
+      ],
+      "href": "https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05",
+      "title": "Cookies: HTTP State Management Mechanism",
+      "status": "Draft",
+      "publisher": "IETF"
+    }
+  },
   wg: "Browser Testing and Tools Working Group",
   wgURI: "https://www.w3.org/testing/browser/",
   wgPublicList: "public-browser-tools-testing",
@@ -5834,10 +5845,10 @@ If an <a>error</a> is returned, return that <a>error</a>
     <dt>Otherwise
     <dd>
      <ol>
-       <li><p>If <var>element</var> does not currently have focus, 
+       <li><p>If <var>element</var> does not currently have focus,
         let <var>current text length</var> be the
        <a>string length</a> of <var><a>element</a></var>’s <a>API value</a>.
- 
+
       <li><p>Set the text insertion caret using <a>set selection range</a>
        using <var>current text length</var> for both the <code>start</code>
        and <code>end</code> parameters.
@@ -9892,8 +9903,8 @@ to automatically sort each list alphabetically.
 
 <dd><p>The following terms are defined in the Same Site Cookie specification: [[RFC6265bis]]
   <ul>
-    <!-- lax --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1"><code>lax</code></a></dfn>
-    <!-- strict --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1"><code>strict</code></a></dfn>
+    <!-- lax --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-06#section-4.1.2.7"><code>lax</code></a></dfn>
+    <!-- strict --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-06#section-4.1.2.7"><code>strict</code></a></dfn>
   </ul>
 
  <dd><p>The following terms are defined in


### PR DESCRIPTION
Documentation of this mechanism:
https://github.com/w3c/respec/wiki/localBiblio

While in the area, update to the latest draft version.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/webdriver/pull/1507.html" title="Last updated on May 28, 2020, 12:06 PM UTC (2a9aa47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1507/f66dd0e...foolip:2a9aa47.html" title="Last updated on May 28, 2020, 12:06 PM UTC (2a9aa47)">Diff</a>