### PR TITLE
Add wheel source type to WebDriver Actions API Spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -7838,9 +7838,11 @@ Return <a>success</a> with data <var>action</var>.
     property set to "<code>pause</code>"
     or <var>action object</var> has <code>type</code> property set
     to "<code>pointer</code>" and <code>subtype</code> property set
-    to "<code>pointerMove</code>", let <var>duration</var> be equal to
-    the <code>duration</code> property of
-    <var>action object</var>.
+    to "<code>pointerMove</code>", or <var>action object</var> has
+    <code>type</code> property set to "<code>wheel</code>" and
+    <code>subtype</code> property set to "<code>scroll</code>",
+    let <var>duration</var> be equal to the <code>duration</code>
+    property of <var>action object</var>.
 
    <li><p>If <var>duration</var> is not <a>undefined</a>,
     and <var>duration</var> is greater than <var>max duration</var>,
@@ -7894,6 +7896,8 @@ Return <a>success</a> with data <var>action</var>.
 <tr><td>"<code>pointer</code>"	<td>"<code>pointerUp</code>"		<td><a>Dispatch a pointerUp action</a>
 <tr><td>"<code>pointer</code>"	<td>"<code>pointerMove</code>		<td><a>Dispatch a pointerMove action</a>
 <tr><td>"<code>pointer</code>"	<td>"<code>pointerCancel</code>		<td><a>Dispatch a pointerCancel action</a>
+<tr><td>"<code>wheel</code>"	<td>"<code>pause</code>"		<td><a>Dispatch a pause action</a>
+<tr><td>"<code>wheel</code>"	<td>"<code>scroll</code>"		<td><a>Dispatch a scroll action</a>	
 </table>
 
    <li><a>Try</a> to run <var>algorithm</var> with arguments

--- a/index.html
+++ b/index.html
@@ -6976,6 +6976,7 @@ For convenience the same terminology is used for their manipulation.
     or left to scroll the page down, up, right or left.</td>
   </tr>
  </table>
+
 <p>Each <a>session</a> maintains a <a>list</a> of <dfn>active input
 sources</dfn>. This list is initially empty. When an <a>input
 source</a> is added to the list of <a>active input sources</a>, a
@@ -7056,6 +7057,18 @@ and a <code>y</code> property which is an unsigned integer.
  a <a>pointer input state</a> object with <code>subtype</code> set
  to <var>subtype</var>, <code>pressed</code> set to an empty set and
  both <code>x</code> and <code>y</code> set to <code>0</code>.
+	
+<p>A <a>wheel input source</a>’s <a>input source state</a> is a
+ <dfn>wheel input state</dfn> object. This is an object with an
+ <code>x</code> property which is an unsigned integer, a <code>y</code>
+ property which is an unsigned integer, a <code>deltaX</code> property
+ which is an integer, and a <code>deltaY</code> property which is an
+ integer.
+
+<p>When required to <dfn>create a new wheel input state object</dfn>,
+ an implementation must return a <a>wheel input state</a> object with
+ the <code>x</code>, <code>y</code>, <code>deltaX</code>, and
+ <code>deltaY</code> properties all set to <code>0</code>.
 
 <p>Each <a>session</a> has an associated <dfn>input state table</dfn>.
  This is a map between <a>input id</a>

--- a/index.html
+++ b/index.html
@@ -7022,6 +7022,11 @@ describe the state associated with each <a>input source</a>.
   <td>"<code>pointer</code>"
   <td><a>pointer input state</a>
  </tr>
+
+ <tr>
+  <td>"<code>wheel</code>"
+  <td><a>wheel input state</a>
+ </tr>	
 </table>
 
 <p>A <a>null input source</a>’s <a>input source state</a> is
@@ -7274,7 +7279,8 @@ from a machine utilisation perspective.
 
  <li><p>If <var>type</var> is
   not "<code>key</code>", "<code>pointer</code>",
-  or "<code>none</code>", return an <a>error</a> with
+  "<code>wheel</code>",	or "<code>none</code>",
+  return an <a>error</a> with
   <a>error code</a> <a>invalid argument</a>.
 
  <li><p>Let <var>id</var> be the result of
@@ -7562,6 +7568,116 @@ If doing so results in an <a>error</a>, return that <a>error</a>.
 If <var>subtype</var> is "<code>pointerCancel</code>"
 <span class=issue>process a pointer cancel action</span>.
 If doing so results in an <a>error</a>, return that <a>error</a>.
