### PR TITLE
Fix browsing context checks for Switch To Parent Frame when already the top-level browsing context

### DIFF
--- a/index.html
+++ b/index.html
@@ -3573,6 +3573,16 @@ make the tab containing the <a>browsing context</a> the selected tab.
 <p>The <a>remote end steps</a> are:
 
 <ol>
+ <li><p>Run the substeps if the <a>current browsing context</a> is already the
+  <a>top-level browsing context</a>:
+
+  <ol>
+    <li><p>If the <a>current browsing context</a> is <a>no longer
+  open</a>, return <a>error</a> with <a>error code</a> <a>no such
+  window</a>.
+    <li><p>Return <a>success</a> with data <a><code>null</code></a>.
+  </ol>
+
  <li><p>If the <a>current parent browsing context</a> is <a>no longer
   open</a>, return <a>error</a> with <a>error code</a> <a>no such
   window</a>.


### PR DESCRIPTION
Fixes issue #1544.

@jgraham or someone else, can you please review? Thanks


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1556.html" title="Last updated on Oct 16, 2020, 12:26 PM UTC (da1275a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1556/99f7ced...da1275a.html" title="Last updated on Oct 16, 2020, 12:26 PM UTC (da1275a)">Diff</a>