### PR TITLE
Remove redundant pointer to GitHub repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,10 +91,7 @@ to control a — possibly separate — browser.
 
 
 <!-- ReSpec complains if removed completely -->
-<section id=sotd>
-<p>
-Use <a href=https://github.com/w3c/webdriver>GitHub w3c/webdriver</a> for comments/issues.
-</section>
+<section id=sotd></section>
 
 
 <section class=informative>


### PR DESCRIPTION
"GitHub w3c/webdriver" is linked at the top, and "GitHub Issues" soon after
the remove sentence in the (generated) "Status of This Document".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1511.html" title="Last updated on May 29, 2020, 9:57 AM UTC (d96fb61)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1511/ee190be...d96fb61.html" title="Last updated on May 29, 2020, 9:57 AM UTC (d96fb61)">Diff</a>