+
+<li><p>
+Return <a>success</a> with data <var>action</var>.
+</ol>
+
+<p>
+When required to <dfn>process a wheel action</dfn> with arguments
+<var>id</var>,
+and <var>action item</var>,
+a <a>remote end</a> must perform the following steps:</p>
+
+<ol>
+<li><p>
+Let <var>subtype</var> be the result
+of <a>getting a property</a> named <code>type</code>
+from <var>action item</var>.
+
+<li><p>
+If <var>subtype</var> is not the value
+"<code>pause</code>", or
+"<code>scroll</code>",
+return an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+<li><p>
+Let <var>action</var> be an <a>action object</a> constructed with arguments
+<var>id</var>,
+"<code>wheel</code>",
+and <var>subtype</var>.
+
+<li><p>
+If <var>subtype</var> is "<code>pause</code>",
+let <var>result</var> be the result of <a>trying</a> to
+<a>process a pause action</a> with arguments
+<var>action item</var> and <var>action</var>,
+and return <var>result</var>.
+
+<li><p>
+Let <var>duration</var> be the result of <a>getting a property</a>
+named <code>duration</code> from <var>action item</var>.
+
+<li><p>
+If <var>duration</var> is not <a>undefined</a> and <var>duration</var>
+is not an <a>Integer</a> greater than or equal to 0, return <a>error</a>
+with <a>error code</a> <a>invalid argument</a>.
+
+<li><p>
+Set the <code>duration</code> property of <var>action</var>
+to <var>duration</var>.
+
+<li><p>
+Let <var>origin</var> be the result of <a>getting the property</a>
+<code>origin</code> from <var>action item</var>.
+
+<li><p>
+If <var>origin</var> is <a>undefined</a> let
+<var>origin</var> equal "<code>viewport</code>".
+
+<li><p>
+If <var>origin</var> is not equal to "<code>viewport</code>"
+or "<code>pointer</code>" and <var>origin</var> is not an <a>Object</a>
+that <a>represents a web element</a>, return <a>error</a> with
+<a>error code</a> <a>invalid argument</a>.
+
+<li><p>
+Set the <code>origin</code> property of <var>action</var>
+to <var>origin</var>.
+
+<li><p>
+Let <var>x</var> be the result of <a>getting the property</a>
+<code>x</code> from <var>action item</var>.
+
+<li><p>
+If <var>x</var> is not <a>undefined</a> and is not an <a>Integer</a>,
+return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+<li><p>
+Set the <code>x</code> property of <var>action</var> to <var>x</var>.
+
+<li><p>
+Let <var>y</var> be the result of <a>getting the property</a>
+<code>y</code> from <var>action item</var>.
+
+<li><p>
+If <var>y</var> is not <a>undefined</a> and is not an <a>Integer</a>,
+return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+<li><p>
+Set the <code>y</code> property of <var>action</var> to <var>y</var>.
+
+<li><p>
+Let <var>deltaX</var> be the result of <a>getting the property</a>
+<code>deltaX</code> from <var>action item</var>.
+
+<li><p>
+If <var>deltaX</var> is not <a>undefined</a> and is not an <a>Integer</a>,
+return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+<li><p>
+Set the <code>deltaX</code> property of <var>action</var> to <var>deltaX</var>.
+
+<li><p>
+Let <var>deltaY</var> be the result of <a>getting the property</a>
+<code>deltaY</code> from <var>action item</var>.
+
+<li><p>
+If <var>deltaY</var> is not <a>undefined</a> and is not an <a>Integer</a>,
+return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
+<li><p>
+Set the <code>deltaY</code> property of <var>action</var> to <var>deltaY</var>.
 
 <li><p>
 Return <a>success</a> with data <var>action</var>.

--- a/index.html
+++ b/index.html
@@ -8733,10 +8733,10 @@ Return <a>success</a> with data <var>action</var>.
   return <a>error</a> with error code <a>move target out of
   bounds</a>.
 	 
- <li><p>Let <var>delta x</var> be equal to the <code>delta x</code>
+ <li><p>Let <var>delta x</var> be equal to the <code>deltaX</code>
   property of <var>action object</var>.
 
- <li><p>Let <var>delta y</var> be equal to the <code>delta y</code>
+ <li><p>Let <var>delta y</var> be equal to the <code>deltaY</code>
   property of <var>action object</var>.
 
  <li><p>Let <var>duration</var> be equal to
@@ -8749,8 +8749,8 @@ Return <a>success</a> with data <var>action</var>.
   implementation defined amount of time to pass.
 
   <aside><p>This wait allows the implementation to model the overall
