### PR TITLE
Modify: SameSite now defaults to Lax

### DIFF
--- a/index.html
+++ b/index.html
@@ -6577,8 +6577,11 @@ The first argument provided to the function will be serialized to JSON and retur
   <td>"<code>SameSite</code>"
   <td>✓
   <td>Whether the cookie applies to a SameSite policy.
-    Defaults to None if omitted when <a>adding a cookie</a>.
-    Can be set to either <a><code>Lax</code></a> or <a><code>Strict</code></a>.
+    Defaults to Lax if omitted when <a>adding a cookie</a>.
+    Can be set to either <a><code>None</code></a> or <a><code>Strict</code></a>.
+
+  cookie with SameSite=None must also specify secure.
+
  </tr>
 </table>
 

--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@ produces the largest integer, closest to positive infinity,
 that is not larger than <var>value</var>.
 
 <p>
-A <dfn data-lt=uuid>Universally Unique IDentifier (UUID)</dfn>
+A <dfn data-lt=uuid>Universally Unique Identifier (UUID)</dfn>
 is a 128 bits long URN that requires no central registration process.
 <dfn>Generating a UUID</dfn> means
 <i>Creating a UUID From Truly Random or Pseudo-Random Numbers</i>,
@@ -1382,7 +1382,7 @@ called just after a new session is created, and before the <a>new
 session</a> response is sent to the <a>remote end</a>. These
 algorithms are called with <var>session</var> representing the
 WebDriver session that will be established, and
-<var>capabilites</var>, the capabilities object that will be returned
+<var>capabilities</var>, the capabilities object that will be returned
 to the <a>remote end</a>. It is permitted for such an algorithm to
 modify any entry in the capabilities object with a name that's an
 <a>additional WebDriver capability</a> defined by the same
@@ -2841,7 +2841,7 @@ Return <a>success</a> with data <a><code>null</code></a>.
  <dt><a>response</a> is a network error
  <dd><p>Return <a>error</a> with <a>error code</a> <a>unknown error</a>.
   <p class="note">A &quot;network error&quot; in this case is not an
-   HTTP response with a status code indicating an unsucessful result,
+   HTTP response with a status code indicating an unsuccessful result,
    but could be a problem occurring lower in the OSI model, or a
    failed DNS lookup.
 
@@ -6246,7 +6246,7 @@ a <a>remote end</a> must run the following steps:
 </ol>
 
 <p>The rules to <dfn>execute a function body</dfn> are as follows.
- The algorithm returns <a data-lt="completion">an ECMASCript completion record</a>.
+ The algorithm returns <a data-lt="completion">an ECMAScript completion record</a>.
 
 <p>If at any point during the algorithm a <a>user prompt</a> appears,
  abort all subsequent substeps of this algorithm, and return


### PR DESCRIPTION
## Previous Behaviour

SameSite defaults to `None` and it can be set either `Strict` or `Lax`

## New Behaviour

From the data points provided in https://web.dev/samesite-cookies-explained/#samesitenone-must-be-secure and in https://support.google.com/chrome/a/answer/7679408#84, sameSite now deefaults to Lax and also when set to `None`  must also be marked as `Secure`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Harsha509/webdriver/pull/1541.html" title="Last updated on Aug 29, 2020, 2:34 PM UTC (43fe4b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1541/f0c7bdf...Harsha509:43fe4b4.html" title="Last updated on Aug 29, 2020, 2:34 PM UTC (43fe4b4)">Diff</a>