### PR TITLE
Fix typo from width to height in print description

### DIFF
--- a/index.html
+++ b/index.html
@@ -9369,7 +9369,7 @@ argument <var>input</var> an implementation must:
   default of <code>21.59</code> from <var>page</var>.
 
  <li><p>Let <var>pageHeight</var> be the result of <a>getting a
-  property with default</a> named <code>width</code> and with a
+  property with default</a> named <code>height</code> and with a
   default of <code>27.94</code> from <var>page</var>.
 
  <li><p>If either of <var>pageWidth</var> or <var>pageHeight</var> is


### PR DESCRIPTION
Should be height instead of width


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k7z45/webdriver/pull/1532.html" title="Last updated on Jun 9, 2020, 11:54 PM UTC (d6e01e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1532/4217382...k7z45:d6e01e3.html" title="Last updated on Jun 9, 2020, 11:54 PM UTC (d6e01e3)">Diff</a>