### PR TITLE
Fix h1-6 levels to match section nesting / ToC

### DIFF
--- a/index.html
+++ b/index.html
@@ -1308,7 +1308,7 @@ when it receives a particular <a>command</a>.
 </section> <!-- /Errors -->
 
 <section>
-<h2>Extensions</h2>
+<h3>Extensions</h3>
 
 <p>Using the terminology defined in this section, others may define additional
  commands that seamlessly integrate with the standard protocol. This allows
@@ -3498,7 +3498,7 @@ make the tab containing the <a>browsing context</a> the selected tab.
 </section> <!-- /Switch To Parent Frame -->
 
 <section>
-<h2>Resizing and positioning windows</h2>
+<h3>Resizing and positioning windows</h3>
 
 <p>WebDriver provides <a>commands</a>
  for interacting with the operating system window
@@ -3618,7 +3618,7 @@ make the tab containing the <a>browsing context</a> the selected tab.
  or until the operation times out.
 
 <section>
-<h3><dfn>Get Window Rect</dfn></h3>
+<h4><dfn>Get Window Rect</dfn></h4>
 
 <table class="simple jsoncommand">
  <tr>
@@ -3652,7 +3652,7 @@ make the tab containing the <a>browsing context</a> the selected tab.
 </section> <!-- /Get Window Rect -->
 
 <section>
-<h3><dfn>Set Window Rect</dfn></h3>
+<h4><dfn>Set Window Rect</dfn></h4>
 
 <table class="simple jsoncommand">
  <tr>
@@ -3778,7 +3778,7 @@ corresponding to the <a>current top-level browsing context</a>.
 </section> <!-- /Set Window Rect -->
 
 <section>
-<h3><dfn>Maximize Window</dfn></h3>
+<h4><dfn>Maximize Window</dfn></h4>
 
 <table class="simple jsoncommand">
  <tr>
@@ -3825,7 +3825,7 @@ corresponding to the <a>current top-level browsing context</a>.
 </section> <!-- /Maximize Window -->
 
 <section>
-<h3><dfn>Minimize Window</dfn></h3>
+<h4><dfn>Minimize Window</dfn></h4>
 
 <table class="simple jsoncommand">
  <tr>
@@ -3868,7 +3868,7 @@ corresponding to the <a>current top-level browsing context</a>.
 </section> <!-- /Minimize Window -->
 
 <section>
-<h3><dfn>Fullscreen Window</dfn></h3>
+<h4><dfn>Fullscreen Window</dfn></h4>
 
 <table class="simple jsoncommand">
  <tr>
@@ -6261,7 +6261,7 @@ a <a>remote end</a> must run the following steps:
  and is therefore not subject to the document CSP <a>directives</a>.
 
 <section>
-<h3><dfn>Execute Script</dfn></h3>
+<h4><dfn>Execute Script</dfn></h4>
 
 <table class="simple jsoncommand">
  <tr>
@@ -6317,7 +6317,7 @@ a <a>remote end</a> must run the following steps:
 </section> <!-- /Execute Script -->
 
 <section>
-<h3><dfn>Execute Async Script</dfn></h3>
+<h4><dfn>Execute Async Script</dfn></h4>
 
 <table class="simple jsoncommand">
  <tr>
@@ -6868,7 +6868,7 @@ The first argument provided to the function will be serialized to JSON and retur
 </aside> <!-- /example -->
 
 <section>
-<h2>Input sources</h2>
+<h3>Input sources</h3>
 
 <p class=note>
 The objects and properties defined in this section are spec-internal constructs
@@ -6886,7 +6886,7 @@ For convenience the same terminology is used for their manipulation.
 
 
 <section>
-<h3 id=input-sources>Sources</h3>
+<h4 id=input-sources>Sources</h4>
 
 <p>A <dfn>null input source</dfn> is an <a>input source</a> that is
  not associated with a specific physical device. A <a>null input source</a>
@@ -6974,7 +6974,7 @@ is also removed.
 
 
 <section>
-<h3 id=input-source-state>State</h3>
+<h4 id=input-source-state>State</h4>
 
 <p>
 <dfn>Input source state</dfn> is used as a generic term to
@@ -7182,7 +7182,7 @@ from a machine utilisation perspective.
 
 
 <section>
-<h2>Processing actions</h2>
+<h3>Processing actions</h3>
 
 <p>The algorithm for <a data-lt="extract an action sequence">
  extracting an action sequence from a request</a> takes the
@@ -7627,7 +7627,7 @@ Return <a>success</a> with data <var>action</var>.
 
 
 <section>
-<h2>Dispatching actions</h2>
+<h3>Dispatching actions</h3>
 
 <p>The algorithm to <a>dispatch actions</a> takes a list of actions
  grouped by <a>tick</a>, and then causes each action to be run at the
@@ -7753,7 +7753,7 @@ Return <a>success</a> with data <var>action</var>.
 
 
 <section>
-<h2>General actions</h2>
+<h4>General actions</h4>
 
 <p>When required to <dfn>dispatch a pause action</dfn> with
  arguments <var>source id</var>, <var>action object</var>,
@@ -7767,7 +7767,7 @@ Return <a>success</a> with data <var>action</var>.
 
 
 <section>
-<h2>Keyboard actions</h2>
+<h4>Keyboard actions</h4>
 
 <p>The <dfn>normalised key value</dfn> for a raw key <var>key</var>
  is, if <var>key</var> appears in the table below, the string value in
@@ -8208,7 +8208,7 @@ Return <a>success</a> with data <var>action</var>.
 
 
 <section>
-<h2>Pointer actions</h2>
+<h4>Pointer actions</h4>
 
 <p>When required to <dfn>dispatch a pointerDown action</dfn> with
  arguments <var>source id</var>, <var>action object</var>,
@@ -8513,7 +8513,7 @@ Return <a>success</a> with data <var>action</var>.
 
 
 <section>
-<h2><dfn>Perform Actions</dfn></h2>
+<h3><dfn>Perform Actions</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>
@@ -8550,7 +8550,7 @@ Return <a>success</a> with data <var>action</var>.
 
 
 <section>
-<h2><dfn>Release Actions</dfn></h2>
+<h3><dfn>Release Actions</dfn></h3>
 
 <table class="simple jsoncommand">
  <tr>


### PR DESCRIPTION
Discovered as part of https://github.com/w3c/webdriver/issues/1462.

It doesn't matter in ReSpec because the <section> nesting level is used,
but Bikeshed does not use the HTML outline algorithm:
https://tabatkins.github.io/bikeshed/#table-of-contents


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/webdriver/pull/1521.html" title="Last updated on Jun 2, 2020, 9:28 AM UTC (5e45041)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1521/df1d9bd...foolip:5e45041.html" title="Last updated on Jun 2, 2020, 9:28 AM UTC (5e45041)">Diff</a>