### PR TITLE
SameSite values should be capitalized

### DIFF
--- a/index.html
+++ b/index.html
@@ -6578,7 +6578,7 @@ The first argument provided to the function will be serialized to JSON and retur
   <td>✓
   <td>Whether the cookie applies to a SameSite policy.
     Defaults to None if omitted when <a>adding a cookie</a>.
-    Can be set to either <a><code>lax</code></a> or <a><code>strict</code></a>.
+    Can be set to either <a><code>Lax</code></a> or <a><code>Strict</code></a>.
  </tr>
 </table>
 
@@ -10044,8 +10044,8 @@ to automatically sort each list alphabetically.
 
 <dd><p>The following terms are defined in the Same Site Cookie specification: [[RFC6265bis]]
   <ul>
-    <!-- lax --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-06#section-4.1.2.7"><code>lax</code></a></dfn>
-    <!-- strict --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-06#section-4.1.2.7"><code>strict</code></a></dfn>
+    <!-- lax --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-06#section-4.1.2.7"><code>Lax</code></a></dfn>
+    <!-- strict --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-06#section-4.1.2.7"><code>Strict</code></a></dfn>
   </ul>
 
  <dd><p>The following terms are defined in


### PR DESCRIPTION
The linked specs and the wpt tests all show values being capitalized


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/titusfortner/webdriver/pull/1535.html" title="Last updated on Jul 16, 2020, 4:02 AM UTC (3d3e39d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1535/536adfe...titusfortner:3d3e39d.html" title="Last updated on Jul 16, 2020, 4:02 AM UTC (3d3e39d)">Diff</a>