### PR TITLE
Normalize markup in definitions index

### DIFF
--- a/index.html
+++ b/index.html
@@ -9963,7 +9963,7 @@ to automatically sort each list alphabetically.
    <!-- HTML Element --> <li><dfn><a href=https://html.spec.whatwg.org/#the-html-element><code>html</code> element</a></dfn>
    <!-- iframe element --> <li><dfn data-lt=iframe><a href=https://html.spec.whatwg.org/#the-iframe-element><code>iframe</code> element</a></dfn>
    <!-- input element --> <li><dfn data-lt="input elements"><a href=https://html.spec.whatwg.org/#the-input-element><code>input</code> element</a></dfn>
-   <!-- map element --> <li><a href=https://html.spec.whatwg.org/#the-map-element><dfn><code>map</code> element</dfn></a>
+   <!-- map element --> <li><dfn><a href=https://html.spec.whatwg.org/#the-map-element><code>map</code> element</a></dfn>
    <!-- optgroup element --> <li><dfn data-lt=optgroup><a href=https://html.spec.whatwg.org/#the-optgroup-element><code>optgroup</code> element</a></dfn>
    <!-- option element --> <li><dfn data-lt="option elements|option"><a href=https://html.spec.whatwg.org/#the-option-element><code>option</code> element</a></dfn>
    <!-- output element --> <li><dfn data-lt=output><a href=https://html.spec.whatwg.org/#the-output-element><code>output</code> element</a></dfn>
@@ -9991,8 +9991,8 @@ to automatically sort each list alphabetically.
 
  <dd><p>The HTML specification also defines a range of different attributes:
   <ul>
-   <!-- Canvas height attribute --> <li><dfn lt="canvas height attribute"><a href=https://html.spec.whatwg.org/#attr-canvas-height><code>canvas</code>’s height attribute</a></dfn>
-   <!-- Canvas width attribute --> <li><dfn lt="canvas width attribute"><a href=https://html.spec.whatwg.org/#attr-canvas-width><code>canvas</code>’ width attribute</a></dfn>
+   <!-- Canvas height attribute --> <li><dfn data-lt="canvas height attribute"><a href=https://html.spec.whatwg.org/#attr-canvas-height><code>canvas</code>’s height attribute</a></dfn>
+   <!-- Canvas width attribute --> <li><dfn data-lt="canvas width attribute"><a href=https://html.spec.whatwg.org/#attr-canvas-width><code>canvas</code>’ width attribute</a></dfn>
    <!-- Checked content attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-checked>Checked</a></dfn>
    <!-- Multiple attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#attr-input-multiple><code>multiple</code> attribute</a></dfn>
    <!-- readOnly attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#the-readonly-attribute><code>readOnly</code> attribute</a></dfn>
@@ -10070,7 +10070,9 @@ to automatically sort each list alphabetically.
  <dd>The following terms are defined in the
    Page Visibility Specification [[PAGE-VISIBILITY]]
    <ul>
-    <!-- visibility hidden --> <li><dfn data-lt="visibility hidden"><a href="https://www.w3.org/TR/page-visibility/#dom-visibilitystate-hidden">Visibility state <code>hidden</code></a></dfn>    <!-- visibility state --> <li><dfn>Visibility state</dfn> being the <a href="https://www.w3.org/TR/page-visibility/#visibility-states-and-the-visibilitystate-enum"><code>visibilityState</code></a> attribute on <a>Document</a>    <!-- visibility visible --> <li><dfn data-lt="visibility visible"><a href="https://www.w3.org/TR/page-visibility/#dom-visibilitystate-visible">Visibility state <code>visible</code></a></dfn>
+    <!-- visibility hidden --> <li><dfn data-lt="visibility hidden"><a href="https://www.w3.org/TR/page-visibility/#dom-visibilitystate-hidden">Visibility state <code>hidden</code></a></dfn>
+    <!-- visibility state --> <li><dfn>Visibility state</dfn> being the <a href="https://www.w3.org/TR/page-visibility/#visibility-states-and-the-visibilitystate-enum"><code>visibilityState</code></a> attribute on <a>Document</a>
+    <!-- visibility visible --> <li><dfn data-lt="visibility visible"><a href="https://www.w3.org/TR/page-visibility/#dom-visibilitystate-visible">Visibility state <code>visible</code></a></dfn>
    </ul>
 
  <dt>Selenium
@@ -10111,7 +10113,7 @@ to automatically sort each list alphabetically.
  <dd>The following terms are defined in
   the Geometry Interfaces Module Level 1 specification: [[GEOMETRY-1]]
   <ul>
