### PR TITLE
take element screenshot: drop scroll feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -9530,17 +9530,10 @@ sets the text field of a <a>window.<code>prompt</code></a>
 The <a>Take Element Screenshot</a> <a>command</a>
 takes a screenshot of the visible region encompassed
 by the <a>bounding rectangle</a> of an <a>element</a>.
-If given a parameter argument <code>scroll</code>
-that evaluates to false, the <a>element</a> will not be <a>scrolled into view</a>.
 
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>Let <var>scroll</var> be the result
-  of <a>getting the property</a> <code>scroll</code> from
-  <var>parameters</var> if it is not <a>undefined</a>.
-  Otherwise let it be true.
-
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 


### PR DESCRIPTION
Issue https://github.com/w3c/webdriver/issues/1245 points out that
you cannot pass data parameters to a GET method request, so it is
currently impossible to pass a "scroll" field to Take Element
Screenshot.

It was also discovered in the discussion that no vendors implement
this feature.  Because we want the specification to match reality,
this patch removes the "scroll" field for Take Element Screenshot.

Fixes: https://github.com/w3c/webdriver/issues/1245

This was originally fixed in 3d0755c, but accidentally got partly
reverted in its merge into master in 4265381.

Signed-off-by: Sam Sneddon <gsnedders@apple.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gsnedders/webdriver/pull/1549.html" title="Last updated on Oct 1, 2020, 4:09 PM UTC (abc2231)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1549/3818807...gsnedders:abc2231.html" title="Last updated on Oct 1, 2020, 4:09 PM UTC (abc2231)">Diff</a>