### PR TITLE
Fix mistaken use and typos with <var>

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,7 +536,7 @@ when it receives a particular <a>command</a>.
  a <a>remote end</a> must run the following steps:</p>
 
 <ol>
- <li><p>Let <var>http status</var> and <var>name</var>
+ <li><p>Let <var>status</var> and <var>name</var>
   be the <a>error response data</a> for <var>error code</var>.
 
  <li><p>Let <var>message</var> be an implementation-defined string
@@ -1339,7 +1339,7 @@ when it receives a particular <a>command</a>.
 
 <aside class=example>
  <p>This might lead to a URL of the form
-  <code>/session/5d376174-36f0-11e5-9b9a-6bdf200a3f7f/<var>ms</var>/<var>edge</var>/<var>context</var></code>,
+  <code>/session/5d376174-36f0-11e5-9b9a-6bdf200a3f7f/<em>ms</em>/<em>edge</em>/<em>context</em></code>,
   where <code>session/{<var>session id</var>}</code> associates the request
   with the specified session, <code>ms/edge</code> identifies the command as
   specific to the Edge browser distributed by Microsoft,
@@ -1645,7 +1645,7 @@ with a "<code>moz:</code>" prefix:
   code</a> <a>invalid argument</a>.
 
  <li><p>If the result of <a>getting a property</a>
-  named <var>proxyType</var> from <var>proxy</var> equals
+  named "<code>proxyType</code>" from <var>proxy</var> equals
   "<code>pac</code>", and <var>proxy</var> does not have an
   <a>own property</a> for "<code>proxyAutoconfigUrl</code>" return
   an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
@@ -7146,7 +7146,7 @@ from a machine utilisation perspective.
       of <var>action</var> in <var>input source actions</var>.
 
      <li><p>If the length of <var>actions by tick</var> is less
-      than <var>i + 1</var>, append a new <a>List</a> to
+      than <var>i</var> + 1, append a new <a>List</a> to
       <var>actions by tick</var>.</li>
 
      <li><p>Append <var>action</var> to the <a>List</a> at
@@ -7993,7 +7993,7 @@ Return <a>success</a> with data <var>action</var>.
   <var>input state</var>’s <code>pressed</code> property.
 
  <li><p>Append a copy of <var>action object</var> with
-  the <var>subtype</var> property changed to <var>keyUp</var>
+  the <var>subtype</var> property changed to "<code>keyUp</code>"
   to <a>current session</a>’s <a>input cancel list</a>.
 
  <li><p><a data-lt=perform-actions>Perform implementation-specific
@@ -8160,7 +8160,7 @@ Return <a>success</a> with data <var>action</var>.
   let <var>buttons</var> be the resulting value of that property.
 
  <li><p>Append a copy of <var>action object</var> with
-  the <var>subtype</var> property changed to <var>pointerUp</var> to
+  the <var>subtype</var> property changed to "<code>pointerUp</code>" to
   the <a>current session</a>’s <a>input cancel list</a>.
 
  <li><p><a data-lt="perform-actions">Perform implementation-specific
@@ -9004,14 +9004,14 @@ sets the text field of a <a>window.<code>prompt</code></a>
    <li><p>Let <var>root rect</var> be the <a>current top-level browsing context</a>’s
     <a>document element</a>’s <a>rectangle</a>.
 
-   <li><p>Let <var>screenshot</var> be the result of <a>trying</a> to call
+   <li><p>Let <var>screenshot result</var> be the result of <a>trying</a> to call
     <a>draw a bounding box from the framebuffer</a>,
     given <var>root rect</var> as an argument.
 
    <li><p>Let <var>canvas</var> be a <a><code>canvas</code> element</a>
     of <var>screenshot result</var>’s data.
 
-   <li><p>Let <var>encoding</var> be the result of <a>trying</a>
+   <li><p>Let <var>encoding result</var> be the result of <a>trying</a>
     <a>encoding a canvas as Base64</a> <var>canvas</var>.
 
    <li><p>Let <var>encoded string</var> be <var>encoding result</var>’s data.
@@ -9280,7 +9280,7 @@ argument <var>input</var> an implementation must:
  <li><p>Let <var>pageRanges</var> be the result of <a>getting a
   property with default</a> named <code>pageRanges</code> from
   the <var>parameters</var> argument with default of an
-  empty <var>Array</var>.
+  empty <a>Array</a>.
 
  <li><p>If <var>pageRanges</var> is not an <a>Array</a>
  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.


### PR DESCRIPTION
These are issues discovered by Bikeshed, but the fixes can be applied to
the current spec as well, to make the future conversion smaller.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/webdriver/pull/1515.html" title="Last updated on May 29, 2020, 1:23 PM UTC (ae64edc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1515/f019306...foolip:ae64edc.html" title="Last updated on May 29, 2020, 1:23 PM UTC (ae64edc)">Diff</a>