-   pointer move as a series of small movements occurring at an
-   implementation defined rate (e.g. one movement per
+   wheel scroll as a series of small scroll occurring at an
+   implementation defined rate (e.g. one scroll per
    vsync).</p></aside>
  </li>
 
@@ -8781,10 +8781,10 @@ Return <a>success</a> with data <var>action</var>.
   let <var>last</var> be true. Otherwise let <var>last</var>
   be <code>false</code>.
 
- <li><p>Let <var>current delta x</var> equal the <code>delta x</code>
+ <li><p>Let <var>current delta x</var> equal the <code>deltaX</code>
   property of <var>input state</var>.
 
- <li><p>Let <var>current delta y</var> equal the <code>delta y</code>
+ <li><p>Let <var>current delta y</var> equal the <code>deltaY</code>
   property of <var>input state</var>.
 
  <li><p>If <var>last</var> is true, let <var>delta x</var> equal
@@ -8807,17 +8807,17 @@ Return <a>success</a> with data <var>action</var>.
    <li><p><a>Perform implementation-specific
     action dispatch steps</a> equivalent to wheel scroll with
     ID <var>source id</var> at viewport x coordinate <var>x</var>,
-    viewport y coordinate <var>y</var>, <var>delta x</var>,
-    <var>delta y</var>, in accordance with the
+    viewport y coordinate <var>y</var>, deltaX value <var>delta x</var>,
+    deltaY value <var>delta y</var>, in accordance with the
     requirements of [[UI-EVENTS]].
 
    <li><p>Let <var>input state</var>’s <code>x</code> property
     equal <var>x</var> and <code>y</code> property
     equal <var>y</var>.
 	   
-   <li><p>Let <var>input state</var>’s <code>delta x</code> property
+   <li><p>Let <var>input state</var>’s <code>deltaX</code> property
     equal <var>delta x</var>  + <var>current delta x</var> and
-    <code>delta y</code> property equal
+    <code>deltaY</code> property equal
     <var>delta y</var>  + <var>current delta y</var>.	   
   </ol>
 
@@ -8850,8 +8850,8 @@ Return <a>success</a> with data <var>action</var>.
 
    <li><p><a>Perform a scroll</a> with arguments
     <var>source id</var>, <var>input state</var>, <var>duration</var>,
-    <var>x</var>, <var>y</var>, <var>delta x</var>, <var>delta y</var>,
-    <var>target delta x</var>, <var>target delta y</var>.
+    <var>x</var>, <var>y</var>, <var>target delta x</var>,
+    <var>target delta y</var>.
  </ol>
 
 </ol>

--- a/index.html
+++ b/index.html
@@ -7279,7 +7279,7 @@ from a machine utilisation perspective.
 
  <li><p>If <var>type</var> is
   not "<code>key</code>", "<code>pointer</code>",
-  "<code>wheel</code>",	or "<code>none</code>",
+  "<code>wheel</code>", or "<code>none</code>",
   return an <a>error</a> with
   <a>error code</a> <a>invalid argument</a>.
 
@@ -7666,11 +7666,11 @@ If <var>deltaX</var> is not <a>undefined</a> and is not an <a>Integer</a>,
 return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
 <li><p>
-Set the <code>deltaX</code> property of <var>action</var> to <var>deltaX</var>.
+Set the <code>delta x</code> property of <var>action</var> to <var>delta x</var>.
 
 <li><p>
-Let <var>deltaY</var> be the result of <a>getting the property</a>
-<code>deltaY</code> from <var>action item</var>.
+Let <var>delta y</var> be the result of <a>getting the property</a>
+<code>delta y</code> from <var>action item</var>.
 
 <li><p>
 If <var>deltaY</var> is not <a>undefined</a> and is not an <a>Integer</a>,
@@ -7678,6 +7678,10 @@ return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
 <li><p>
 Set the <code>deltaY</code> property of <var>action</var> to <var>deltaY</var>.
+
+<li><p>
+If <var>delta x</var> is not <a>undefined</a> and is not an <a>Integer</a>,
+return <a>error</a> with <a>error code</a> <a>invalid argument</a>.        
 
 <li><p>
 Return <a>success</a> with data <var>action</var>.
@@ -7886,16 +7890,16 @@ Return <a>success</a> with data <var>action</var>.
     <code>subtype</code> property, to a dispatch action algorithm.
 
 <table class=simple>
-<tr><th><var>source type</var>	<th><code>subtype</code> property	<th>Dispatch action algorithm
-<tr><td>"<code>none</code>"	<td>"<code>pause</code>"		<td><a>Dispatch a pause action</a>
-<tr><td>"<code>key</code>"	<td>"<code>pause</code>"		<td><a>Dispatch a pause action</a>
-<tr><td>"<code>key</code>"	<td>"<code>keyDown</code>"		<td><a>Dispatch a keyDown action</a>
-<tr><td>"<code>key</code>"	<td>"<code>keyUp</code>"		<td><a>Dispatch a keyUp action</a>
-<tr><td>"<code>pointer</code>"	<td>"<code>pause</code>"		<td><a>Dispatch a pause action</a>
-<tr><td>"<code>pointer</code>"	<td>"<code>pointerDown</code>"		<td><a>Dispatch a pointerDown action</a>
-<tr><td>"<code>pointer</code>"	<td>"<code>pointerUp</code>"		<td><a>Dispatch a pointerUp action</a>
-<tr><td>"<code>pointer</code>"	<td>"<code>pointerMove</code>		<td><a>Dispatch a pointerMove action</a>
-<tr><td>"<code>pointer</code>"	<td>"<code>pointerCancel</code>		<td><a>Dispatch a pointerCancel action</a>
+<tr><th><var>source type</var>  <th><code>subtype</code> property       <th>Dispatch action algorithm
+<tr><td>"<code>none</code>"     <td>"<code>pause</code>"                <td><a>Dispatch a pause action</a>
+<tr><td>"<code>key</code>"      <td>"<code>pause</code>"                <td><a>Dispatch a pause action</a>
+<tr><td>"<code>key</code>"      <td>"<code>keyDown</code>"              <td><a>Dispatch a keyDown action</a>
+<tr><td>"<code>key</code>"      <td>"<code>keyUp</code>"                <td><a>Dispatch a keyUp action</a>
+<tr><td>"<code>pointer</code>"  <td>"<code>pause</code>"                <td><a>Dispatch a pause action</a>
+<tr><td>"<code>pointer</code>"  <td>"<code>pointerDown</code>"          <td><a>Dispatch a pointerDown action</a>
+<tr><td>"<code>pointer</code>"  <td>"<code>pointerUp</code>"            <td><a>Dispatch a pointerUp action</a>
+<tr><td>"<code>pointer</code>"  <td>"<code>pointerMove</code>           <td><a>Dispatch a pointerMove action</a>
+<tr><td>"<code>pointer</code>"  <td>"<code>pointerCancel</code>         <td><a>Dispatch a pointerCancel action</a>
 <tr><td>"<code>wheel</code>"    <td>"<code>pause</code>"                <td><a>Dispatch a pause action</a>
 <tr><td>"<code>wheel</code>"    <td>"<code>scroll</code>"               <td><a>Dispatch a scroll action</a>	
 </table>
@@ -8793,13 +8797,15 @@ Return <a>success</a> with data <var>action</var>.
   <var>current delta y</var>.
 
   <p>Otherwise let <var>delta x</var> equal an approximation
-   to <var>duration ratio</var> &times; <var>target delta x</var>,
+   to <var>duration ratio</var> &times; <var>target delta x</var> -
+   <var>current delta x</var>,
    and <var>delta y</var> equal an approximation to
-   <var>duration ratio</var> &times; <var>target delta y</var>.
+   <var>duration ratio</var> &times; <var>target delta y</var> -
+   <var>current delta y</var>.
  
- <li><p>If <var>current delta x</var> is not equal to
-  <var>target delta x</var> or <var>current delta y</var> is not equal
-  to <var>target delta y</var>, run the following steps:
+ <li><p>If <var>delta x</var> is not equal to <var>0</var> or
+  <var>delta y</var> is not equal to <var>0</var>,
+  run the following steps:
 
   <ol>
    <li><p><a>Perform implementation-specific

--- a/index.html
+++ b/index.html
@@ -7666,11 +7666,11 @@ If <var>deltaX</var> is not <a>undefined</a> and is not an <a>Integer</a>,
 return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
 <li><p>
-Set the <code>delta x</code> property of <var>action</var> to <var>delta x</var>.
+Set the <code>deltaX</code> property of <var>action</var> to <var>deltaX</var>.
 
 <li><p>
-Let <var>delta y</var> be the result of <a>getting the property</a>
-<code>delta y</code> from <var>action item</var>.
+Let <var>deltaY</var> be the result of <a>getting the property</a>
+<code>deltaY</code> from <var>action item</var>.
 
 <li><p>
 If <var>deltaY</var> is not <a>undefined</a> and is not an <a>Integer</a>,
@@ -7678,10 +7678,6 @@ return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
 <li><p>
 Set the <code>deltaY</code> property of <var>action</var> to <var>deltaY</var>.
-
-<li><p>
-If <var>delta x</var> is not <a>undefined</a> and is not an <a>Integer</a>,
-return <a>error</a> with <a>error code</a> <a>invalid argument</a>.        
 
 <li><p>
 Return <a>success</a> with data <var>action</var>.

--- a/index.html
+++ b/index.html
@@ -7064,16 +7064,7 @@ and a <code>y</code> property which is an unsigned integer.
  both <code>x</code> and <code>y</code> set to <code>0</code>.
 	
 <p>A <a>wheel input source</a>’s <a>input source state</a> is a
- <dfn>wheel input state</dfn> object. This is an object with an
- <code>x</code> property which is an unsigned integer, a <code>y</code>
- property which is an unsigned integer, a <code>deltaX</code> property
- which is an integer, and a <code>deltaY</code> property which is an
- integer.
-
-<p>When required to <dfn>create a new wheel input state object</dfn>,
- an implementation must return a <a>wheel input state</a> object with
- the <code>x</code>, <code>y</code>, <code>deltaX</code>, and
- <code>deltaY</code> properties all set to <code>0</code>.
+ <dfn>wheel input state</dfn> object. This is always an empty object.
 
 <p>Each <a>session</a> has an associated <dfn>input state table</dfn>.
  This is a map between <a>input id</a>
@@ -8673,7 +8664,7 @@ Return <a>success</a> with data <var>action</var>.
 
 <p>When required to <dfn>dispatch a scroll action</dfn> with
  arguments <var>source id</var>, <var>action object</var>,
- <var>input state</var> and <var>tick duration</var> a
+ and <var>tick duration</var> a
  <a>remote end</a> must run the following steps:
 
 <ol>
@@ -8682,12 +8673,6 @@ Return <a>success</a> with data <var>action</var>.
 
  <li><p>Let <var>y offset</var> be equal to the <code>y</code>
   property of <var>action object</var>.
-
- <li><p>Let <var>start x</var> be equal to the <code>x</code>
-  property of <var>input state</var>.
-
- <li><p>Let <var>start y</var> be equal to the <code>y</code>
-  property of <var>input state</var>.
 
  <li><p>Let <var>origin</var> be equal to the <code>origin</code>
   property of <var>action object</var>.
@@ -8699,11 +8684,6 @@ Return <a>success</a> with data <var>action</var>.
    <dt>"<code>viewport</code>"
    <dd><p>Let <var>x</var> equal <var>x offset</var> and
     <var>y</var> equal <var>y offset</var>.</dd>
-
-   <dt>"<code>pointer</code>"
-   <dd><p>Let <var>x</var> equal <var>start x</var> +
-    <var>x offset</var> and <var>y</var> equal
-    <var>start y</var> + <var>y  offset</var>.</dd>
 
    <dt>An object that <a>represents a web element</a></dt>
    <dd>
@@ -8755,16 +8735,18 @@ Return <a>success</a> with data <var>action</var>.
  </li>
 
  <li><p><a>Perform a scroll</a> with arguments
-  <var>source id</var>, <var>input state</var>, <var>duration</var>,
-  <var>x</var>, <var>y</var>, <var>delta x</var>, <var>delta y</var>.
+  <var>source id</var>, <var>duration</var>,
+  <var>x</var>, <var>y</var>, <var>delta x</var>, <var>delta y</var>,
+  <var>0</var>, <var>0</var>.
 
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
 
 <p>When required to <dfn>perform a scroll</dfn> with
- arguments <var>source id</var>, <var>input state</var>,
+ arguments <var>source id</var>,
  <var>duration</var>, <var>x</var>, <var>y</var>,
- <var>target delta x</var> and <var>target delta y</var>,
+ <var>target delta x</var>, <var>target delta y</var>,
+ <var>current delta x</var> and <var>current delta y</var>,
  an implementation must run the following steps:
 
 <ol>
@@ -8780,12 +8762,6 @@ Return <a>success</a> with data <var>action</var>.
   the implementation will not further subdivide the move action,
   let <var>last</var> be true. Otherwise let <var>last</var>
   be <code>false</code>.
-
- <li><p>Let <var>current delta x</var> equal the <code>deltaX</code>
-  property of <var>input state</var>.
-
- <li><p>Let <var>current delta y</var> equal the <code>deltaY</code>
-  property of <var>input state</var>.
 
  <li><p>If <var>last</var> is true, let <var>delta x</var> equal
   <var>target delta x</var> - <var>current delta x</var> and
@@ -8810,14 +8786,10 @@ Return <a>success</a> with data <var>action</var>.
     viewport y coordinate <var>y</var>, deltaX value <var>delta x</var>,
     deltaY value <var>delta y</var>, in accordance with the
     requirements of [[UI-EVENTS]].
-
-   <li><p>Let <var>input state</var>’s <code>x</code> property
-    equal <var>x</var> and <code>y</code> property
-    equal <var>y</var>.
-	   
-   <li><p>Let <var>input state</var>’s <code>deltaX</code> property
+ 
+   <li><p>Let <code>current delta x</code> property
     equal <var>delta x</var>  + <var>current delta x</var> and
-    <code>deltaY</code> property equal
+    <code>current delta y</code> property equal
     <var>delta y</var>  + <var>current delta y</var>.	   
   </ol>
 
@@ -8849,9 +8821,10 @@ Return <a>success</a> with data <var>action</var>.
     vsync).</aside>
 
    <li><p><a>Perform a scroll</a> with arguments
