### PR TITLE
Add pointerevent's additional properties such as width, height, pressure, tiltX, tiltY, twist...

### DIFF
--- a/index.html
+++ b/index.html
@@ -7804,6 +7804,17 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Set the <code>button</code> property of <var>action</var>
   to <var>button</var>.
 
+<li><p>Let <var>width</var> be the result
+  of getting the property <code>width</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>width</var> is not a <a>Number</a> greater than or
+  equal to 0 return <a>error</a> with <a>error code</a>
+  <a>invalid argument</a>.
+
+ <li><p>Set the <code>width</code> property of <var>action</var>
+  to <var>width</var>.
+
  <li><p>Return success with data <a><code>null</code></a>.
 </ol>
 

--- a/index.html
+++ b/index.html
@@ -8693,6 +8693,33 @@ Return <a>success</a> with data <var>action</var>.
   <var>input state</var>’s <code>pressed</code> property, and
   let <var>buttons</var> be the resulting value of that property.
 
+ <li><p>Let <var>width</var> be equal to <var>action object</var>’s
+  <code>width</code> property.
+
+ <li><p>Let <var>height</var> be equal to <var>action object</var>’s
+  <code>height</code> property.
+
+ <li><p>Let <var>pressure</var> be equal to <var>action object</var>’s
+  <code>pressure</code> property.
+
+ <li><p>Let <var>tangentialPressure</var> be equal to
+  <var>action object</var>’s <code>tangentialPressure</code> property.
+
+ <li><p>Let <var>tiltX</var> be equal to <var>action object</var>’s
+  <code>tiltX</code> property.
+
+ <li><p>Let <var>tiltY</var> be equal to <var>action object</var>’s
+  <code>tiltY</code> property.
+
+ <li><p>Let <var>twist</var> be equal to <var>action object</var>’s
+  <code>twist</code> property.
+
+ <li><p>Let <var>altitudeAngle</var> be equal to <var>action object</var>’s
+  <code>altitudeAngle</code> property.
+
+ <li><p>Let <var>azimuthAngle</var> be equal to <var>action object</var>’s
+  <code>azimuthAngle</code> property.
+
  <li><p>Append a copy of <var>action object</var> with
   the <var>subtype</var> property changed to "<code>pointerUp</code>" to
   the <a>current session</a>’s <a>input cancel list</a>.
@@ -8702,7 +8729,10 @@ Return <a>success</a> with data <var>action</var>.
   numbered <var>button</var> on the pointer with ID
   <var>source id</var>, having type <var>pointerType</var> at
   viewport x coordinate <var>x</var>, viewport y
-  coordinate <var>y</var>, with buttons <var>buttons</var> depressed
+  coordinate <var>y</var>, <var>width</var>, <var>height</var>,
+  <var>pressure</var>, <var>tangentialPressure</var>, <var>tiltX</var>,
+  <var>tiltY</var>, <var>twist</var>, <var>altitudeAngle</var>,
+  <var>azimuthAngle</var>, with buttons <var>buttons</var> depressed
   in accordance with the requirements of [[UI-EVENTS]] and
   [[POINTER-EVENTS]]. The generated events must
   set <code>ctrlKey</code>, <code>shiftKey</code>, <code>altKey</code>,
@@ -8843,9 +8873,39 @@ Return <a>success</a> with data <var>action</var>.
    vsync).</p></aside>
  </li>
 
+ <li><p>Let <var>width</var> be equal to <var>action object</var>’s
+  <code>width</code> property.
+
+ <li><p>Let <var>height</var> be equal to <var>action object</var>’s
+  <code>height</code> property.
+
+ <li><p>Let <var>pressure</var> be equal to <var>action object</var>’s
+  <code>pressure</code> property.
+
+ <li><p>Let <var>tangentialPressure</var> be equal to
+  <var>action object</var>’s <code>tangentialPressure</code> property.
+
+ <li><p>Let <var>tiltX</var> be equal to <var>action object</var>’s
+  <code>tiltX</code> property.
+
+ <li><p>Let <var>tiltY</var> be equal to <var>action object</var>’s
+  <code>tiltY</code> property.
+
+ <li><p>Let <var>twist</var> be equal to <var>action object</var>’s
+  <code>twist</code> property.
+
+ <li><p>Let <var>altitudeAngle</var> be equal to <var>action object</var>’s
+  <code>altitudeAngle</code> property.
+
+ <li><p>Let <var>azimuthAngle</var> be equal to <var>action object</var>’s
+  <code>azimuthAngle</code> property.
+
  <li><p><a>Perform a pointer move</a> with arguments
   <var>source id</var>, <var>input state</var>, <var>duration</var>,