-   <!-- DOMRect --> <li><a href="https://www.w3.org/TR/geometry-1/#dom-domrect"><dfn><code>DOMRect</code></dfn></a>
+   <!-- DOMRect --> <li><dfn><a href="https://www.w3.org/TR/geometry-1/#dom-domrect"><code>DOMRect</code></a></dfn>
    <!-- Rectangle --> <li><dfn data-lt="bounding rectangle"><a href=https://drafts.fxtf.org/geometry/#rectangle>Rectangle</a></dfn>
    <!-- Rectangle height dimension --> <li><dfn data-lt="height dimension"><a href=https://drafts.fxtf.org/geometry/#rectangle-height-dimension>Rectangle height dimension</a></dfn>
    <!-- Rectangle width dimension --> <li><dfn data-lt="width dimension"><a href=https://drafts.fxtf.org/geometry/#rectangle-width-dimension>Rectangle width dimension</a></dfn>
@@ -10209,8 +10211,8 @@ to automatically sort each list alphabetically.
   must be interpreted as required for conforming IDL fragments,
   as described in the Web IDL specification. [[WEBIDL]]
   <ul>
-   <!-- DOMException --> <li><a href="https://heycam.github.io/webidl/#dfn-DOMException"><dfn><code>DOMException</code></dfn></a>
-   <!-- Sequence --> <li><a href="https://heycam.github.io/webidl/#idl-sequence"><dfn>Sequence</dfn></a>
+   <!-- DOMException --> <li><dfn><a href="https://heycam.github.io/webidl/#dfn-DOMException"><code>DOMException</code></a></dfn>
+   <!-- Sequence --> <li><dfn><a href="https://heycam.github.io/webidl/#idl-sequence">Sequence</a></dfn>
    <!-- Supported property indices --> <li><dfn data-lt="supported property index"><a href=https://heycam.github.io/webidl/#dfn-supported-property-indices>Supported property indices</a></dfn>
    <!-- SyntaxError --> <li><dfn><a href="https://heycam.github.io/webidl/#syntaxerror"><code>SyntaxError</code></a></dfn></li>
 
@@ -10228,16 +10230,16 @@ to automatically sort each list alphabetically.
   <dt>XML Namespaces
   <dd><p>The following terms are defined in the Namespaces in XML [[XML-NAMES]]
     <ul>
-      <!-- qualified element name --><li><a href="https://www.w3.org/TR/REC-xml-names/#ns-using"><dfn>qualified element name</dfn></a>
+      <!-- qualified element name --><li><dfn><a href="https://www.w3.org/TR/REC-xml-names/#ns-using">qualified element name</a></dfn>
     </ul>
 
   <dt>XPATH
   <dd><p>The following terms are defined in the Document Object Model XPath standard [[XPATH]]
     <ul>
-      <!-- evaluate --><li><a href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator-evaluate"><dfn><code>evaluate</code></dfn></a>
-      <!-- ORDERED_NODE_SNAPSHOT_TYPE --><li><a href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-ORDERED-NODE-SNAPSHOT-TYPE"><dfn><code>ORDERED_NODE_SNAPSHOT_TYPE</code></dfn></a>
-      <!-- snapshotItem --><li><a href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-snapshotItem"><dfn><code>snapshotItem</code></dfn></a>
-      <!-- XPathException --><li><a href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathException"><dfn><code>XPathException</code></dfn></a>
+      <!-- evaluate --><li><dfn><a href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator-evaluate"><code>evaluate</code></a></dfn>
+      <!-- ORDERED_NODE_SNAPSHOT_TYPE --><li><dfn><a href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-ORDERED-NODE-SNAPSHOT-TYPE"><code>ORDERED_NODE_SNAPSHOT_TYPE</code></a></dfn>
+      <!-- snapshotItem --><li><dfn><a href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-snapshotItem"><code>snapshotItem</code></a></dfn>
+      <!-- XPathException --><li><dfn><a href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathException"><code>XPathException</code></a></dfn>
     </ul>
 </dl>
 </section>


### PR DESCRIPTION
A few of these result in warnings about links inside links with
Bikeshed, but normalize all of them to the same style.

Drive-by lt->data-lt and wrapping of page visibility terms.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/webdriver/pull/1524.html" title="Last updated on Jun 2, 2020, 3:27 PM UTC (dbc9dce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1524/4c58fec...foolip:dbc9dce.html" title="Last updated on Jun 2, 2020, 3:27 PM UTC (dbc9dce)">Diff</a>