### PR TITLE
Link the browser chrome (elements) definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -2937,7 +2937,7 @@ Return <a>success</a> with data <a><code>null</code></a>.
 <p class=note>This command causes the browser to traverse
  one step backward in the <a>joint session history</a>
  of the <a>current top-level browsing context</a>.
- This is equivalent to pressing the back button in the browser chrome
+ This is equivalent to pressing the back button in the <a>browser chrome</a>
  or invoking <code>window.history.back</code>.
 
 <p>The <a>remote end steps</a> are:
@@ -2982,7 +2982,7 @@ Return <a>success</a> with data <a><code>null</code></a>.
 <p class=note>This command causes the browser
  to traverse one step forwards in the <a>joint session history</a>
  of the <a>current top-level browsing context</a>.
- This is equivalent to pressing the forward button in the browser chrome
+ This is equivalent to pressing the forward button in the <a>browser chrome</a>
  or invoking <code>window.history.forward</code>.
 
 <p>The <a>remote end steps</a> are:
@@ -3717,13 +3717,13 @@ corresponding to the <a>current top-level browsing context</a>.
    <li><p>Set the width, in <a>CSS pixels</a>,
     of the operating system window containing
     the <a>current top-level browsing context</a>,
-    including any browser chrome and externally drawn window decorations
+    including any <a>browser chrome</a> and externally drawn window decorations
     to a value that is as close as possible to <var>width</var>.
 
   <li><p>Set the height, in <a>CSS pixels</a>,
    of the operating system window containing
    the <a>current top-level browsing context</a>,
-   including any browser chrome and externally drawn window decorations
+   including any <a>browser chrome</a> and externally drawn window decorations
    to a value that is as close as possible to <var>height</var>.
 
    <aside class=note>
@@ -9466,7 +9466,7 @@ ensuring both privacy and preventing state from bleeding through to the next ses
  make an effort to visually distinguish
  a user agent session that is under control of WebDriver
  from those used for normal browsing sessions.
- This can be done through a browser chrome element
+ This can be done through a <a>browser chrome element</a>
  such as a “door hanger”,
  colorful decoration of the OS window,
  or some widget element that is prevalent in the window


### PR DESCRIPTION
These are both unused definitions before this change:
https://w3c.github.io/webdriver/#dfn-browser-chrome
https://w3c.github.io/webdriver/#dfn-browser-chrome-element


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/webdriver/pull/1520.html" title="Last updated on Jun 2, 2020, 8:22 AM UTC (a8e332e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1520/33c1f38...foolip:a8e332e.html" title="Last updated on Jun 2, 2020, 8:22 AM UTC (a8e332e)">Diff</a>