-    <var>source id</var>, <var>input state</var>, <var>duration</var>,
-    <var>x</var>, <var>y</var>, <var>target delta x</var>,
-    <var>target delta y</var>.
+    <var>source id</var>, <var>duration</var>,
+    <var>x</var>, <var>y</var>,
+    <var>target delta x</var>, <var>target delta y</var>,
+    <var>current delta x</var>, <var>current delta y</var>.
  </ol>
 
 </ol>

--- a/index.html
+++ b/index.html
@@ -6960,6 +6960,22 @@ For convenience the same terminology is used for their manipulation.
  </tr>
 </table>
 
+<p>A <dfn>wheel input source</dfn> is an <a>input source</a>
+ that is associated with a wheel-type input device.
+ A <a>wheel input source</a> supports the same <a>pause</a> action
+ as a <a>null input source</a> plus the following actions:
+
+ <table class=simple>
+  <tr>
+   <th>Action
+   <th>Non-normative Description
+  </tr>
+  <tr>
+   <td><dfn>scroll</dfn></td>
+   <td>Used to indicate that the scroll wheel is rolled down, up, right
+    or left to scroll the page down, up, right or left.</td>
+  </tr>
+ </table>
 <p>Each <a>session</a> maintains a <a>list</a> of <dfn>active input
 sources</dfn>. This list is initially empty. When an <a>input
 source</a> is added to the list of <a>active input sources</a>, a

