### PR TITLE
Fix link to Selenium's `bot.dom.isShown`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -10476,7 +10476,8 @@ ensuring both privacy and preventing state from bleeding through to the next ses
  is a boolean state where <code>true</code> signifies that the element is displayed
  and <code>false</code> signifies that the element is not displayed.
  To compute the state on <var>element</var>,
- invoke the <a>Function.[[\Call]]</a>(<a><code>null</code></a>, <var>element</var>),
+ invoke the <a>Function.[[\Call]]</a>(<a><code>null</code></a>, <var>element</var>,
+ <code>false</code>),
  with <a><code>bot.dom.isShown</code></a> as the this value.
  If doing so does not produce an error,
  return the return value from this function call.
@@ -10990,7 +10991,7 @@ to automatically sort each list alphabetically.
   revision <code>1721e627e3b5ab90a06e82df1b088a33a8d11c20</code>.
   <ul>
    <!-- bot.dom.getVisibleText --> <li><dfn><a href=https://github.com/SeleniumHQ/selenium/blob/e09e28f016c9f53196cf68d6f71991c5af4a35d4/javascript/atoms/dom.js#L981><code>bot.dom.getVisibleText</code></a></dfn>
-   <!-- bot.dom.isShown --> <li><dfn><a href=https://github.com/SeleniumHQ/selenium/blob/e09e28f016c9f53196cf68d6f71991c5af4a35d4/javascript/atoms/dom.js#L437><code>bot.dom.isShown</code></a></dfn>
+   <!-- bot.dom.isShown --> <li><dfn><a href=https://github.com/SeleniumHQ/selenium/blob/e09e28f016c9f53196cf68d6f71991c5af4a35d4/javascript/atoms/dom.js#L550><code>bot.dom.isShown</code></a></dfn>
   </ul>
 
  <dt>Styling


### PR DESCRIPTION
Also:

* Fix its invocation reference under the "Element Displayedness" section.

Fixes #1623


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jginsburgn/webdriver/pull/1625.html" title="Last updated on Oct 12, 2021, 3:07 AM UTC (0a67f58)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1625/1bee362...jginsburgn:0a67f58.html" title="Last updated on Oct 12, 2021, 3:07 AM UTC (0a67f58)">Diff</a>