### PR TITLE
fix regression in definition of beforeunload prompts caused by #1040 / #1518

### DIFF
--- a/index.html
+++ b/index.html
@@ -9730,8 +9730,8 @@ It also clears all the internal state of the virtual devices.
 
 <p><a>User prompts</a> that are spawned
  from <a><code>beforeunload</code></a> event handlers,
- are <a>dismissed</a> implicitly upon <a>navigation</a>
- or <a>close window</a>,
+ are <a>dismissed</a> implicitly upon a subsequent <a>navigation</a>
+ or a subsequent <a>close window</a>,
  regardless of the defined <a>user prompt handler</a>.
 
 <p>A <a>user prompt</a> has an associated <dfn>user prompt message</dfn>

--- a/index.html
+++ b/index.html
@@ -9730,9 +9730,8 @@ It also clears all the internal state of the virtual devices.
 
 <p><a>User prompts</a> that are spawned
  from <a><code>beforeunload</code></a> event handlers,
- are <a>dismissed</a> implicitly upon a subsequent <a>navigation</a>
- or a subsequent <a>close window</a>,
- regardless of the defined <a>user prompt handler</a>.
+ are <a>dismissed</a> implicitly upon a <a data-lt="Navigate To">navigation</a>
+ or a <a>close window</a>, regardless of the defined <a>user prompt handler</a>.
 
 <p>A <a>user prompt</a> has an associated <dfn>user prompt message</dfn>
  that is the string message shown to the user,


### PR DESCRIPTION
The definition of what happens to a prompt created from a `beforeunload` event unintentionally changed from being implicitly dismissed from explicit navigation to implicit navigation.

the link used to go to "Go" but this was renamed in #1040 leaving a dead link.
This link was "fixed" in #1518 but instead of fixing the link to how it was (by linking to the new `"Navigate To"` which was renamed earlier) it linked to the default definition of `navigate` which is vastly different and covers all navigation implicit or explicit.

fixes #1294


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jtnord/webdriver/pull/1573.html" title="Last updated on Feb 22, 2021, 2:35 PM UTC (5d22ffa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1573/90b179e...jtnord:5d22ffa.html" title="Last updated on Feb 22, 2021, 2:35 PM UTC (5d22ffa)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1573)
<!-- Reviewable:end -->
