### PR TITLE
Consolidate the DOM Parsing and Serialization references

### DIFF
--- a/index.html
+++ b/index.html
@@ -9716,12 +9716,13 @@ to automatically sort each list alphabetically.
    <!-- textContent attribute --> <li><dfn data-lt=textContent><a href=https://dom.spec.whatwg.org/#dom-node-textcontent><code>textContent</code> attribute</a></dfn>
   </ul>
 
- <dd><p>The following attributes are defined in
-  the DOM Parsing and Serialisation specification: [[DOM-PARSING]]
+ <dd><p>The following terms are defined in
+  the DOM Parsing and Serialization specification: [[DOM-PARSING]]
   <ul>
-   <!-- innerHTML IDL Attribute--> <li><dfn><a href=https://w3c.github.io/DOM-Parsing/#dom-element-innerhtml><code>innerHTML</code> IDL attribute</a></dfn>
+   <!-- fragment serializing algorithm --> <li><dfn><a href="https://w3c.github.io/DOM-Parsing/#dfn-fragment-serializing-algorithm">fragment serializing algorithm</a></dfn>
+   <!-- innerHTML IDL Attribute--> <li><dfn><a href=https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml><code>innerHTML</code> IDL attribute</a></dfn>
    <!-- outerHTML IDL Attribute--> <li><dfn><a href=https://w3c.github.io/DOM-Parsing/#dom-element-outerhtml><code>outerHTML</code> IDL attribute</a></dfn>
-   <!-- serializeToString --> <li><dfn data-lt="serializing to string"><a href=https://w3c.github.io/DOM-Parsing/#dom-xmlserializer-serializetostring><code>serializeToString</code></a></dfn>
+   <!-- serializeToString --> <li><dfn data-lt="serializing to string"><a href=https://w3c.github.io/DOM-Parsing/#dom-xmlserializer-serializetostring><code>serializeToString</code> method</a></dfn>
   </ul>
 
  <dd><p>The following attributes are defined
@@ -9753,13 +9754,6 @@ to automatically sort each list alphabetically.
   <ul>
    <li><dfn data-lt="modifier key"><a href=https://www.w3.org/TR/uievents-key/#keys-modifier>Keyboard modifier keys</a></dfn>
   </ul>
-
- <dt>DOM Parsing
- <dd><p>The following terms are defined in the DOM Parsing and Serialization Specification: [[DOMPARSING]]
-  <ul>
-   <li><!-- Fragment serializing algorithm --><dfn><a href="https://w3c.github.io/DOM-Parsing/#dfn-fragment-serializing-algorithm">Fragment serializing algorithm</a></dfn>
-  </ul>
- </dd>
 
  <dt>ECMAScript
  <dd><p>The following terms are defined in the ECMAScript Language Specification: [[ECMA-262]]


### PR DESCRIPTION
Both [DOM-PARSING] and [DOMPARSING] were referenced, and the latter
resolved to https://domparsing.spec.whatwg.org/, which doesn't exist.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/webdriver/pull/1525.html" title="Last updated on Jun 2, 2020, 6:06 PM UTC (90f1eb6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1525/4c58fec...foolip:90f1eb6.html" title="Last updated on Jun 2, 2020, 6:06 PM UTC (90f1eb6)">Diff</a>