### PR TITLE
Clarify immediate script abortion when user prompt appears.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6705,8 +6705,8 @@ a <a>remote end</a> must run the following steps:
  The algorithm returns <a data-lt="completion">an ECMAScript completion record</a>.
 
 <p>If at any point during the algorithm a <a>user prompt</a> appears,
- abort all subsequent substeps of this algorithm, and return
- <a>Completion</a> { [[\Type]]: <code>normal</code>, [[\Value]]: <a><code>null</code></a>, [[\Target]]: <code>empty</code> }.
+ immediately return <a>Completion</a> { [[\Type]]: <code>normal</code>, [[\Value]]: <a><code>null</code></a>,
+ [[\Target]]: <code>empty</code> }, but continue to run the other steps of this algorithm in parallel.
 
 <ol>
  <li><p>Let <var>window</var> be the <a>associated window</a>


### PR DESCRIPTION
Fixes issue #1153.

I took the words as @jgraham proposed given that it seems to describe the expected behavior best. @AutomatedTester if you think it needs further tweaking please let me know.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1572.html" title="Last updated on Feb 17, 2021, 11:52 AM UTC (6f59a7c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1572/8315393...6f59a7c.html" title="Last updated on Feb 17, 2021, 11:52 AM UTC (6f59a7c)">Diff</a>