### PR TITLE
Tweak IDL definition style to avoid unused <dfn>

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@ and decorations (such as operating system widget borders).
 </section> <!-- /Terminology -->
 
 
-<section data-dfn-for=NavigatorAutomationInformation data-link-for=NavigatorAutomationInformation>
+<section>
 <h2>Interface</h2>
 
 <p>
@@ -228,18 +228,15 @@ is set to true when the user agent is under remote control.
 It is initially false.
 
 <pre class=idl>
-<a>Navigator</a> includes <a>NavigatorAutomationInformation</a>;
-</pre>
-
-<p>
-Note that the <dfn>NavigatorAutomationInformation</dfn> interface
-should not be exposed on <a><code>WorkerNavigator</code></a>.
-
-<pre class=idl>
 interface mixin NavigatorAutomationInformation {
-	readonly attribute boolean webdriver;
+  readonly attribute boolean webdriver;
 };
+Navigator includes NavigatorAutomationInformation;
 </pre>
+
+<p class=note>
+The {{NavigatorAutomationInformation}} interface
+should not be exposed on {{WorkerNavigator}}.
 
 <dl>
 <dt><dfn>webdriver</dfn>


### PR DESCRIPTION
<dfn>NavigatorAutomationInformation</dfn> was unused and results in a
warning when converting to Bikeshed.

Use a style closer to the "ideal linking setup" instead:
https://github.com/w3c/respec/wiki/WebIDL-Guide

data-dfn-for/data-link-for are no longer needed with this setup.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/webdriver/pull/1526.html" title="Last updated on Jun 2, 2020, 7:15 PM UTC (fb68e5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1526/4c58fec...foolip:fb68e5c.html" title="Last updated on Jun 2, 2020, 7:15 PM UTC (fb68e5c)">Diff</a>