### PR TITLE
Add a hook immediately before a new session is created

### DIFF
--- a/index.html
+++ b/index.html
@@ -1379,15 +1379,16 @@ either <a><code>null</code></a> to indicate the capability is not
 matched, or a non-null JSON-serializable value if the capability is
 matched.
 
-<p>Other specifications may also define a <dfn>WebDriver new
-session algorithm</dfn>, which are called just after a new session is
-created, and before the <a>new session</a> response is sent to the
-<a>remote end</a>. These algorithms are called with <var>session</var>
-representing the WebDriver session that will be established,
-and <var>capabilites</var>, the capabilities object that will be
-returned to the <a>remote end</a>. It is permitted for such an
-algorithm to modify any entry in the capabilities object with a name
-that's an <a>additional WebDriver capability</a> defined by the same
+<p>Other specifications may also define <dfn data-lt="WebDriver new
+session algorithm">WebDriver new session algorithms</dfn>, which are
+called just after a new session is created, and before the <a>new
+session</a> response is sent to the <a>remote end</a>. These
+algorithms are called with <var>session</var> representing the
+WebDriver session that will be established, and
+<var>capabilites</var>, the capabilities object that will be returned
+to the <a>remote end</a>. It is permitted for such an algorithm to
+modify any entry in the capabilities object with a name that's an
+<a>additional WebDriver capability</a> defined by the same
 specification.
 
 <p><a>Remote ends</a> may also introduce
@@ -2361,7 +2362,7 @@ If the creation fails, a <a>session not created</a> <a>error</a> is returned.
 
  <li><p>Set the <a>current session</a> to <var>session</var>.
 
- <li><p>Run any <a>WebDriver new session algorithm</a>defined in
+ <li><p>Run any <a>WebDriver new session algorithm</a> defined in
  external specifications, with arguments <var>session</var>
  and <var>capabilities</var>.
 

--- a/index.html
+++ b/index.html
@@ -1379,6 +1379,17 @@ either <a><code>null</code></a> to indicate the capability is not
 matched, or a non-null JSON-serializable value if the capability is
 matched.
 
+<p>Other specifications may also define a <dfn>WebDriver new
+session algorithm</dfn>, which are called just after a new session is
+created, and before the <a>new session</a> response is sent to the
+<a>remote end</a>. These algorithms are called with <var>session</var>
+representing the WebDriver session that will be established,
+and <var>capabilites</var>, the capabilities object that will be
+returned to the <a>remote end</a>. It is permitted for such an
+algorithm to modify any entry in the capabilities object with a name
+that's an <a>additional WebDriver capability</a> defined by the same
+specification.
+
 <p><a>Remote ends</a> may also introduce
  <dfn data-lt="extension capability">extension capabilities</dfn>
  that are extra <a>capabilities</a>
@@ -2349,6 +2360,10 @@ If the creation fails, a <a>session not created</a> <a>error</a> is returned.
   with the <a>session ID</a> of <var>session id</var>.
 
  <li><p>Set the <a>current session</a> to <var>session</var>.
+
+ <li><p>Run any <a>WebDriver new session algorithm</a>defined in
+ external specifications, with arguments <var>session</var>
+ and <var>capabilities</var>.
 
  <li><p>Append <var>session</var> to <a>active sessions</a>.
 


### PR DESCRIPTION
The hook allows other specs to get access to the session and the
capabilities immediately before the new session response is sent to
the local end. This allows them to set up any state that is connected
to the session, and update the value of any capabilities they own in
the response.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1527.html" title="Last updated on Jun 4, 2020, 8:13 AM UTC (8e92a48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1527/a953788...8e92a48.html" title="Last updated on Jun 4, 2020, 8:13 AM UTC (8e92a48)">Diff</a>