### PR TITLE
Add .cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.cache


### PR DESCRIPTION
This should fix the CI failures — the cause here of which is that Bikeshed generates a .cache directory containing some files that Bikeshed uses internally. So we need to tell git to not let those files be committed. Otherwise, without this change, spec-prod appears to be committing those files to the publishing branch (gh-pages) but then is subsequently unable to overwrite them.