### PR TITLE
Editorial: export definitions needed for Permissions API

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@ In all other cases it must be true.
 
 <p>Where algorithms that return values are fallible,
  they are written in terms of returning either
- <dfn>success</dfn> or <dfn data-lt=errors>error</dfn>.
+ <dfn class="export" data-local-lt="success">WebDriver success</dfn> (success) or <dfn data-local-lt="error" class="export">WebDriver error</dfn> (error).
  A <a>success</a> value has an associated <var>data</var> field
  which encapsulates the value returned,
  whereas an <a>error</a> response has an associated <a>error code</a>.
@@ -400,7 +400,7 @@ and therefore each command produces a single <a>HTTP response</a>.
 <p>
 In response to a <a>command</a>,
 a <a>remote end</a> will run a series of actions
-known as <dfn>remote end steps</dfn>.
+known as <dfn class="export">remote end steps</dfn>.
 These provide the sequences of actions that a <a>remote end</a> takes
 when it receives a particular <a>command</a>.
 </section>
@@ -1090,7 +1090,7 @@ when it receives a particular <a>command</a>.
 }</code></pre>
 </aside>
 
-<p>The following table lists each <dfn>error code</dfn>,
+<p>The following table lists each <dfn data-local-lt="error code">WebDriver error code</dfn>,
  its associated <a>HTTP status</a>,
  JSON <code>error</code> code,
  and a non-normative description of the error.
@@ -1134,7 +1134,7 @@ when it receives a particular <a>command</a>.
    which is usually the result of an expired or invalid TLS certificate.
 
  <tr>
-  <td><dfn>invalid argument</dfn>
+  <td><dfn class="export" data-local-lt="invalid argument">WebDriver invalid argument</dfn>
   <td>400
   <td><code>invalid argument</code>
   <td>The arguments passed to a <a>command</a>
@@ -1344,12 +1344,12 @@ when it receives a particular <a>command</a>.
  features.
 
 <p>Commands defined in this way
- are called <dfn data-lt="extension command">extension commands</dfn>
+ are called <dfn class="export" data-local-lt="extension commands">WebDriver extension commands</dfn>
  and behave no differently than other <a>commands</a>;
  each has a dedicated HTTP endpoint and a set of <a>remote end steps</a>.
 
 <p>Each <a>extension command</a> has an associated
- <dfn>extension command URI Template</dfn>
+ <dfn class="export">extension command URI Template</dfn>
  that is a <a>URI Template</a> string,
  and which should bear some resemblance to what the command performs.
  This value,
@@ -2146,7 +2146,7 @@ with a "<code>moz:</code>" prefix:
  and allowing sessions to be routed via a multiplexer
  (known as an <a>intermediary node</a>).
 
-<p>A WebDriver <dfn data-lt="sessions">session</dfn> represents
+<p>A <dfn class="export" data-local-lt="session">WebDriver session</dfn> represents
  the <a>connection</a> between a <a>local end</a> and a specific <a>remote end</a>.
 
 <p>A <a>session</a> is started when

--- a/index.html
+++ b/index.html
@@ -1349,7 +1349,7 @@ when it receives a particular <a>command</a>.
  each has a dedicated HTTP endpoint and a set of <a>remote end steps</a>.
 
 <p>Each <a>extension command</a> has an associated
- <dfn class="export">extension command URI Template</dfn>
+ <dfn class="export" data-local-lt="extension command URI Template">WebDriver extension command URI Template</dfn>
  that is a <a>URI Template</a> string,
  and which should bear some resemblance to what the command performs.
  This value,

--- a/index.html
+++ b/index.html
@@ -1349,7 +1349,7 @@ when it receives a particular <a>command</a>.
  each has a dedicated HTTP endpoint and a set of <a>remote end steps</a>.
 
 <p>Each <a>extension command</a> has an associated
- <dfn class="export" data-local-lt="extension command URI Template">WebDriver extension command URI Template</dfn>
+ <dfn class="export">extension command URI Template</dfn>
  that is a <a>URI Template</a> string,
  and which should bear some resemblance to what the command performs.
  This value,

--- a/index.html
+++ b/index.html
@@ -1406,7 +1406,8 @@ either <a><code>null</code></a> to indicate the capability is not
 matched, or a non-null JSON-serializable value if the capability is
 matched.
 
-<p>Other specifications may also define <dfn>new session algorithms</dfn>, which are
+<p>Other specifications may also define <dfn data-lt="WebDriver new
+session algorithm" class="export">WebDriver new session algorithms</dfn>, which are
 called just after a new session is created, and before the <a>new
 session</a> response is sent to the <a>remote end</a>. These
 algorithms are called with <var>session</var> representing the