-  <var>start x</var>, <var>start y</var>, <var>x</var>, <var>y</var>.
+  <var>start x</var>, <var>start y</var>, <var>x</var>, <var>y</var>,
+  <var>width</var>, <var>height</var>, <var>pressure</var>,
+  <var>tangentialPressure</var>, <var>tiltX</var>, <var>tiltY</var>,
+  <var>twist</var>, <var>altitudeAngle</var>, <var>azimuthAngle</var>.
 
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
@@ -8853,7 +8913,10 @@ Return <a>success</a> with data <var>action</var>.
 <p>When required to <dfn>perform a pointer move</dfn> with
  arguments <var>source id</var>, <var>input state</var>,
  <var>duration</var>, <var>start x</var>, <var>start y</var>,
- <var>target x</var> and <var>target y</var>, an implementation must
+ <var>target x</var> and <var>target y</var>, <var>width</var>,
+ <var>height</var>, <var>pressure</var>, <var>tangentialPressure</var>,
+ <var>tiltX</var>, <var>tiltY</var>, <var>twist</var>,
+ <var>altitudeAngle</var>, <var>azimuthAngle</var>, an implementation must
  run the following steps:
 
 <ol>
@@ -8898,7 +8961,10 @@ Return <a>success</a> with data <var>action</var>.
     ID <var>source id</var> having type <var>pointerType</var> from
     viewport x coordinate <var>current x</var>, viewport y
     coordinate <var>current y</var> to viewport x coordinate <var>x</var> and
-    viewport y coordinate <var>y</var>, with
+    viewport y coordinate <var>y</var>, <var>width</var>, <var>height</var>,
+    <var>pressure</var>, <var>tangentialPressure</var>, <var>tiltX</var>,
+    <var>tiltY</var>, <var>twist</var>, <var>altitudeAngle</var>,
+    <var>azimuthAngle</var>, with
     buttons <var>buttons</var> depressed, in accordance with the
     requirements of [[UI-EVENTS]] and [[POINTER-EVENTS]]. The
     generated events must set <code>ctrlKey</code>, <code>shiftKey</code>,

--- a/index.html
+++ b/index.html
@@ -7804,16 +7804,113 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Set the <code>button</code> property of <var>action</var>
   to <var>button</var>.
 
-<li><p>Let <var>width</var> be the result
+ <li><p>Let <var>width</var> be the result
   of getting the property <code>width</code>
   from <var>action item</var>.
 
- <li><p>If <var>width</var> is not a <a>Number</a> greater than or
+ <li><p>If <var>width</var> is not <a>undefined</a>
+  and <var>width</var> is not a <a>Number</a> greater than or
   equal to 0 return <a>error</a> with <a>error code</a>
   <a>invalid argument</a>.
 
  <li><p>Set the <code>width</code> property of <var>action</var>
   to <var>width</var>.
+
+ <li><p>Let <var>height</var> be the result
+  of getting the property <code>height</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>height</var> is not <a>undefined</a>
+  and <var>height</var> is not a <a>Number</a> greater than or
+  equal to 0 return <a>error</a> with <a>error code</a>
+  <a>invalid argument</a>.
+
+ <li><p>Set the <code>height</code> property of <var>action</var>
+  to <var>height</var>.
+
+ <li><p>Let <var>pressure</var> be the result
+  of getting the property <code>pressure</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>pressure</var> is not <a>undefined</a>
+  and <var>pressure</var> is not a <a>Number</a> greater than or
+  equal to 0 and less than or equal to 1 return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>pressure</code> property of <var>action</var>
+  to <var>pressure</var>.
+
+ <li><p>Let <var>tangentialPressure</var> be the result
+  of getting the property <code>tangentialPressure</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>tangentialPressure</var> is not <a>undefined</a>
+  and <var>tangentialPressure</var> is not a <a>Number</a> greater
+  than or equal to -1 and less than or equal to 1 return <a>error</a>
+  with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>tangentialPressure</code> property of <var>action</var>
+  to <var>tangentialPressure</var>.
+
+ <li><p>Let <var>tiltX</var> be the result
+  of getting the property <code>tiltX</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>tiltX</var> is not <a>undefined</a>
+  and <var>tiltX</var> is not an <a>Integer</a> greater than or
+  equal to -90 and less than or equal to 90 return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>tiltX</code> property of <var>action</var>
+  to <var>tiltX</var>.
+
+ <li><p>Let <var>tiltY</var> be the result
+  of getting the property <code>tiltY</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>tiltY</var> is not <a>undefined</a>
+  and <var>tiltY</var> is not an <a>Integer</a> greater than or
+  equal to -90 and less than or equal to 90 return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>tiltY</code> property of <var>action</var>
+  to <var>tiltY</var>.
+
+ <li><p>Let <var>twist</var> be the result
+  of getting the property <code>twist</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>twist</var> is not <a>undefined</a>
+  and <var>twist</var> is not an <a>Integer</a> greater than or
+  equal to 0 and less than or equal to 359 return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>twist</code> property of <var>action</var>
+  to <var>twist</var>.
+
+ <li><p>Let <var>altitudeAngle</var> be the result
+  of getting the property <code>altitudeAngle</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>altitudeAngle</var> is not <a>undefined</a>
+  and <var>altitudeAngle</var> is not a <a>Number</a> greater than
+  or equal to 0 and less than or equal to π/2 return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>altitudeAngle</code> property of <var>action</var>
+  to <var>altitudeAngle</var>.
+
+ <li><p>Let <var>azimuthAngle</var> be the result
+  of getting the property <code>azimuthAngle</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>azimuthAngle</var> is not <a>undefined</a>
+  and <var>azimuthAngle</var> is not a <a>Number</a> greater than
+  or equal to 0 and less than or equal to 2π return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>azimuthAngle</code> property of <var>action</var>
+  to <var>azimuthAngle</var>.
 
  <li><p>Return success with data <a><code>null</code></a>.
 </ol>
