### PR TITLE
Fix various minor mishaps with <dfn> and <a>

### DIFF
--- a/index.html
+++ b/index.html
@@ -1461,7 +1461,7 @@ with a "<code>moz:</code>" prefix:
   <td>"<code>acceptInsecureCerts</code>"
   <td>boolean
   <td>Indicates whether untrusted and self-signed TLS certificates
-   are implicitly trusted on <a data-lt=go>navigation</a>
+   are implicitly trusted on <a>navigation</a>
    for the duration of the <a>session</a>.
  </tr>
 
@@ -1913,7 +1913,7 @@ with a "<code>moz:</code>" prefix:
    <dt>"<code>acceptInsecureCerts</code>"
    <dd><a>Boolean</a> initially set to false,
     indicating the session will not implicitly trust untrusted
-    or self-signed TLS certificates on <a data-lt=go>navigation</a>.
+    or self-signed TLS certificates on <a>navigation</a>.
 
    <dt>"<code>strictFileInteractability</code>"
     <dd><a>Boolean</a> initially set to false,
@@ -2133,7 +2133,7 @@ and <a href=#elements>element retrieval</a>.
  that indicates whether untrusted or self-signed TLS certificates
  should be trusted for the duration of the WebDriver session.
  If it is unset, this indicates that certificate- or TLS errors
- that occur upon <a data-lt=go>navigation</a> should be suppressed.
+ that occur upon <a>navigation</a> should be suppressed.
  The state can be unset by providing
  an "<code>acceptInsecureCerts</code>" <a>capability</a> with the value true.
  Unless stated otherwise, it is set.
@@ -5579,7 +5579,7 @@ an <a>element not interactable</a> <a>error</a> is returned.
 <p>
 A <dfn>non-typeable form control</dfn>
 is an <a><code>input</code> element</a>
-whose <a data-lt="input type state"><code>type</code> attribute</a> state
+whose <a><code>type</code> attribute</a> state
 causes the primary input mechanism
 not to be through means of a keyboard, whether virtual or physical.
 
@@ -8072,7 +8072,7 @@ Return <a>success</a> with data <var>action</var>.
   the <var>subtype</var> property changed to "<code>keyUp</code>"
   to <a>current session</a>’s <a>input cancel list</a>.
 
- <li><p><a data-lt=perform-actions>Perform implementation-specific
+ <li><p><a>Perform implementation-specific
   action dispatch steps</a> equivalent to pressing a key on the
   keyboard in accordance with the requirements of [[UI-EVENTS]], and
   producing the following events, as appropriate, with the specified
@@ -8174,7 +8174,7 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Remove <var>key</var> from the set corresponding
   to <var>input state</var>’s <code>pressed</code> property.
 
- <li><p><a data-lt=perform-actions>Perform implementation-specific
+ <li><p><a>Perform implementation-specific
   action dispatch steps</a> equivalent to releasing a key on the
   keyboard in accordance with the requirements of [[UI-EVENTS]], and
   producing at least the following events with the specified
@@ -8239,7 +8239,7 @@ Return <a>success</a> with data <var>action</var>.
   the <var>subtype</var> property changed to "<code>pointerUp</code>" to
   the <a>current session</a>’s <a>input cancel list</a>.
 
- <li><p><a data-lt="perform-actions">Perform implementation-specific
+ <li><p><a>Perform implementation-specific
   action dispatch steps</a> equivalent to pressing the button
   numbered <var>button</var> on the pointer with ID
   <var>source id</var>, having type <var>pointerType</var> at
@@ -8287,7 +8287,7 @@ Return <a>success</a> with data <var>action</var>.
   let <var>buttons</var> be the resulting value of that
   property.
 
- <li><p><a data-lt=perform-actions>Perform implementation-specific
+ <li><p><a>Perform implementation-specific
   action dispatch steps</a> equivalent to releasing the button
   numbered <var>button</var> on the pointer of ID
   <var>source id</var> having type <var>pointerType</var> at
@@ -8435,7 +8435,7 @@ Return <a>success</a> with data <var>action</var>.
    <li><p>Let <var>buttons</var> be equal to input
     state’s <code>buttons</code> property.
 