@@ -2145,7 +2146,7 @@ with a "<code>moz:</code>" prefix:
  and allowing sessions to be routed via a multiplexer
  (known as an <a>intermediary node</a>).
 
-<p>A <dfn class="export">session</dfn> represents
+ <p>A WebDriver <dfn class="export">session</dfn> represents
  the <a>connection</a> between a <a>local end</a> and a specific <a>remote end</a>.
 
 <p>A <a>session</a> is started when

--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@ In all other cases it must be true.
 
 <p>Where algorithms that return values are fallible,
  they are written in terms of returning either
- <dfn class="export" data-local-lt="success">WebDriver success</dfn> (success) or <dfn data-local-lt="error" class="export">WebDriver error</dfn> (error).
+ <dfn class="export">success</dfn> or <dfn class="export">error</dfn>.
  A <a>success</a> value has an associated <var>data</var> field
  which encapsulates the value returned,
  whereas an <a>error</a> response has an associated <a>error code</a>.
@@ -1090,7 +1090,7 @@ when it receives a particular <a>command</a>.
 }</code></pre>
 </aside>
 
-<p>The following table lists each <dfn data-local-lt="error code">WebDriver error code</dfn>,
+<p>The following table lists each <dfn>error code</dfn>,
  its associated <a>HTTP status</a>,
  JSON <code>error</code> code,
  and a non-normative description of the error.
@@ -1134,7 +1134,7 @@ when it receives a particular <a>command</a>.
    which is usually the result of an expired or invalid TLS certificate.
 
  <tr>
-  <td><dfn class="export" data-local-lt="invalid argument">WebDriver invalid argument</dfn>
+  <td><dfn class="export">invalid argument</dfn>
   <td>400
   <td><code>invalid argument</code>
   <td>The arguments passed to a <a>command</a>
@@ -1344,7 +1344,7 @@ when it receives a particular <a>command</a>.
  features.
 
 <p>Commands defined in this way
- are called <dfn class="export" data-local-lt="extension commands">WebDriver extension commands</dfn>
+ are called <dfn class="export">extension commands</dfn>
  and behave no differently than other <a>commands</a>;
  each has a dedicated HTTP endpoint and a set of <a>remote end steps</a>.
 
@@ -1406,8 +1406,7 @@ either <a><code>null</code></a> to indicate the capability is not
 matched, or a non-null JSON-serializable value if the capability is
 matched.
 
-<p>Other specifications may also define <dfn data-lt="WebDriver new
-session algorithm">WebDriver new session algorithms</dfn>, which are
+<p>Other specifications may also define <dfn>new session algorithms</dfn>, which are
 called just after a new session is created, and before the <a>new
 session</a> response is sent to the <a>remote end</a>. These
 algorithms are called with <var>session</var> representing the
@@ -2146,7 +2145,7 @@ with a "<code>moz:</code>" prefix:
  and allowing sessions to be routed via a multiplexer
  (known as an <a>intermediary node</a>).
 
-<p>A <dfn class="export" data-local-lt="session">WebDriver session</dfn> represents
+<p>A <dfn class="export">session</dfn> represents
  the <a>connection</a> between a <a>local end</a> and a specific <a>remote end</a>.
 
 <p>A <a>session</a> is started when

--- a/index.html
+++ b/index.html
@@ -1406,8 +1406,8 @@ either <a><code>null</code></a> to indicate the capability is not
 matched, or a non-null JSON-serializable value if the capability is
 matched.
 
-<p>Other specifications may also define <dfn data-lt="WebDriver new
-session algorithm" class="export">WebDriver new session algorithms</dfn>, which are
+<p>Other specifications may also define <dfn class="export">WebDriver
+new session algorithms</dfn>, which are
 called just after a new session is created, and before the <a>new
 session</a> response is sent to the <a>remote end</a>. These
 algorithms are called with <var>session</var> representing the
@@ -2146,7 +2146,7 @@ with a "<code>moz:</code>" prefix:
  and allowing sessions to be routed via a multiplexer
  (known as an <a>intermediary node</a>).
 
- <p>A WebDriver <dfn class="export">session</dfn> represents
+<p>A WebDriver <dfn class="export">session</dfn> represents
  the <a>connection</a> between a <a>local end</a> and a specific <a>remote end</a>.
 
 <p>A <a>session</a> is started when


### PR DESCRIPTION
The Permissions API is looking to add a Web Driver extension. However, the spec is currently missing these exports for us to do the integration.

Blocks: https://github.com/w3c/permissions/pull/346


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1639.html" title="Last updated on Feb 14, 2022, 5:58 AM UTC (22bd73d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1639/1917e89...22bd73d.html" title="Last updated on Feb 14, 2022, 5:58 AM UTC (22bd73d)">Diff</a>