--- a/index.html
+++ b/index.html
@@ -7896,8 +7896,8 @@ Return <a>success</a> with data <var>action</var>.
 <tr><td>"<code>pointer</code>"	<td>"<code>pointerUp</code>"		<td><a>Dispatch a pointerUp action</a>
 <tr><td>"<code>pointer</code>"	<td>"<code>pointerMove</code>		<td><a>Dispatch a pointerMove action</a>
 <tr><td>"<code>pointer</code>"	<td>"<code>pointerCancel</code>		<td><a>Dispatch a pointerCancel action</a>
-<tr><td>"<code>wheel</code>"	<td>"<code>pause</code>"		<td><a>Dispatch a pause action</a>
-<tr><td>"<code>wheel</code>"	<td>"<code>scroll</code>"		<td><a>Dispatch a scroll action</a>	
+<tr><td>"<code>wheel</code>"    <td>"<code>pause</code>"                <td><a>Dispatch a pause action</a>
+<tr><td>"<code>wheel</code>"    <td>"<code>scroll</code>"               <td><a>Dispatch a scroll action</a>	
 </table>
 
    <li><a>Try</a> to run <var>algorithm</var> with arguments
@@ -8666,6 +8666,195 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
 </section> <!-- /pointer-actions -->
+
+
+<section>
+<h4>Wheel actions</h4>
+
+<p>When required to <dfn>dispatch a scroll action</dfn> with
+ arguments <var>source id</var>, <var>action object</var>,
+ <var>input state</var> and <var>tick duration</var> a
+ <a>remote end</a> must run the following steps:
+
+<ol>
+ <li><p>Let <var>x offset</var> be equal to the <code>x</code>
+  property of <var>action object</var>.
+
+ <li><p>Let <var>y offset</var> be equal to the <code>y</code>
+  property of <var>action object</var>.
+
+ <li><p>Let <var>start x</var> be equal to the <code>x</code>
+  property of <var>input state</var>.
+
+ <li><p>Let <var>start y</var> be equal to the <code>y</code>
+  property of <var>input state</var>.
+
+ <li><p>Let <var>origin</var> be equal to the <code>origin</code>
+  property of <var>action object</var>.
+
+ <li><p>Run the substeps of the first matching value
+  of <var>origin</var>:
+
+  <dl>
+   <dt>"<code>viewport</code>"
+   <dd><p>Let <var>x</var> equal <var>x offset</var> and
+    <var>y</var> equal <var>y offset</var>.</dd>
+
+   <dt>"<code>pointer</code>"
+   <dd><p>Let <var>x</var> equal <var>start x</var> +
+    <var>x offset</var> and <var>y</var> equal
+    <var>start y</var> + <var>y  offset</var>.</dd>
+
+   <dt>An object that <a>represents a web element</a></dt>
+   <dd>
+    <ol>
+     <li><p>Let <var>element</var> be equal to the result
+      of <a>trying</a> to <a>get a known connected element</a> with
+      argument <var>origin</var>.
+
+     <li><p>Let <var>x element</var> and <var>y element</var> be the
+      result of calculating the <a>in-view center point</a>
+      of <var>element</var>.
+
+     <li><p>Let <var>x</var> equal <var>x element</var> +
+      <var>x offset</var>, and <var>y</var> equal
+      <var>y element</var> + <var>y offset</var>.
+    </ol>
+   </dd>
+  </dl>
+
+ <li><p>If <var>x</var> is less than 0 or greater than the width of
+  the viewport in <a>CSS pixels</a>, then
+  return <a>error</a> with error code <a>move target out of
+  bounds</a>.
+
+ <li><p>If <var>y</var> is less than 0 or greater than the height of
+  the viewport in <a>CSS pixels</a>, then
+  return <a>error</a> with error code <a>move target out of
+  bounds</a>.
+	 
+ <li><p>Let <var>delta x</var> be equal to the <code>delta x</code>
+  property of <var>action object</var>.
+
+ <li><p>Let <var>delta y</var> be equal to the <code>delta y</code>
+  property of <var>action object</var>.
+
+ <li><p>Let <var>duration</var> be equal to
+  <var>action object</var>’s <code>duration</code> property if it
+  is not <a>undefined</a>, or <var>tick duration</var>
+  otherwise.
+
+ <li><p>If <var>duration</var> is greater than 0 and inside any
+  implementation-defined bounds, <a>asynchronously wait</a> for an
+  implementation defined amount of time to pass.
+
+  <aside><p>This wait allows the implementation to model the overall
+   pointer move as a series of small movements occurring at an
+   implementation defined rate (e.g. one movement per
+   vsync).</p></aside>
+ </li>
+
+ <li><p><a>Perform a scroll</a> with arguments
+  <var>source id</var>, <var>input state</var>, <var>duration</var>,
+  <var>x</var>, <var>y</var>, <var>delta x</var>, <var>delta y</var>.
+
+ <li><p>Return <a>success</a> with data <a><code>null</code></a>.
+</ol>
+
+<p>When required to <dfn>perform a scroll</dfn> with
+ arguments <var>source id</var>, <var>input state</var>,
+ <var>duration</var>, <var>x</var>, <var>y</var>,
+ <var>target delta x</var> and <var>target delta y</var>,
+ an implementation must run the following steps:
+
+<ol>
+ <li><p>Let <var>time delta</var> be the time since the beginning of
+  the current <a>tick</a>, measured in milliseconds on a monotonic
+  clock.
+
+ <li><p>Let <var>duration ratio</var> be the ratio of
+  <var>time delta</var> and <var>duration</var>, if <var>duration</var>
+  is greater than 0, or 1 otherwise.
+
+ <li><p>If <var>duration ratio</var> is 1, or close enough to 1 that
+  the implementation will not further subdivide the move action,
+  let <var>last</var> be true. Otherwise let <var>last</var>
+  be <code>false</code>.
+
+ <li><p>Let <var>current delta x</var> equal the <code>delta x</code>
+  property of <var>input state</var>.
+
+ <li><p>Let <var>current delta y</var> equal the <code>delta y</code>
+  property of <var>input state</var>.
+
+ <li><p>If <var>last</var> is true, let <var>delta x</var> equal
+  <var>target delta x</var> - <var>current delta x</var> and
+  <var>delta y</var> equal <var>target delta y</var> -
+  <var>current delta y</var>.
+
+  <p>Otherwise let <var>delta x</var> equal an approximation
+   to <var>duration ratio</var> &times; <var>target delta x</var>,
+   and <var>delta y</var> equal an approximation to
+   <var>duration ratio</var> &times; <var>target delta y</var>.
+ 
+ <li><p>If <var>current delta x</var> is not equal to
+  <var>target delta x</var> or <var>current delta y</var> is not equal
+  to <var>target delta y</var>, run the following steps:
+
+  <ol>
+   <li><p><a>Perform implementation-specific
+    action dispatch steps</a> equivalent to wheel scroll with
+    ID <var>source id</var> at viewport x coordinate <var>x</var>,
+    viewport y coordinate <var>y</var>, <var>delta x</var>,
+    <var>delta y</var>, in accordance with the
+    requirements of [[UI-EVENTS]].
+
+   <li><p>Let <var>input state</var>’s <code>x</code> property
+    equal <var>x</var> and <code>y</code> property
+    equal <var>y</var>.
+	   
+   <li><p>Let <var>input state</var>’s <code>delta x</code> property
+    equal <var>delta x</var>  + <var>current delta x</var> and
+    <code>delta y</code> property equal
+    <var>delta y</var>  + <var>current delta y</var>.	   
+  </ol>
+
+ <li><p>If <var>last</var> is true, return.
+
+ <li><p>Run the following substeps <a>in parallel</a>:
+
+  <aside class=note>
+   <p>This algorithm may trigger multiple events spread across some
+    duration. Parallelism is applied intentionally in order to manage the
+    scheduling of these events relative to the events triggered by other
+    actions in the same tick.
+
+   <p>The initial scroll is performed synchronously. This ensures
+    determinism in the sequence of the first event triggered by each
+    action in the tick.
+
+   <p>Subsequent scrolls (if any) are performed asynchronously. This allows
+    events from two <a>scroll</a> actions in the tick to be interspersed.
+  </aside>
+
+ <ol>
+   <li><p><a>Asynchronously wait</a> for an implementation defined
+    amount of time to pass.
+
+   <aside><p>This wait allows the implementation to model the overall
+    scroll as a series of small scrolls occurring at an
+    implementation defined rate (e.g. one scroll per
+    vsync).</aside>
+
+   <li><p><a>Perform a scroll</a> with arguments
+    <var>source id</var>, <var>input state</var>, <var>duration</var>,
+    <var>x</var>, <var>y</var>, <var>delta x</var>, <var>delta y</var>,
+    <var>target delta x</var>, <var>target delta y</var>.
+ </ol>
+
+</ol>
+
+</section> <!-- /wheel-actions -->
 </section> <!-- /dispatching-actions -->
 
 