-   <li><p><a data-lt="perform-actions">Perform implementation-specific
+   <li><p><a>Perform implementation-specific
     action dispatch steps</a> equivalent to moving the pointer with
     ID <var>source id</var> having type <var>pointerType</var> from
     viewport x coordinate <var>current x</var>, viewport y
@@ -8500,7 +8500,7 @@ Return <a>success</a> with data <var>action</var>.
  <a>remote end</a> must run the following steps:
 
 <ol>
- <li><p><a data-lt=perform-actions>Perform implementation-specific
+ <li><p><a>Perform implementation-specific
   action dispatch steps</a> equivalent to cancelling the any action of
   the pointer with ID <var>source id</var> having
   type <var>pointerType</var>, in accordance with the requirements of
@@ -8616,7 +8616,7 @@ It also clears all the internal state of the virtual devices.
 
 <p><a>User prompts</a> that are spawned
  from <a><code>beforeunload</code></a> event handlers,
- are <a>dismissed</a> implicitly upon <a data-lt=go>navigation</a>
+ are <a>dismissed</a> implicitly upon <a>navigation</a>
  or <a>close window</a>,
  regardless of the defined <a>user prompt handler</a>.
 
@@ -9879,8 +9879,7 @@ to automatically sort each list alphabetically.
    <!-- Raw value --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-textarea-raw-value>Raw value</a></dfn>
    <!-- Refresh state pragma directive --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-meta-http-equiv-refresh>Refresh state pragma directive</a></dfn>
    <!-- Reset algorithm --> <li><dfn data-lt="reset algorithms"><a href=https://html.spec.whatwg.org/#concept-form-reset-control>Reset algorithm</a></dfn>
-   <!-- Resettable element --> <li><dfn data-lt="resettable elements"><a href=https://html.spec.whatwg.org/#category-reset>Resettable</a></dfn> element
-   <!-- Resettable element --> <li><dfn><a href=https://html.spec.whatwg.org/#category-reset>Resettable element</a></dfn>
+   <!-- Resettable element --> <li><dfn data-lt="resettable elements|resettable"><a href=https://html.spec.whatwg.org/#category-reset>Resettable element</a></dfn>
    <!-- Run the animation frame callbacks --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks">Run the animation frame callbacks</a></dfn>
    <!-- Satisfies its constraints --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fv-valid>Satisfies its constraints</a></dfn>
    <!-- Script --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-script>Script</a></dfn>
@@ -9950,8 +9949,8 @@ to automatically sort each list alphabetically.
 
  <dd><p>The HTML specification also defines a range of different attributes:
   <ul>
-   <!-- Canvas height attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-canvas-height><code>canvas</code>’s height attribute</a></dfn>
-   <!-- Canvas width attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-canvas-width><code>canvas</code>’ width attribute</a></dfn>
+   <!-- Canvas height attribute --> <li><dfn lt="canvas height attribute"><a href=https://html.spec.whatwg.org/#attr-canvas-height><code>canvas</code>’s height attribute</a></dfn>
+   <!-- Canvas width attribute --> <li><dfn lt="canvas width attribute"><a href=https://html.spec.whatwg.org/#attr-canvas-width><code>canvas</code>’ width attribute</a></dfn>
    <!-- Checked content attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-checked>Checked</a></dfn>
    <!-- Multiple attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-multiple><code>multiple</code> attribute</a></dfn>
    <!-- readOnly attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#the-readonly-attribute><code>readOnly</code> attribute</a></dfn>


### PR DESCRIPTION
Discovered while converting to Bikeshed but also affects ReSpec:
- data-lt=go and data-lt="input type state" don't work since
  there's no matching <dfn>.
- data-lt=perform-actions doesn't make sense, the "Perform Actions"
  section isn't the intended target.
- Duplicate "Resettable element" definition
- Broken canvas width/height links


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/webdriver/pull/1518.html" title="Last updated on Jun 1, 2020, 12:15 PM UTC (1f3cdb4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1518/162e738...foolip:1f3cdb4.html" title="Last updated on Jun 1, 2020, 12:15 PM UTC (1f3cdb4)">Diff</a>