@@ -7869,6 +7966,114 @@ Return <a>success</a> with data <var>action</var>.
 
  <li><p>Set the <code>y</code> property of <var>action</var>
   to <var>y</var>.
+
+ <li><p>Let <var>width</var> be the result
+  of getting the property <code>width</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>width</var> is not <a>undefined</a>
+  and <var>width</var> is not a <a>Number</a> greater than or
+  equal to 0 return <a>error</a> with <a>error code</a>
+  <a>invalid argument</a>.
+
+ <li><p>Set the <code>width</code> property of <var>action</var>
+  to <var>width</var>.
+
+ <li><p>Let <var>height</var> be the result
+  of getting the property <code>height</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>height</var> is not <a>undefined</a>
+  and <var>height</var> is not a <a>Number</a> greater than or
+  equal to 0 return <a>error</a> with <a>error code</a>
+  <a>invalid argument</a>.
+
+ <li><p>Set the <code>height</code> property of <var>action</var>
+  to <var>height</var>.
+
+ <li><p>Let <var>pressure</var> be the result
+  of getting the property <code>pressure</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>pressure</var> is not <a>undefined</a>
+  and <var>pressure</var> is not a <a>Number</a> greater than or
+  equal to 0 and less than or equal to 1 return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>pressure</code> property of <var>action</var>
+  to <var>pressure</var>.
+
+ <li><p>Let <var>tangentialPressure</var> be the result
+  of getting the property <code>tangentialPressure</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>tangentialPressure</var> is not <a>undefined</a>
+  and <var>tangentialPressure</var> is not a <a>Number</a> greater
+  than or equal to -1 and less than or equal to 1 return <a>error</a>
+  with <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>tangentialPressure</code> property of <var>action</var>
+  to <var>tangentialPressure</var>.
+
+ <li><p>Let <var>tiltX</var> be the result
+  of getting the property <code>tiltX</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>tiltX</var> is not <a>undefined</a>
+  and <var>tiltX</var> is not an <a>Integer</a> greater than or
+  equal to -90 and less than or equal to 90 return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>tiltX</code> property of <var>action</var>
+  to <var>tiltX</var>.
+
+ <li><p>Let <var>tiltY</var> be the result
+  of getting the property <code>tiltY</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>tiltY</var> is not <a>undefined</a>
+  and <var>tiltY</var> is not an <a>Integer</a> greater than or
+  equal to -90 and less than or equal to 90 return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>tiltY</code> property of <var>action</var>
+  to <var>tiltY</var>.
+
+ <li><p>Let <var>twist</var> be the result
+  of getting the property <code>twist</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>twist</var> is not <a>undefined</a>
+  and <var>twist</var> is not an <a>Integer</a> greater than or
+  equal to 0 and less than or equal to 359 return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>twist</code> property of <var>action</var>
+  to <var>twist</var>.
+
+ <li><p>Let <var>altitudeAngle</var> be the result
+  of getting the property <code>altitudeAngle</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>altitudeAngle</var> is not <a>undefined</a>
+  and <var>altitudeAngle</var> is not a <a>Number</a> greater than
+  or equal to 0 and less than or equal to π/2 return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>altitudeAngle</code> property of <var>action</var>
+  to <var>altitudeAngle</var>.
+
+ <li><p>Let <var>azimuthAngle</var> be the result
+  of getting the property <code>azimuthAngle</code>
+  from <var>action item</var>.
+
+ <li><p>If <var>azimuthAngle</var> is not <a>undefined</a>
+  and <var>azimuthAngle</var> is not a <a>Number</a> greater than
+  or equal to 0 and less than or equal to 2π return <a>error</a> with
+  <a>error code</a> <a>invalid argument</a>.
+
+ <li><p>Set the <code>azimuthAngle</code> property of <var>action</var>
+  to <var>azimuthAngle</var>.
 
  <li><p>Return success with data <a><code>null</code></a>.
 </ol>


### PR DESCRIPTION
The pointerevent' spec has properties e.g. width, height, pressure, tiltX, tiltY, twist..., so we are working on adding the pointerevent's properties to Webdriver Action API to simulate the inputs from devices such as touchscreen and stylus, which have these additional properties.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/LanWei22/webdriver/pull/1554.html" title="Last updated on Oct 19, 2020, 8:15 AM UTC (7414992)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1554/99f7ced...LanWei22:7414992.html" title="Last updated on Oct 19, 2020, 8:15 AM UTC (7414992)">Diff</a>