--- a/index.html
+++ b/index.html
@@ -7317,6 +7317,9 @@ from a machine utilisation perspective.
      <dd>Create a new <a>pointer input source</a>. Let the
       new <a>input source</a>’s <a>pointer type</a> be set to the value
       of <var>parameters</var>’s <code>pointerType</code> property.
+    
+     <dt>"<code>wheel</code>"
+     <dd>Create a new <a>wheel input source</a>.
     </dl>
 
    <li><p>Add <var>source</var> to the <a>current session</a>’s list
@@ -7366,6 +7369,11 @@ from a machine utilisation perspective.
     let <var>action</var> be the result of <a>trying</a> to <a>process
     a pointer action</a> with parameters <var>id</var>,
     <var>parameters</var>, and <var>action item</var>.
+
+   <li><p>Otherwise, if <var>type</var> is "<code>wheel</code>"
+    let <var>action</var> be the result of <a>trying</a> to <a>process
+    a wheel action</a> with parameters <var>id</var>, and
+    <var>action item</var>.
 
    <li><p>Append <var>action</var> to <var>actions</var>.
   </ol>


### PR DESCRIPTION
The current Webdriver Actions API’s pointer source types have three input types: "mouse", "pen", and "touch". For the three pointer type, it only supports actions of "pointerDown", "pointerUp", "pointerMove" and "pointerCancel". We cannot generate a mouse wheel scroll from the current source types and actions. We want to add a new source type to generate wheel events to support testing wheel scroll or zoom on web pages.

The design doc is 
https://docs.google.com/document/d/1AzPkvexzuUJ1SF-6pZFpnn2lwEYlk3T0e-Wi52UWFZ4/

WPT tests:
https://cs.chromium.org/chromium/src/third_party/blink/web_tests/external/wpt/uievents/order-of-events/mouse-events/wheel-scrolling-manual.htm
https://cs.chromium.org/chromium/src/third_party/blink/web_tests/external/wpt/uievents/order-of-events/mouse-events/wheel-basic-manual.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/SummerLW/webdriver/pull/1522.html" title="Last updated on Aug 19, 2020, 6:13 AM UTC (704125b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1522/cebfd28...SummerLW:704125b.html" title="Last updated on Aug 19, 2020, 6:13 AM UTC (704125b)">Diff</a>