### PR TITLE
Revert "Add Get Session and Async New Session"

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,21 +681,9 @@ when it receives a particular <a>command</a>.
  </tr>
 
  <tr>
-  <td>GET</td>
-  <td>/session/{session id}</td>
-  <td><a>Get Session</a></td>
- </tr>
-
- <tr>
   <td>DELETE</td>
   <td>/session/{<var>session id</var>}</td>
   <td><a>Delete Session</a></td>
- </tr>
-
- <tr>
-  <td>POST</td>
-  <td>/session/async</td>
-  <td><a>Async New Session</a></td>
  </tr>
 
  <tr>
@@ -1332,14 +1320,6 @@ when it receives a particular <a>command</a>.
   <td><code>unknown method</code>
   <td>The requested <a>command</a> matched a known URL
    but did not match an method for that URL.
- </tr>
-
- <tr>
-  <td><dfn>unknown session</dfn>
-  <td>404
-  <td><code>unknown session</code>
-  <td>The requested <a>sessionId</a> did not match 
-   with any <a>sessionId</a> known by a node.
  </tr>
 
  <tr>
@@ -2192,15 +2172,8 @@ with a "<code>moz:</code>" prefix:
  an <a>intermediary node</a> will also <a>close the session</a> of
  the <a>associated session</a>.
 
-<p>An <a>intermediary node</a> will also maintain a list of
- <dfn>session creation jobs</dfn>. These include a mapping from
- a <dfn>session creation id</dfn> to a <a>session id</a> of
- an <a>associated session</a>.
-
-<a>New Session</a>, <a>Async New Session</a>, and <a>Status</a> <a>commands</a>
- have no associated <a>session</a> or <a>session creation job</a>.
-
-<p>All other <a>commands</a> have an associated <dfn>current session</dfn>,
+<p>All <a>commands</a>, except <a>New Session</a> and <a>Status</a>,
+ have an associated <dfn>current session</dfn>,
  which is the <a>session</a> in which that <a>command</a> will run.
 
 <p>A <a>remote end</a> has an associated list of
@@ -2510,55 +2483,6 @@ If the creation fails, a <a>session not created</a> <a>error</a> is returned.
 </section> <!-- /New Session -->
 
 <section>
- <h3><dfn>Get Session</dfn></h3>
-  
- <table class="simple jsoncommand">
-  <tr>
-   <th>HTTP Method</th>
-   <th>URI Template</th>
-  </tr>
-  <tr>
-   <td>GET</td>
-   <td>/session/{session id}</td>
-  </tr>
- </table>
-  
- <p>The <a>remote end steps</a> are:
-  
- <ol>
-  <li><p>Let <var>session</var> be a job in <a>active sessions</a>
-   with a <a>session id</a> matching <var>session id</var>
-  
-  <li><p>If <a>Remote end</a> is an <a>endpoint node</a> and
-   <var>session</var> is <code>null</code>, return <a>error</a>
-   with <a>error code</a> <a>unknown session</a>.
-  
-  <li><p>If <a>Remote end</a> is an <a>intermediary node</a> and
-   <var>session</var> is <code>null</code>, let <var>session</var>
-   be a job in <a>session creation job</a> with a <a>session id</a>
-   matching <var>session creation id</var>
-  
-  <li><p>If <a>Remote end</a> is an <a>intermediary node</a> and
-   <var>session</var> is <code>null</code>, return <a>error</a>
-   with <a>error code</a> <a>unknown session</a>.
-  
-  <li><p>Let <var>body</var> be a JSON <a>Object</a> initialised with:
-   <dl>
-    <dl>
-     <dt>"<code>sessionId</code>"
-     <dd>The <a>session id</a> of the <a>current session</a>.
-    
-     <dt>"<code>capabilities</code>"
-     <dd>The capabilities of the <a>current session</a>.
-    </dl>
-   </dl>
-  
-  <li><p>Return success with data <var>body</var>.
-   This conversation was marked as resolved by christian-bromann
- </ol>
-</section> <!-- /Get Session -->
-
-<section>
 <h3><dfn>Delete Session</dfn></h3>
 
 <table class="simple jsoncommand">
@@ -2581,69 +2505,6 @@ If the creation fails, a <a>session not created</a> <a>error</a> is returned.
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
 </section> <!-- /Delete Session -->
-
-<section>
-<h3><dfn>Async New Session</dfn></h3>
-
-<table class="simple jsoncommand">
-  <tr>
-  <th>HTTP Method</th>
-  <th>URI Template</th>
-  </tr>
-  <tr>
-  <td>POST</td>
-  <td>/session/async</td>
-  </tr>
-</table>
-
-<p>The <a>remote end</a> steps are:
-
-<ol>
- <li><p>Perform the following substeps based on the <a>remote end</a>’s type:
-  <dl class=switch>
-   <dt><a>Remote end</a> is an <a>endpoint node</a>
-   <dd>
-    <ol>
-     <li><p>Let <var>session</var> be a job iniated by following the same steps
-      defined in <a>New Session</a>
-
-     <li><p>Let <var>body</var> be a new JSON <a>Object</a> with the following
-      properties:
-       
-      <dl>
-       <dt>"<code>sessionCreationId</code>"
-       <dd>The <a>session id</a> of the <a>session</a>.
-      </dl>
-
-      <li><p>Return <a>success</a> with data <var>body</var>.
-    </ol>
-   
-   <dt><a>Remote end</a> is an <a>intermediary node</a>
-   <dd>
-    <ol>
-     <li><p>Use the result of the <a>capabilities processing</a> algorithm
-      to route the <a>new session</a> request to the appropriate <a>endpoint node</a>.
-      An <a>intermediary node</a> is free to define <a>extension capabilities</a>
-      to assist in this process, however, these specific capabilities
-      must not be forwarded to the <a>endpoint node</a>.
-
-      <li><p>Let <var>session creation job</var> be a new JSON <a>Object</a>
-       with the following properties:
-      
-       <dl>
-        <dt>"<code>sessionCreationId</code>"
-        <dd>The result of <a>generating a UUID</a>.
-       </dl>
-      
-      <li>Add the <var>session creation job</var> to the list of
-       <a>session creation jobs</a>.
-
-      <li><p>Return <a>success</a> with data <var>session creation job</var>.
-   </ol>
-  </dl>
-</ol>
-
-</section> <!-- /Async New Session -->
 
 <section>
 <h3><dfn>Status</dfn></h3>


### PR DESCRIPTION
This change to the protocol was made a bit prematurely.
At Sauce Labs we have evaluated the implementation details
after the change and found lots of improvements to be made.
Therefor I propose to revert this and come back when we have
found a better solution to this.

Revert "add unknown session error"

This reverts commit 83153937210ef5e797ee03cb4124b4fcb883f8bb.

Revert "make responses between endpoint and intermediary node conform"

This reverts commit 96790d52d672acb5407ef20ef7597abc30fe9870.

Revert "add get session and async new session"

This reverts commit c83c8f0cef5bf06bcf12708c0e240b1fb574da41.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webdriver/webdriver/pull/1576.html" title="Last updated on Mar 9, 2021, 3:00 PM UTC (2fb6155)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1576/90b179e...webdriver:2fb6155.html" title="Last updated on Mar 9, 2021, 3:00 PM UTC (2fb6155)">Diff</a>