### PR TITLE
Factor global state out of the actions algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -2227,11 +2227,8 @@ and <a href=#elements>element retrieval</a>.
 A <a>session</a> has an associated <a>user prompt handler</a>.
 Unless stated otherwise it is in the <a>dismiss and notify state</a>.
 
-<p>A <a>session</a> has an associated list of <a>active input sources</a>.
-
-<p>A <a>session</a> has an associated <a>input state table</a>.
-
-<p>A <a>session</a> has an associated <a>input cancel list</a>.
+<p>A <a>session</a> has an associated <a>input state</a>, which is
+initially set to the result of <a>create an input state</a>.
 
 <p>A <a>session</a> has an associated <dfn>request queue</dfn> which is a
  [=queue=] of [=requests=] that are currently awaiting
@@ -5685,7 +5682,7 @@ an <a>element not interactable</a> <a>error</a> is returned.
 
 <p>The <a>remote end steps</a> are:
 
-<ol>
+<ol class="algorithm">
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
@@ -5752,14 +5749,24 @@ an <a>element not interactable</a> <a>error</a> is returned.
    <dt>Otherwise
    <dd>
     <ol>
-     <li><p>Let <var>mouse</var> be a new <a>pointer input source</a>.
+     <li><p>Let <var>input state</var> be <a>current session</a>'s
+     <a>input state</a>.
+
+     <li><p>Let <var>input id</var> be a the result of <a>generating a
+     UUID</a>.
+
+     <li><p>Let <var>source</var> be the result of <a>create an input
+     source</a> with "<code>pointer</code>".
+
+     <li><p><a>Add an input source</a> with <var>input
+     state</var>, <var>input id</var> and <var>source</var>.
 
      <li><p>Let <var>click point</var> be
       the <var>element</var>’s <a>in-view center point</a>.
 
-     <li><p>Let <var>pointer move action</var> be an <a>action object</a>
-      with the <var>mouse</var>’s <code>id</code>, "<code>pointer</code>",
-      and "<code>pointerMove</code>" as arguments.
+     <li><p>Let <var>pointer move action</var> be an <a>action
+      object</a> constructed with arguments <var>input id</code>,
+      "<code>pointer</code>", and "<code>pointerMove</code>".
 
      <li><p><a>Set a property</a> <code>x</code> to <code>0</code> on
       <var>pointer move action</var>.
@@ -5770,43 +5777,40 @@ an <a>element not interactable</a> <a>error</a> is returned.
      <li><p><a>Set a property</a> <code>origin</code>
       to <var>element</var> on <var>pointer move action</var>.
 
-     <li><p>Let <var>pointer down action</var> be an <a>action object</a>
-      with the <var>mouse</var>’s <code>id</code>, "<code>pointer</code>",
-      and "<code>pointerDown</code>" as arguments.
+     <li><p>Let <var>pointer down action</var> be an <a>action
+      object</a> constructed with arguments <var>input id</code>,
+      "<code>pointer</code>", and "<code>pointerDown</code>".
 
      <li><p><a>Set a property</a> <code>button</code>  to <code>0</code>
       on <var>pointer down action</var>.
 
-     <li><p>Let <var>pointer up action</var> be an <a>action object</a>
-      with the <var>mouse</var>’s <code>id</code>, "<code>mouse</code>",
-      and "<code>pointerUp</code>" as arguments.
+     <li><p>Let <var>pointer up action</var> be an <a>action
+      object</a> constructed with arguments <var>input id</var>,
+      "<code>mouse</code>", and "<code>pointerUp</code>" as arguments.
 
      <li><p><a>Set a property</a> <code>button</code>
       to <code>0</code> on <var>pointer up action</var>.
 
+     <li><p>Let <var>global key state</var> be the result of <a>get the
+     global key state</a> with <var>input state</var>.
+
      <li><p><a>Dispatch a pointerMove action</a> with
-     arguments <var>mouse</var>’s <code><a>input
-     id</a></code>, <var>pointer move action</var>,
-     <var>mouse</var>’s <a>input source state</a>,
-     and <code>0</code>.
+     arguments <var>input id</var>, <var>pointer move action</var>,
+     <var>source</var>, <var>global key state</var>, <code>0</code>,
+     and <a>current browsing context</a>.
 
      <li><p><a>Dispatch a pointerDown action</a> with
-      arguments <var>mouse</var>’s
-      <code><a>input id</a></code>, <var>pointer down action</var>,
-      <var>mouse</var>’s <a>input source state</a>,
-      and <code>0</code>.
+      <var>input id</var>, <var>pointer down action</var>,
+      <var>source</var>, <var>global key state</var>, <code>0</code>,
+      and <a>current browsing context</a>.
 
      <li><p><a>Dispatch a pointerUp action</a> with
-      arguments <var>mouse</var>’s
-      <code><a>input id</a></code>, <var>pointer up action</var>,
-      <var>mouse</var>’s <a>input source state</a>,
-      and <code>0</code>.
+      arguments <var>input id</var>, <var>pointer up action</var>,
+      <var>source</var>, <var>global key state</var>, <code>0</code>,
+      and <a>current browsing context</a>.
 
-     <li><p>Remove <var>mouse</var> from the
-      <a>current session</a>’s <a>input state table</a>.
-
-     <li><p>Remove <var>mouse</var> from the list of
-      <a>active input sources</a>.
+     <li><p><a>Remove an input source</a> with <var>input state</var>
+     and <var>input id</var>.
     </ol>
   </dl>
 
@@ -5850,7 +5854,7 @@ an <a>element not interactable</a> <a>error</a> is returned.
 
 <p>To <dfn>clear a content editable element</dfn>:
 
-<ol>
+<ol class="algorithm">
  <li><p>If <var>element</var>’s <a><code>innerHTML</code> IDL attribute</a>
   is an empty string do nothing and return.
 
@@ -5864,7 +5868,7 @@ an <a>element not interactable</a> <a>error</a> is returned.
 
 <p>To <dfn>clear a resettable element</dfn>:
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>empty</var> be the result of the first matching condition:
 
   <dl class=switch>
@@ -5892,7 +5896,7 @@ an <a>element not interactable</a> <a>error</a> is returned.
 
 <p>The <a>remote end steps</a> for <a>Element Clear</a> are:
 
-<ol>
+<ol class="algorithm">
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
@@ -5978,17 +5982,16 @@ and a number keypad for <a><code>input</code> elements</a>
 in the <a><code>number</code> state</a> on non-desktop devices.
 </div>
 
-<p>The <a>key input state</a> used for input
- may be cleared mid-way through “typing”
- by sending the <dfn>null key</dfn>,
- which is U+E000 (NULL).
+<p>The <a>key input source</a> used for input may be cleared mid-way
+ through “typing” by sending the <dfn>null key</dfn>, which is U+E000
+ (NULL).
 
-<p>When required to <dfn>clear the modifier key state</dfn> with an
- argument of <var>undo actions</var> and <var>keyboard</var>
- a <a>remote end</a> must run the following steps:
+<p>To <dfn>clear the modifier key state</dfn> given <var>input
+ state</var>, <var>input id</var>, <var>source</var>, <var>undo
+ actions</var>, and <var>browsing context</var>:
 
-<ol>
- <li><p>If <var>keyboard</var> is not a <a>key input source</a>
+<ol class="algorithm">
+ <li><p>If <var>source</var> is not a <a>key input source</a>
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>For each <var>entry key</var>
@@ -5998,13 +6001,18 @@ in the <a><code>number</code> state</a> on non-desktop devices.
    <li><p>Let <var>action</var> be the value of <var>undo actions</var>
     equal to the key <var>entry key</var>.
 
-   <li><p>If <var>action</var> is not an <a>action object</a>
-    of <code>type</code> "<code>key</code>"
-    and <code>subtype</code> "<code>keyUp</code>",
-    return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+   <li><p>If <var>action</var> is not an <a>action object</a> with
+    type "<code>key</code>" and subtype "<code>keyUp</code>",
+    return <a>error</a> with <a>error code</a> <a>invalid
+    argument</a>.
+
+   <li><p>Let <var>global key state</var> be the result of <a>get the
+   global key state</a> with <var>input state</var>.
 
    <li><p><a>Dispatch a keyUp action</a> with arguments
-    <var>action</var> and <var>keyboard</var>’s <a>key input state</a>.
+   <var>input id</var>, <var>action</var>, <var>source</var>,
+   <var>global key state</var>, <code>0</code>, and <var>browsing
+   context</var>.
   </ol>
 </ol>
 
@@ -6012,64 +6020,76 @@ in the <a><code>number</code> state</a> on non-desktop devices.
  if it consists of a single <a>unicode code point</a>
  and the <a>code</a> is not <a>undefined</a>.
 
-<p>The <dfn>shifted state</dfn> for <var>keyboard</var>
- is the value of <var>keyboard</var>’s
- <a>key input state</a>’s <code>shift</code> property.
+<p>The <dfn>shifted state</dfn> for <var>keyboard</var> is the value
+ of <var>keyboard</var>’s <code>shift</code> property.
 
-<p>In order to <dfn>dispatch the events for a typeable string</dfn>
-with arguments <var>text</var> and <var>keyboard</var>, a <a>remote
-end</a> must for each <var>char</var> corresponding to an indexed
-property in <var>text</var>:
+<p>To <dfn>dispatch the events for a typeable string</dfn>
+given <var>input state</var>, <var>input id</var>, <var>source</var>,
+<var>text</var>, and <var>browsing context</var>:
 
-<ol>
+<ol class="algorithm">
+ <li>For each <var>char</var> of <var>text</var>:
 
-<li><p>
-If <var>char</var> is a <a>shifted character</a>
-and the <a>shifted state</a> of <var>keyboard</var> is false,
-create a new <a>action object</a> with <var>keyboard</var>’s <code>id</code>,
-"<code>key</code>", and "<code>keyDown</code>",
-and set its <code>value</code> property to U+E008 ("left shift").
-<a>Dispatch a keyDown action</a> with this <a>action object</a>
-and <var>keyboard</var>’s <a>key input state</a>.
+  <ol>
+   <li><p>Let <var>global key state</a> be the result of <a>get the
+   global key state</a> with <var>input state</var>.
 
-<li><p>
-If <var>char</var> is not a <a>shifted character</a>
-and the <a>shifted state</a> of <var>keyboard</var> is true,
-create a new <a>action object</a> with <var>keyboard</var>’s <code>id</code>,
-"<code>key"</code>", and "<code>keyUp</code>",
-and set its <code>value</code> property to U+E008 ("left shift").
-<a>Dispatch a keyUp action</a> with this <a>action object</a>
-and <var>keyboard</var>’s <a>key input state</a>.
+   <li><p>If <var>char</var> is a <a>shifted character</a>, and
+   the <a>shifted state</a> of <var>source</var> is false:</p>
 
-<li><p>
-Let <var>keydown action</var> be a new <a>action object</a>
-constructed with arguments <var>keyboard</var>’s
-<code>id</code>, "<code>key</code>", and "<code>keyDown</code>".
+    <ol>
+      <li><p>Let <var>action</var> be an <a>action object</a>
+      constructed with <var>input id</var>, "<code>key</code>", and
+      "<code>keyDown</code>", and set its <code>value</code> property
+      to U+E008 ("left shift").</p>
 
-<li><p>
-Set the <code>value</code> property of <var>keydown action</var> to <var>char</var>.
+       <li><p><a>Dispatch a keyDown action</a> with <var>input
+       id</var>, <a>action</a>, <var>source</var>, <var>global key
+       state</var>, <code>0</code>, and <var>browsing context</var>.
+    </ol>
 
-<li><p>
-<a>Dispatch a keyDown action</a> with arguments
-<var>keydown action</var> and <var>keyboard</var>’s <a>key input state</a>.
+   <li><p>If <var>char</var> is not a <a>shifted character</a>
+   and the <a>shifted state</a> of <var>source</var> is true:
 
-<li><p>
-Let <var>keyup action</var> be a copy of <var>keydown action</var>
-with the <code>subtype</code> property changed to "<code>keyUp</code>".
+    <ol>
+     <li><p>Let <var>action</var> be an <a>action object</a>
+     constructed with <var>input id</var>, "<code>key</code>", and
+     "<code>keyUp</code>", and set its <code>value</code> property to
+     U+E008 ("left shift").</p>
 
-<li><p>
-<a>Dispatch a keyUp action</a> with arguments
-<var>keyup action</var> and <var>keyboard</var>’s <a>key input state</a>.
+     <li><p><a>Dispatch a keyUp action</a> with <var>input
+      id</var>, <a>action</a>, <var>source</var>, <var>global key
+      state</var>, <code>0</code>, and <var>browsing context</var>.
+    </ol>
 
+   <li><p>Let <var>keydown action</var> be an <a>action object</a>
+   constructed with arguments <var>input id</var>, "<code>key</code>",
+   and "<code>keyDown</code>".
+
+   <li><p>Set the <code>value</code> property of <var>keydown
+   action</var> to <var>char</var>.
+
+   <li><p><a>Dispatch a keyDown action</a> with <var>input id</var>
+   <var>keydown action</var>, <var>source</var>, <var>global key
+   state</var>, <code>0</code>, and <var>browsing context</var>.
+
+   <li><p>Let <var>keyup action</var> be a copy of <var>keydown action</var>
+   with the subtype property changed to "<code>keyUp</code>".
+
+   <li><p><a>Dispatch a keyUp action</a> with <var>input id</var>,
+   <var>keyup action</var>, <var>source</var>, <var>global key
+   state</var>, <code>0</code>, and <var>browsing context</var>.
+
+  </ol>
 </ol>
 
-<p>
-When required to <dfn>dispatch a composition event</dfn>
-with arguments <var>type</var> and <var>cluster</var>,
-the <a>remote end</a> must <a>perform implementation-specific action dispatch steps</a>
-equivalent to sending composition events
-in accordance with the requirements of [[UI-EVENTS]],
-and producing the following event with the specified properties.
+<p>When required to <dfn>dispatch a composition event</dfn>
+given <var>type</var> and <var>cluster</var>, and <var>browsing
+context</var>, the <a>remote end</a> must <a>perform
+implementation-specific action dispatch steps</a> on <var>browsing
+context</var> equivalent to sending composition events in accordance
+with the requirements of [[UI-EVENTS]], and producing the following
+event with the specified properties.
 
 <ul>
  <li><a href=https://www.w3.org/TR/uievents/#events-compositionevents><code>composition event</code></a> with properties:
@@ -6089,111 +6109,106 @@ and producing the following event with the specified properties.
  </table>
 </ul>
 
-<p>
-When required to <dfn>dispatch actions for a string</dfn>
-with arguments <var>text</var> and <var>keyboard</var>,
-a <a>remote end</a> must run the following steps:
+<p>To <dfn>dispatch actions for a string</dfn> given <var>input
+state</var>, <var>input id</var>, <var>source</var>,
+<var>text</var>, and <var>browsing context</var>:
 
-<ol>
+<ol class="algorithm">
+ <li><p>Let <var>clusters</var> be an array created by
+ <a>breaking <var>text</var> into extended grapheme clusters</a>.
 
-<li><p>
-Let <var>clusters</var> be an array created by
-<a>breaking <var>text</var> into extended grapheme clusters</a>.
+ <li><p>Let <var>undo actions</var> be an empty map.
 
-<li><p>
-Let <var>undo actions</var> be an empty dictionary.
+ <li><p>Let <var>current typeable text</var> be an empty list.
 
-<li><p>
-Let <var>current typeable text</var> be an empty string.
+ <li><p>For each <var>cluster</var> corresponding to an indexed
+ property in <var>clusters</var> run the substeps of the first matching
+ statement:
 
-<li><p>
-For each <var>cluster</var> corresponding to an indexed property in <var>clusters</var>
-run the substeps of the first matching statement:
+ <dl class=switch>
+  <dt><var>cluster</var> is the <a>null key</a>
+  <dd>
+   <ol>
+    <li><p><a>Dispatch the events for a typeable string</a> with
+    <var>input state</var>, <var>input
+    id</var>, <var>source</var>, <var>current typeable text</var>,
+    and <var>browsing context</var>. Empty <var>current typeable
+    text</var>.
 
-<dl class=switch>
-<dt><var>cluster</var> is the <a>null key</a>
-<dd><ol>
-<li><p>
-<a>Dispatch the events for a typeable string</a>
-with arguments <var>current typeable text</var> and <var>keyboard</var>.
-Reset <var>current typeable text</var> to an empty string.
+    <li><p><a>Try</a> to <a>clear the modifier key state</a> with
+    <var>input state</var>, <var>input id</var>, <var>source</var>,
+    <var>undo actions</var> and <var>browsing context</var>.
 
-<li><p>
-<a>Clear the modifier key state</a> with arguments
-being <var>undo actions</var> and <var>keyboard</var>.
+    <li><p>Clear <var>undo actions</var>.
+   </ol>
 
-<li><p>
-If the previous step results in an <a>error</a>, return that <a>error</a>.
+  <dt><var>cluster</var> is a <a>modifier key</a>
+  <dd>
+   <ol>
+    <li><p><a>Dispatch the events for a typeable string</a> with
+    <var>input state</var>, <var>input id</var>, <var>source</var>,
+    <var>current typeable text</var>, and <var>browsing context</var>.
 
-<li><p>
-Reset <var>undo actions</var> to be an empty dictionary.
-</ol>
+    <li><p>Empty<var>current typeable text</var>.
 
-<dt><var>cluster</var> is a <a>modifier key</a>
-<dd><ol>
-<li><p>
-<a>Dispatch the events for a typeable string</a>
-with arguments <var>current typeable text</var> and <var>keyboard</var>.
-Reset <var>current typeable text</var> to an empty string.
+    <li><p>Let <var>keydown action</var> be an <a>action object</a>
+    constructed with arguments <var>input id</var>,
+    "<code>key</code>", and "<code>keyDown</code>".
 
-<li><p>
-Let <var>keydown action</var> be an <a>action object</a>
-constructed with arguments <var>keyboard</var>’s ID,
-"<code>key</code>",
-and "<code>keyDown</code>".
+   <li><p>Set the <code>value</code> property of <var>keydown
+   action</var> to <var>cluster</var>.
 
-<li><p>
-Set the <code>value</code> property of <var>keydown action</var> to <var>cluster</var>.
+   <li><p><a>Dispatch a keyDown action</a> with arguments
+   <var>input id</var>, <var>keydown action</var>, <var>source</var>,
+   <var>global key state</var>, <code>0</code>, and <var>browsing
+   context</var>.
 
-<li><p>
-<a>Dispatch a keyDown action</a> with arguments
-<var>keydown action</var> and <var>keyboard</var>’s <a>key input state</a>.
+   <li><p>Add an entry to <var>undo actions</var> with
+   key <var>cluster</var> and value being a copy of <var>keydown
+   action</var> with the subtype property modified to
+   "<code>keyUp</code>".
+  </ol>
 
-<li><p>
-Add an entry to <var>undo actions</var> with key <var>cluster</var>
-and value being a copy of <var>keydown action</var>
-with the <code>subtype</code> modified to "<code>keyUp</code>".
-</ol>
+  <dt><var>cluster</var> is <a>typeable</a>
+  <dd><p>Append <var>cluster</var> to <var>current typeable
+  text</var>.
 
-<dt><var>cluster</var> is <a>typeable</a>
-<dd><p>
-Append <var>cluster</var> to <var>current typeable text</var>.
+  <dt>Otherwise
+  <dd>
+   <ol>
+    <li><p><a>Dispatch the events for a typeable string</a> with
+    <var>input state</var>, <var>input id</var>, <var>source</var>,
+    <var>current typeable text</var>, and <var>browsing context</var>.
 
-<dt>Otherwise
+    <li><p>Empty <var>current typeable text</var>.
 
-<dd><ol>
-<li><p>
-<a>Dispatch the events for a typeable string</a> with arguments
-<var>current typeable text</var> and <var>keyboard</var>.
-Reset <var>current typeable text</var> to an empty string.
+    <li><p><a>Dispatch a <code>composition event</code></a> with
+    arguments "<code>compositionstart</code>", <a>undefined</a>,
+    and <var>browsing context</var>.
 
-<li><p>
-<a>Dispatch a <code>composition event</code></a> with arguments
-"<code>compositionstart</code>" and <a>undefined</a>.
+    <li><p><a>Dispatch a <code>composition event</code></a> with arguments
+    "<code>compositionupdate</code>", <var>cluster</var>,
+    and <var>browsing context</var>.
 
-<li><p>
-<a>Dispatch a <code>composition event</code></a> with arguments
-"<code>compositionupdate</code>" and <var>cluster</var>.
+    <li><p><a>Dispatch a <code>composition event</code></a> with arguments
+    "<code>compositionend</code>", <var>cluster</var>,
+    and <var>browsing context</var>.
+   </ol>
+ </dl>
 
-<li><p>
-<a>Dispatch a <code>composition event</code></a> with arguments
-"<code>compositionend</code>" and <var>cluster</var>.
-</ol>
-</dl>
+ <li><p><a>Dispatch the events for a typeable string</a>
+ with <var>input state</var>, <var>input id</var>
+ and <var>source</var>, <var>current typeable text</var>,
+ and <var>browsing context</var>.
 
-<li><p>
-<a>Dispatch the events for a typeable string</a> with arguments
-<var>current typeable text</var> and <var>keyboard</var>.
-
-<li><p>
-<a>Clear the modifier key state</a> with arguments
-<var>undo actions</var> and <var>keyboard</var>.
-If an <a>error</a> is returned, return that <a>error</a>
+ <li><p><a>Try</a> to <a>clear the modifier key state</a> with arguments
+ <var>input state</var>, <var>input id</var>, <var>source</var>,
+ <var>undo actions</var>, and <var>browsing context</var>.
 </ol> <!-- /create actions from a string -->
 
 <p>The <a>remote end steps</a> for <a>Element Send Keys</a> are:
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>text</var> be the result
   of <a>getting a property</a> called "<code>text</code>"
   from the <var>parameters</var> argument.
@@ -6306,18 +6321,26 @@ If an <a>error</a> is returned, return that <a>error</a>
        and <code>end</code> parameters.
      </ol>
     </dd>
-   </dl>
+  </dl>
 
- <li><p>Let <var>keyboard</var> be a new <a>key input source</a>.
+ <li><p>Let <var>input state</var> be the <a>current session</a>'s
+ <a>input state</a>.
 
- <li><p><a>Dispatch actions for a string</a> with
-  arguments <var>text</var> and <var>keyboard</var>.
+ <li><p>Let <var>input id</var> be a the result of <a>generating a
+ UUID</a>.
 
- <li><p>Remove <var>keyboard</var> from the <a>current
-  session</a>’s <a>input state table</a>
+ <li><p>Let <var>source</var> be the result of <a>create an
+ input source</a> with "<code>key</code>".
 
- <li><p>Remove <var>keyboard</var> from the list of
-  <a>active input sources</a>.
+ <li><p><a>Add an input source</a> with <var>input
+ state</var>, <var>input id</var> and <var>source</var>.
+
+ <li><p><a>Dispatch actions for a string</a> with arguments <var>input
+ state</var>, <var>input id</var>, and <var>source</var>,
+<var>text</var>, and <a>current browsing  context</a>.
+
+ <li><p><a>Remove an input source</a> with <var>input state</var>
+ and <var>input id</var>.
 
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
@@ -7256,27 +7279,49 @@ The first argument provided to the function will be serialized to JSON and retur
 <section>
 <h3>Input sources</h3>
 
-<p class=note>
-The objects and properties defined in this section are spec-internal constructs
-and do not correspond to ECMAScript objects.
-For convenience the same terminology is used for their manipulation.
+<p>An <dfn>input source</dfn> is a virtual device providing input
+ events. Each input source is represented by an [=struct=] specific to
+ the type of the input source. Each input source has an <dfn>input
+ id</dfn> which is stored as a key in the <a>input state map</a>.
 
-<p>An <dfn data-lt="input sources">input source</dfn> is a virtual device providing input events.
- Each <a>input source</a> has an associated <dfn>input id</dfn>,
- which is a string that identifies the particular device,
- and a <dfn>source type</dfn> which determines
- the kind of input the device can provide.
- As with real devices, virtual devices are stateful;
- this state is recorded in an <a>input source state</a> object
- associated with each <a>input source</a>.
+<p>To <dfn>create an input source</dfn> given <var>type</var> and
+optional <var>subtype</var>:
 
+<ol>
+ <li><p>Run the substeps matching the first matching value
+ of <var>type</var>:
+
+  <dl>
+    <dt>"<code>none</code>"
+    <dd>Let <var>source</var> be the result of <a>create a null input
+    source</a>.
+
+    <dt>"<code>key</code>"
+    <dd>Let <var>source</var> be the result of <a>create a key input
+    source</a>.
+
+    <dt>"<code>pointer</code>"
+    <dd>Let <var>source</var> be the result of <a>create a pointer
+    input source</a> with <var>subtype</var>.
+
+    <dt>"<code>wheel</code>"
+    <dd>Let <var>source</var> be the result of <a>create a wheel input
+    source</a>.
+
+    <dt>Otherwise:
+    <dd>Return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+  </dl>
+
+ <li>Return <a>success</a> with data <var>source</var>.
+</ol>
 
 <section>
-<h4 id=input-sources>Sources</h4>
+<h4>Null input source</h4>
 
 <p>A <dfn>null input source</dfn> is an <a>input source</a> that is
- not associated with a specific physical device. A <a>null input source</a>
- supports the following actions:
+ not associated with a specific physical device. a <a>null input
+ source</a> has no type-specific items, and supports the
+ following actions:
 
 <table class=simple>
  <tr>
@@ -7291,32 +7336,117 @@ For convenience the same terminology is used for their manipulation.
  </tr>
 </table>
 
+<p>To <dfn>create a null input source</dfn>, return a new <a>null input
+source</a>.
+
+</section> <!-- /Null input source -->
+
+<section>
+<h4>Key input source</h4>
+
 <p>A <dfn>key input source</dfn> is an <a>input source</a>
  that is associated with a keyboard-type device.
- A <a>key input source</a> supports the same <a>pause</a> action
- as a <a>null input source</a> plus the following actions:
 
- <table class=simple>
-  <tr>
-   <th>Action
-   <th>Non-normative Description
-  </tr>
-  <tr>
-   <td><dfn>keyDown</dfn></td>
-   <td>Used to indicate that a particular key should be held down.</td>
-  </tr>
-  <tr>
-   <td><dfn>keyUp</dfn></td>
-   <td>Used to indicate that a depressed key should be released.</td>
-  </tr>
- </table>
+<p>A <a>key input source</a> has the following items:
+
+<table class=simple>
+ <tr>
+  <th>Item
+  <th>Non-normative Description
+  <th>Default Value
+ </tr>
+ <tr>
+  <td>pressed
+  <td>A set of strings representing currently pressed keys.
+  <td>Empty set
+ </tr>
+ <tr>
+  <td>alt
+  <td>A boolean indicating whether the alt modifier is depressed.
+  <td>False
+ </tr>
+ <tr>
+  <td>ctrl
+  <td>A boolean indicating whether the ctrl modifier is depressed.
+  <td>False
+ </tr>
+ <tr>
+  <td>meta</td>
+  <td>A boolean indicating whether the meta modifier is depressed.
+  <td>False
+ </tr>
+ <tr>
+  <td>shift</td>
+  <td>A boolean indicating whether the shift modifier is depressed.
+  <td>False
+ </tr>
+</table>
+
+<p>A <a>key input source</a> supports the same <a>pause</a> action
+as a <a>null input source</a> plus the following actions:
+
+<table class=simple>
+ <tr>
+  <th>Action
+  <th>Non-normative Description
+ </tr>
+ <tr>
+  <td><dfn>keyDown</dfn></td>
+  <td>Used to indicate that a particular key should be held down.</td>
+ </tr>
+ <tr>
+  <td><dfn>keyUp</dfn></td>
+  <td>Used to indicate that a depressed key should be released.</td>
+ </tr>
+</table>
+
+<p>To <dfn>create a key input source</dfn>, return a new <a>key
+input source</a> with the items initalized to their default values.
+
+</section> <!-- /key input source -->
+
+<section>
+<h4>Pointer input source</h4>
 
 <p>A <dfn>pointer input source</dfn> is an <a>input source</a> that is
- associated with a pointer-type input device. Such an <a>input source</a> has
- an associated <dfn>pointer type</dfn> specifying exactly which kind
- of pointing device it is associated with. A <a>pointer input source</a>
- supports the same <a>pause</a> action as a <a>null input source</a>
- plus the following actions:
+ associated with a pointer-type input device.
+
+<p>A <a>pointer input source</a> has the following items:
+
+<table class=simple>
+ <tr>
+  <th>Item
+  <th>Non-normative Description
+  <th>Default Value
+ </tr>
+ <tr>
+  <td>subtype
+  <td>The type of pointing device. This can be "<code>mouse</code>",
+  "<code>pen</code>", or "<code>touch</code>".
+  <td>
+ </tr>
+ <tr>
+  <td>pressed
+  <td>A set of unsigned integers representing the pointer buttons that
+  are currently depressed.
+  <td>Empty set
+ </tr>
+ <tr>
+  <td>x
+  <td>An unsigned integer representing the pointer x location in
+  viewport coordinates.
+  <td>0
+ </tr>
+ <tr>
+  <td>y
+  <td>An unsigned integer representing the pointer y location in
+  viewport coordindates.
+  <td>0
+ </tr>
+</table>
+
+<p>A <a>pointer input source</a> supports the same <a>pause</a> action as
+ a <a>null input source</a> plus the following actions:
 
 <table class=simple>
  <tr>
@@ -7346,10 +7476,21 @@ For convenience the same terminology is used for their manipulation.
  </tr>
 </table>
 
-<p>A <dfn>wheel input source</dfn> is an <a>input source</a>
- that is associated with a wheel-type input device.
- A <a>wheel input source</a> supports the same <a>pause</a> action
- as a <a>null input source</a> plus the following actions:
+<p>To <dfn>create a pointer input source</dfn> object
+ given <var>subtype</var>, return a new <a>pointer input source</a>
+ with subtype set to <var>subtype</var>, and the other items set to
+ their default values.
+
+</section> <!-- /Pointer input source -->
+
+<section>
+<h4>Wheel input source</h4>
+
+<p>A <dfn>wheel input source</dfn> is an <a>input source</a> that is
+ associated with a wheel-type input device.  A <a>wheel input
+ source</a> has no type specific items, and supports the
+ same <a>pause</a> action as a <a>null input source</a> plus the
+ following actions:
 
  <table class=simple>
   <tr>
@@ -7363,171 +7504,142 @@ For convenience the same terminology is used for their manipulation.
   </tr>
  </table>
 
-<p>Each <a>session</a> maintains a <a>list</a> of <dfn>active input
-sources</dfn>. This list is initially empty. When an <a>input
-source</a> is added to the list of <a>active input sources</a>, a
-corresponding entry is made in the <a>input state table</a> where the
-key is the <a>input source</a>’s <code>input id</code> and the value is
-the <a>input source</a>’s <a>input source state</a>. When an
-<a>input source</a> is removed from the list of <a>active input
-sources</a>, the corresponding entry in the <a>input state table</a>
-is also removed.
+<p>To <dfn>create a wheel input source</dfn> return a new <a>wheel
+ input source</a>.
 
-</section> <!-- /input-sources -->
-
+</section> <!-- /Wheel input souece-->
+</section> <!-- /Input sources -->
 
 <section>
-<h4 id=input-source-state>State</h4>
+<h3>Input state</h3>
 
-<p>
-<dfn>Input source state</dfn> is used as a generic term to
-describe the state associated with each <a>input source</a>.
+<p>An <dfn>input state</dfn> represents the overall state of a
+collection of <a>input sources</a>.
 
-<p>The <dfn>corresponding input source state type</dfn>
- for a label <var>action type</var> is given by the following table:
+An <a>input state</a> has the following items:
 
-<table class=simple>
- <thead>
-  <tr>
-   <th><var>Action type</var>
-   <th>Input state
-  </tr>
- </thead>
+<ul>
 
- <tr>
-  <td>"<code>none</code>"
-  <td><a>null input state</a>
- </tr>
+ <li><p>A <dfn>input state map</dfn> which is a map where keys are
+ <a>input ids</a>, and the values are <a>input sources</a>.
 
- <tr>
-  <td>"<code>key</code>"
-  <td><a>key input state</a>
- </tr>
+ <li><p>An <dfn>input cancel list</dfn>, which is a list of <a>action
+  objects</a>.  This list is used to manage dispatching events when
+  resetting the state of the <a>input source</a>
 
- <tr>
-  <td>"<code>pointer</code>"
-  <td><a>pointer input state</a>
- </tr>
+</ul>
 
- <tr>
-  <td>"<code>wheel</code>"
-  <td><a>wheel input state</a>
- </tr>
-</table>
+<p>To <dfn>create an input state</dfn>:
 
-<p>A <a>null input source</a>’s <a>input source state</a> is
- a <dfn>null input state</dfn>. This is always an empty object.
+<ol class="algorithm">
+ <li><p>Let <var>input state</var> be an <a>input state</a> with
+ the <a>input state map</a> set to an empty map, and the <a>input
+ cancel list</a> set to an empty list.
 
-<p>A <a>key input source</a>’s <a>input source state</a> is a
- <dfn>key input state</dfn> object. This is an object with a
- property, <code>pressed</code>, which is a set of strings
- representing currently pressed keys and
- properties <code>alt</code>, <code>shift</code>, <code>ctrl</code>,
- and <code>meta</code>, which are <a>Boolean</a>s.
-
-<p>When required to <dfn>create a new key input state object</dfn>, an
- implementation must return a <a>key input state</a> object with
- the <code>pressed</code> property set to the empty set
- and <code>alt</code>, <code>shift</code>, <code>ctrl</code>,
- and <code>meta</code> all set to <code>false</code>.
-
-<p>
-A <a>pointer input source</a>’s <a>input source state</a>
-is a <dfn>pointer input state</dfn> object.
-This consists of a <code>subtype</code> property,
-which has the possible values
-"<code>mouse</code>",
-"<code>pen</code>",
-and "<code>touch</code>",
-a <code>pressed</code> property which is a set of unsigned integers,
-an <code>x</code> property which is an unsigned integer,
-and a <code>y</code> property which is an unsigned integer.
-
-<p>When required to <dfn>create a new pointer input state</dfn> object
- with arguments <var>subtype</var> an implementation must return
- a <a>pointer input state</a> object with <code>subtype</code> set
- to <var>subtype</var>, <code>pressed</code> set to an empty set and
- both <code>x</code> and <code>y</code> set to <code>0</code>.
-
-<p>A <a>wheel input source</a>’s <a>input source state</a> is a
- <dfn>wheel input state</dfn> object. This is always an empty object.
-
-<p>Each <a>session</a> has an associated <dfn>input state table</dfn>.
- This is a map between <a>input id</a>
- and the <a>input source state</a> for that <a>input source</a>,
- with one entry for each item in the list of <a>active input sources</a>.
-
-<p>Each <a>session</a> also has an associated <dfn>input cancel
- list</dfn>, which is a list of actions. This list is used to manage
- dispatching events when resetting the state of the <a>input
- source</a>s. For simplicity the algorithms described here only append
- actions to the list and rely on the fact that the reset operations
- are idempotent.
-
-<p>The <dfn>calculated global key state</dfn> is the aggregated key
- state from all <a>key input state</a> objects. It can be calculated
- this way:
-
-<ol>
- <li><p>Let <var>pressed</var> be a new Set.
-
- <li><p>Let <var>alt</var>, <var>ctrl</var>, <var>meta</var>,
-  and <var>shift</var> be the <a>Boolean</a> <code>false</code> value.
-
- <li><p>For enumerable <a>own property</a> in the <a>input state table</a>:
-
- <ol>
-  <li><p>Let <var>source</var> be the value of the property.
-
-  <li><p>If <var>source</var> is not a <a>key input state</a>,
-   continue to the first step of this loop.
-
-  <li><p>Let <var>key state pressed</var> be the result of <a>getting
-   a property</a> named <code>pressed</code> from <var>source</var>.
-
-  <li><p>Add all strings from <var>key state pressed</var>
-   to <var>pressed</var>.
-
-  <li>Let <var>alt</var> be a logical OR of <var>alt</var> and the
-   result of <a>getting a property</a> named <code>alt</code>
-   from <var>source</var>.
-
-  <li>Let <var>ctrl</var> be a logical OR of <var>ctrl</var> and the
-   result of <a>getting a property</a> named <code>ctrl</code>
-   from <var>source</var>.
-
-  <li>Let <var>meta</var> be a logical OR of <var>meta</var> and the
-   result of <a>getting a property</a> named <code>meta</code>
-   from <var>source</var>.
-
-  <li>Let <var>shift</var> be a logical OR of <var>shift</var> and the
-   result of <a>getting a property</a> named <code>shift</code>
-   from <var>source</var>.
- </ol>
-
- <li><p>Let <var>state</var> be a new JSON <a>Object</a>.
-
- <li><p><a>Set a property</a> on <var>state</var> with
-  name <var>pressed</var> and value <var>pressed</var>.
-
- <li><p><a>Set a property</a> on <var>state</var> with
-  name <var>alt</var> and value <var>alt</var>.
-
- <li><p><a>Set a property</a> on <var>state</var> with
-  name <var>ctrl</var> and value <var>ctrl</var>.
-
- <li><p><a>Set a property</a> on <var>state</var> with
-  name <var>meta</var> and value <var>meta</var>.
-
- <li><p><a>Set a property</a> on <var>state</var> with
-  name <var>shift</var> and value <var>shift</var>.
-
- <li><p>Return <var>state</var>.
+ <li><p>Return <var>input state</var>.
 </ol>
 
-</section> <!-- /input-source-state -->
-</section> <!-- /Input-sources -->
+<p>To <dfn>add an input source</dfn> given <var>input state</var>
+<var>input id</var>, and <var>source</var>:
 
+<ol class="algorithm">
+  <li><p>Let <var>input state map</var> be <var>input
+  state</var>'s <a>input state map</a>.
+
+  <li>Set <var>input state map</var>[<var>input id</var>]
+  to <var>source</var>.
+</ol>
+</div>
+
+<p>To <dfn>remove an input source</dfn> given <var>input state</var>,
+and <var>input id</var>:
+<ol class="algorithm">
+  <li><p>Assert: None of the items in <var>input
+  state</var>'s <a>input cancel list</a> has id equal
+  to <var>input id</var>.
+
+  <li><p>Let <var>input state map</var> be <var>input
+  state</var>'s <a>input state map</a>.
+
+  <li>Remove <var>input state map</var>[<var>input id</var>].
+</ol>
+
+<p>To <dfn>get an input source</dfn> given <var>input state</var>
+and <var>input id</var>:
+
+<ol class="algorithm">
+  <li><p>Let <var>input state map</var> be <var>input
+  state</var>'s <a>input state map</a>.
+
+  <li><p>If <var>input state map</var>[<var>input id</var>] exists,
+  return <var>input state map</var>[<var>input id</var>].
+
+ <li><p>Return undefined.</p></li>
+</ol>
+
+<p>To <dfn>get or create an input source</dfn> given <var>input
+state</var>, <var>type</var>, <var>input id</var>, and
+optional <var>subtype</var>:
+
+<ol class="algorithm">
+  <li><p>Let <var>source</var> be <a>get an input source</a>
+  with <var>input state</var> and <var>input id</var>.
+
+  <li><p>If <var>source</var> is not undefined and <var>source</var>'s
+  type is not equal to <var>type</var>, or <var>source</var> is
+  a <a>pointer input source</a>return <a>error</a> with <a>error
+  code</a> <a>invalid argument</a>.
+
+  <li><p>If <var>source</var> is undefined, set <var>source</var> to
+  the result of <a>trying</a> to <a>create an input source</a>
+  with <var>type</var>.
+
+ <li><p>Return success with data <var>source</var>.</p></li>
+</ol>
+
+<p>A <dfn>global key state</dfn> is a [=struct=] with items pressed,
+altKey, ctrlKey, metaKey, and shiftKey.
+
+<p>To <dfn>get the global key state</dfn> given <var>input state</var>:
+
+<ol class="algorithm">
+ <li><p>Let <var>input state map</var> be <var>input
+  state</var>'s <a>input state map</a>.
+
+ <li><p>Let <var>sources</var> be the result of [=map/getting the
+ values=] with <var>input state map</var>.
+
+ <li><p>Let <var>key state</var> be a new <a>global key state</a>
+  with <code>pressed</code> set to an empty
+  set, <code>altKey</code>, <code>ctrlKey</code>, <code>metaKey</code>,
+  and <code>shiftKey</code> set to false.
+
+ <li><p>For each <var>source</var> in <var>sources</var>:
+
+ <ol>
+  <li><p>If <var>source</var> is not a <a>key input source</a>,
+   continue to the first step of this loop.
+
+  <li><p>Set <var>key state</var>'s <code>pressed</code> item to the
+  union of its current value and <var>source</var>'s pressed item.
+
+  <li><p>If <var>source</var>'s <code>alt</code> item is true,
+  set <var>key state</var>'s <code>altKey</code> item to true.
+
+  <li><p>If <var>source</var>'s <code>ctrl</code> item is true,
+  set <var>key state</var>'s <code>ctrlKey</code> item to true.
+
+  <li><p>If <var>source</var>'s <code>meta</code> item is true,
+  set <var>key state</var>'s <code>metaKey</code> item to true.
+
+  <li><p>If <var>source</var>'s <code>shift</code> item is true,
+  set <var>key state</var>'s <code>shiftKey</code> item to true.
+ </ol>
+
+ <li><p>Return <var>key state</var>.
+</ol>
+
+</section> <!-- /input state -->
 
 <section>
 <h3>Ticks</h3>
@@ -7554,14 +7666,20 @@ and a <code>y</code> property which is an unsigned integer.
  up in implementation-specific territory. However there are certain
  content observable effects that must be consistent across
  implementations. To accommodate this, the specification requires
- that <a>remote ends</a> <dfn>perform implementation-specific action dispatch
- steps</dfn>, along with a list of events and their properties. This
- list is not comprehensive; in particular the default action of the
- <a>input source</a> may cause additional events to be generated depending on
- the implementation and the state of the browser (e.g. input events
- relating to key actions when the focus is on an
- editable <a>element</a>, scroll events, etc.).
+ that <a>remote ends</a> <dfn>perform implementation-specific action
+ dispatch steps</dfn> on a <a>browsing context</a> <var>context</var>,
+ and a <var>list of events</var> and their properties. These steps
+ must be equivalent to performing the given input device manipulations
+ on <var>context</var>, such that trusted events corresponding to the
+ entries in <var>list of events</var>are dispatched.
 
+<aside class=note>
+ <p>The list of events is not comprehensive; in particular the default
+ action of the <a>input source</a> may cause additional events to be
+ generated depending on the implementation and the state of the
+ browser (e.g. input events relating to key actions when the focus is
+ on an editable <a>element</a>, scroll events, etc.).
+</aside>
  <!-- todo: define generating DOM events from an input somewhere -->
 
 <aside class=note>
@@ -7572,15 +7690,14 @@ In particular, the dispatched events
 will have the {{Event/isTrusted}} attribute set to true.
 
 <p>
-The most robust way to dispatch these events
-is by creating them in the browser implementation itself.
-Sending operating system specific input messages to the browser’s window
-has the disadvantage that the browser being automated
-may not be properly isolated from a user
-accidentally modifying <a>input source state</a>.
-Use of an operating system level accessibility API
-has the disadvantage that the browser’s window must be focused,
-and as a result, multiple WebDriver instances cannot run in parallel.
+The most robust way to dispatch these events is by creating them in
+the browser implementation itself.  Sending operating system specific
+input messages to the browser’s window has the disadvantage that the
+browser being automated may not be properly isolated from a user
+accidentally modifying an <a>input source</a>.  Use of an operating
+system level accessibility API has the disadvantage that the browser’s
+window must be focused, and as a result, multiple WebDriver instances
+cannot run in parallel.
 
 <p>
 The advantage of an operating system level accessibility API
@@ -7602,11 +7719,10 @@ from a machine utilisation perspective.
  input JSON, such that the actions to be performed in a single <a>tick</a>
  are grouped together.
 
-<p>When required to <dfn>extract an action sequence</dfn> with
- argument <var>parameters</var>, a <a>remote end</a> must run the
- following steps:
+<p>To <dfn>extract an action sequence</dfn> with
+ <var>input state</var>, and <var>parameters</var>:
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>actions</var> be the result
   of <a>getting a property</a> from <var>parameters</var>
   named <code>actions</code>.
@@ -7622,15 +7738,15 @@ from a machine utilisation perspective.
   corresponding to an indexed property in <var>actions</var>:
 
   <ol>
-   <li><p>Let <var>input source actions</var> be the result
+   <li><p>Let <var>source actions</var> be the result
     of <a>trying</a> to <a>process an input source action sequence</a>
-    with argument <var>action sequence</var>.
+    given <var>input state</var> and <var>action sequence</var>.
 
-   <li><p>For each <var>action</var> in <var>input source actions</var>:
+   <li><p>For each <var>action</var> in <var>source actions</var>:
 
     <ol>
      <li><p>Let <var>i</var> be the zero-based index
-      of <var>action</var> in <var>input source actions</var>.
+      of <var>action</var> in <var>source actions</var>.
 
      <li><p>If the length of <var>actions by tick</var> is less
       than <var>i</var> + 1, append a new <a>List</a> to
@@ -7646,13 +7762,14 @@ from a machine utilisation perspective.
   <var>actions by tick</var>.
 </ol>
 
-<p>When required to <dfn>process an input source action sequence</dfn>,
- with argument <var>action sequence</var>, a <a>remote end</a>
- must run the following steps:
+<p>When required to <dfn>process an input source action
+ sequence</dfn>, with argument <var>input state</var>
+ and <var>action sequence</var>, a <a>remote end</a> must run the
+ following steps:
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>type</var> be the result of <a>getting a property</a>
-  named <code>type</code> from <var>action sequence</var>.
+  named "<code>type</code>" from <var>action sequence</var>.
 
  <li><p>If <var>type</var> is
   not "<code>key</code>", "<code>pointer</code>",
@@ -7661,7 +7778,7 @@ from a machine utilisation perspective.
   <a>error code</a> <a>invalid argument</a>.
 
  <li><p>Let <var>id</var> be the result of
-  <a>getting the property</a> <code>id</code> from
+  <a>getting the property</a> "<code>id</code>" from
   <var>action sequence</var>.
 
  <!-- TODO: consider picking the current input of the right
@@ -7677,50 +7794,14 @@ from a machine utilisation perspective.
   of <a>trying</a> to <a>process pointer parameters</a>
   with argument <var>parameters data</var>.
 
- <li><p>Let <var>source</var> be the <a>input source</a>
-  in the list of <a>active input sources</a>
-  where that <a>input source</a>’s <a>input id</a>
-  is equal to <var>id</var>,
-  or <a>undefined</a> if there is no matching <a>input source</a>.
-
- <li><p>If <var>source</var> is <a>undefined</a>:
-
-  <ol>
-   <li>Let <var>source</var> be a new <a>input source</a> created from
-    the first match against <var>type</var>:
-
-    <dl class=switch>
-     <dt>"<code>none</code>"
-     <dd>Create a new <a>null input source</a>.
-
-     <dt>"<code>key</code>"
-     <dd>Create a new <a>key input source</a>.
-
-     <dt>"<code>pointer</code>"
-     <dd>Create a new <a>pointer input source</a>. Let the
-      new <a>input source</a>’s <a>pointer type</a> be set to the value
-      of <var>parameters</var>’s <code>pointerType</code> property.
-
-     <dt>"<code>wheel</code>"
-     <dd>Create a new <a>wheel input source</a>.
-    </dl>
-
-   <li><p>Add <var>source</var> to the <a>current session</a>’s list
-    of <a>active input sources</a>.
-
-   <li><p>Add <var>source</var>’s <a>input source state</a> to
-    the <a>current session</a>’s <a>input state table</a>, keyed
-    on <var>source</var>’s <a>input id</a>.
-  </ol>
-
- <li><p>If <var>source</var>’s <a>source type</a> is not equal to
-  <var>type</var> return an <a>error</a> with <a>error
-  code</a> <a>invalid argument</a>.
+  <li><p>Let <var>source</var> be the result of trying to <a>get or
+  create an input source</a> given <var>input
+  state</var>, <var>type</var> and <var>id</var>.
 
  <li><p>If <var>parameters</var> is not <a>undefined</a>,
   then if its <code>pointerType</code> property is not equal to
-  <var>source</var>’s <a>pointer type</a>,
-  return an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+  <var>source</var>’s subtype property, return an <a>error</a>
+  with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>Let <var>action items</var> be the result of <a>getting a
   property</a> named <code>actions</code> from
@@ -7767,11 +7848,10 @@ from a machine utilisation perspective.
 <p>The <dfn>default pointer parameters</dfn> consist of an object with
  property <code>pointerType</code> set to <code>mouse</code>.
 
-<p>When required to <dfn>process pointer parameters</dfn> with
- argument <var>parameters data</var>, a <a>remote end</a> must perform
- the following steps:
+<p>To <dfn>process pointer parameters</dfn> given
+ <var>parameters data</var>:
 
-<ol>
+<ol class="algorithm">
 <li><p>
 Let <var>parameters</var> be the <a>default pointer parameters</a>.
 
@@ -7809,20 +7889,19 @@ If <var>pointer type</var> is not <a>undefined</a>:
 
 <p>An <dfn>action object</dfn> constructed with
  arguments <var>id</var>, <var>type</var>, and <var>subtype</var> is
- an object with property <code>id</code> set to <var>id</var>,
- <code>type</code> set to <var>type</var> and <code>subtype</code> set
+ an object with property id set to <var>id</var>, type
+ set to <var>type</var> and subtype set
  to <var>subtype</var>. Specific action objects have further
  properties added by other algorithms in this specification.
 
 <p>
-When required to <dfn>process a null action</dfn> with arguments
-<var>id</var> and <var>action item</var>,
-a <a>remote end</a> must perform the following steps:</p>
+To <dfn>process a null action</dfn> given
+<var>id</var> and <var>action item</var>:
 
-<ol>
+<ol class="algorithm">
 <li><p>
 Let <var>subtype</var> be the result of <a>getting a property</a>
-named <code>type</code> from <var>action item</var>.
+named "<code>type</code>" from <var>action item</var>.
 
 <li><p>
 If <var>subtype</var> is not "<code>pause</code>",
@@ -7844,14 +7923,13 @@ Return <var>result</var>.
 </ol>
 
 <p>
-When required to <dfn>process a key action</dfn> with arguments
-<var>id</var> and <var>action item</var>,
-a <a>remote end</a> must perform the following steps:</p>
+To <dfn>process a key action</dfn> given
+<var>id</var> and <var>action item</var>:</p>
 
-<ol>
+<ol class="algorithm">
 <li><p>
 Let <var>subtype</var> be the result of <a>getting a property</a>
-named <code>type</code> from <var>action item</var>.
+named "<code>type</code>" from <var>action item</var>.
 
 <li><p>
 If <var>subtype</var> is not one of the values
@@ -7890,17 +7968,13 @@ Set the <code>value</code> property on <var>action</var> to <var>key</var>.
 Return success with data <var>action</var>.
 </ol>
 
-<p>
-When required to <dfn>process a pointer action</dfn> with arguments
-<var>id</var>,
-<var>parameters</var>,
-and <var>action item</var>,
-a <a>remote end</a> must perform the following steps:</p>
+<p>To <dfn>process a pointer action</dfn> given <var>id</var>,
+<var>parameters</var>, and <var>action item</var>:
 
-<ol>
+<ol class="algorithm">
 <li><p>
 Let <var>subtype</var> be the result
-of <a>getting a property</a> named <code>type</code>
+of <a>getting a property</a> named "<code>type</code>"
 from <var>action item</var>.
 
 <li><p>
@@ -7950,16 +8024,13 @@ If doing so results in an <a>error</a>, return that <a>error</a>.
 Return <a>success</a> with data <var>action</var>.
 </ol>
 
-<p>
-When required to <dfn>process a wheel action</dfn> with arguments
-<var>id</var>,
-and <var>action item</var>,
-a <a>remote end</a> must perform the following steps:</p>
+<p>To <dfn>process a wheel action</dfn> given
+<var>id</var>, and <var>action item</var>:</p>
 
-<ol>
+<ol class="algorithm">
 <li><p>
 Let <var>subtype</var> be the result
-of <a>getting a property</a> named <code>type</code>
+of <a>getting a property</a> named "<code>type</code>"
 from <var>action item</var>.
 
 <li><p>
@@ -8060,14 +8131,12 @@ Set the <code>deltaY</code> property of <var>action</var> to <var>deltaY</var>.
 Return <a>success</a> with data <var>action</var>.
 </ol>
 
-<p>When required to <dfn>process a pause action</dfn> with
- arguments <var>action item</var>, and <var>action</var>, a
- <a>remote end</a> must run the following steps:</p>
+<p>To <dfn>process a pause action</dfn> given <var>action item</var>,
+and <var>action</var>:</p>
 
-<ol>
- <li><p>Let <var>duration</var> be the result
-  of <a>getting the property</a> "<code>duration</code>"
-  from <var>action item</var>.
+<ol class="algorithm">
+ <li><p>Let <var>duration</var> be the result of <a>getting the
+  property</a> "<code>duration</code>" from <var>action item</var>.
 
  <li><p>If <var>duration</var> is not <a>undefined</a>
   and <var>duration</var> is not an <a>Integer</a> greater than or
@@ -8080,11 +8149,10 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Return success with data <var>action</var>.
 </ol>
 
-<p>When required to <dfn>process a pointer up or pointer down action</dfn>
- with arguments <var>action item</var>, and <var>action</var>, a
- <a>remote end</a> must run the following steps:</p>
+<p>To <dfn>process a pointer up or pointer down action</dfn>
+ given <var>action item</var>, and <var>action</var>:</p>
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>button</var> be the result
   of getting the property <code>button</code>
   from <var>action item</var>.
@@ -8207,11 +8275,10 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Return success with data <a><code>null</code></a>.
 </ol>
 
-<p>When required to <dfn>process a pointer move action</dfn> with
- arguments <var>action item</var>, and <var>action</var>, a
- <a>remote end</a> must run the following steps:</p>
+<p>To <dfn>process a pointer move action</dfn> given <var>action
+item</var>, and <var>action</var>:</p>
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>duration</var> be the result
   of getting the property <code>duration</code>
   from <var>action item</var>.
@@ -8379,11 +8446,11 @@ Return <a>success</a> with data <var>action</var>.
  grouped by <a>tick</a>, and then causes each action to be run at the
  appropriate point in the sequence.
 
-<p>When asked to <dfn>dispatch actions</dfn> with
-    argument <var>actions by tick</var>, a <a>remote end</a> must run the
-    following steps:</p>
+<p>To <dfn>dispatch actions</dfn> given <var>input
+   state</var>, <var>actions by tick</var>, and <var>browsing
+   context</var>:</p>
 
-<ol>
+<ol class="algorithm">
  <li><p>For each item <var>tick actions</var> in
   <var>actions by tick</var>:
 
@@ -8391,9 +8458,10 @@ Return <a>success</a> with data <var>action</var>.
    <li><p>Let <var>tick duration</var> be the result of <a>computing
     the tick duration</a> with argument <var>tick actions</var>.
 
-   <li><p><a>Dispatch tick actions</a> with arguments
-   <var>tick actions</var> and <var>tick duration</var>.
-   If this results in an <a>error</a> return that error.
+   <li><p><a>Dispatch tick actions</a> with
+   <var>tick actions</var>, <var>tick duration</var>,
+   and <var>browsing context</var>.  If this results in
+   an <a>error</a> return that error.
 
    <li><p>Wait until the following conditions are all met:
 
@@ -8414,12 +8482,11 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Return success with data <a><code>null</code></a>.
 </ol>
 
-<p>When required to
+<p>To
  <dfn data-lt="computing the tick duration">compute the tick duration</dfn>
- with argument <var>tick actions</var>, a <a>remote end</a>
- must take the following steps:</p>
+ given <var>tick actions</var>:</p>
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>max duration</var> be 0.
 
  <li><p>For each <var>action object</var> in <var>tick actions</var>:
@@ -8427,15 +8494,13 @@ Return <a>success</a> with data <var>action</var>.
   <ol>
    <li><p>let <var>duration</var> be <a>undefined</a>.
 
-   <li><p>If <var>action object</var> has <code>subtype</code>
-    property set to "<code>pause</code>"
-    or <var>action object</var> has <code>type</code> property set
-    to "<code>pointer</code>" and <code>subtype</code> property set
-    to "<code>pointerMove</code>", or <var>action object</var> has
-    <code>type</code> property set to "<code>wheel</code>" and
-    <code>subtype</code> property set to "<code>scroll</code>",
-    let <var>duration</var> be equal to the <code>duration</code>
-    property of <var>action object</var>.
+   <li><p>If <var>action object</var> has subtype property set to
+    "<code>pause</code>" or <var>action object</var> has type property
+    set to "<code>pointer</code>" and subtype property set to
+    "<code>pointerMove</code>", or <var>action object</var> has type
+    property set to "<code>wheel</code>" and subtype property set to
+    "<code>scroll</code>", let <var>duration</var> be equal to
+    the <code>duration</code> property of <var>action object</var>.
 
    <li><p>If <var>duration</var> is not <a>undefined</a>,
     and <var>duration</var> is greater than <var>max duration</var>,
@@ -8445,41 +8510,38 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Return <var>max duration</var>.
 </ol>
 
-<p>When required to <dfn>dispatch tick actions</dfn> with
- arguments <var>tick actions</var> and <var>tick duration</var>,
- a <a>remote end</a> must run the following steps:
+<p>To <dfn>dispatch tick actions</dfn> given <var>input
+ state</var>, <var>tick actions</var>, <var>tick duration</var>,
+ and <var>browsing context</var>:
 
-<ol>
+<ol class="algorithm">
  <li><p>For each <var>action object</var> in <var>tick actions</var>:
 
   <ol>
-   <li><p>Let <var>source id</var> be equal to the value
-    of <var>action object</var>’s <code>id</code> property.
+   <li><p>Let <var>input id</var> be equal to the value
+    of <var>action object</var>’s id property.
 
    <li><p>Let <var>source type</var> be equal to the value
-    of <var>action object</var>’s <code>type</code> property.
+    of <var>action object</var>’s type property.
 
-   <!-- TODO: this next bit doesn’t really link to the right
-    point in the spec for creating objects of the right type -->
+   <li><p>Let <var>source</var> be the result of <a>get an input
+    source</a> given <var>input state</var> and <var>input id</var>.
 
-   <li><p>If the <a>current session</a>’s <a>input state table</a> doesn’t
-    have a property corresponding to <var>source id</var>, then let
-    the property corresponding to <var>source id</var> be a new object
-    of the <a>corresponding input source state type</a> for
-    <var>source type</var>.
+   <li><p>Assert: <a>source</a> is not undefined.
 
-   <li><p>Let <var>device state</var> be the <a>input source state</a>
-    corresponding to <var>source id</var> in the
-    <a>current session</a>’s <a>input state table</a>.
+   <li><p>Let <var>global key state</a> be the result of <a>get the
+   global key state</a> with <var>input state</var>.
+
+   <li><p>Let <var>subtype</var> be <var>action
+   object</var>’s subtype.
 
    <li><p>Let <var>algorithm</var> be the value of the column
-    <i>dispatch action algorithm</i> from the following table of
-    <dfn>dispatch action algorithms</dfn> that is equal to the
-    <var>source type</var> and the <var>action object</var>’s
-    <code>subtype</code> property, to a dispatch action algorithm.
+    <i>dispatch action algorithm</i> from the following table where the
+    <i>source type</i> column is <var>source type</var> and
+    the <i>subtype</i> column is equal to <var>subtype</var>.
 
 <table class=simple>
-<tr><th><var>source type</var>  <th><code>subtype</code> property       <th>Dispatch action algorithm
+<tr><th>source type             <th>subtype                             <th>Dispatch action algorithm
 <tr><td>"<code>none</code>"     <td>"<code>pause</code>"                <td><a>Dispatch a pause action</a>
 <tr><td>"<code>key</code>"      <td>"<code>pause</code>"                <td><a>Dispatch a pause action</a>
 <tr><td>"<code>key</code>"      <td>"<code>keyDown</code>"              <td><a>Dispatch a keyDown action</a>
@@ -8487,15 +8549,27 @@ Return <a>success</a> with data <var>action</var>.
 <tr><td>"<code>pointer</code>"  <td>"<code>pause</code>"                <td><a>Dispatch a pause action</a>
 <tr><td>"<code>pointer</code>"  <td>"<code>pointerDown</code>"          <td><a>Dispatch a pointerDown action</a>
 <tr><td>"<code>pointer</code>"  <td>"<code>pointerUp</code>"            <td><a>Dispatch a pointerUp action</a>
-<tr><td>"<code>pointer</code>"  <td>"<code>pointerMove</code>           <td><a>Dispatch a pointerMove action</a>
-<tr><td>"<code>pointer</code>"  <td>"<code>pointerCancel</code>         <td><a>Dispatch a pointerCancel action</a>
+<tr><td>"<code>pointer</code>"  <td>"<code>pointerMove</code>"          <td><a>Dispatch a pointerMove action</a>
+<tr><td>"<code>pointer</code>"  <td>"<code>pointerCancel</code>"        <td><a>Dispatch a pointerCancel action</a>
 <tr><td>"<code>wheel</code>"    <td>"<code>pause</code>"                <td><a>Dispatch a pause action</a>
 <tr><td>"<code>wheel</code>"    <td>"<code>scroll</code>"               <td><a>Dispatch a scroll action</a>
 </table>
 
    <li><a>Try</a> to run <var>algorithm</var> with arguments
-    <var>source id</var>, <var>action object</var>,
-    <var>device state</var> and <var>tick duration</var>.
+    <var>input id</var>, <var>action object</var>,
+    <var>source</var>, <var>global key state</var>, <var>tick
+    duration</var>, and <var>browsing context</var>.
+
+   <li><p>If <var>subtype</var> is "<code>keyDown</code>", append
+    a copy of <var>action object</var> with the <var>subtype</var>
+    property changed to "<code>keyUp</code>" to <var>input
+    state</var>’s <a>input cancel list</a>.
+
+   <li><p>If <var>subtype</var> is "<code>pointerDown</code>", append
+    a copy of <var>action object</var> with the <var>subtype</var>
+    property changed to "<code>pointerUp</code>" to <var>input
+    state</var>’s <a>input cancel list</a>.
+
   </ol>
 
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
@@ -8505,15 +8579,15 @@ Return <a>success</a> with data <var>action</var>.
 <section>
 <h4>General actions</h4>
 
-<p>When required to <dfn>dispatch a pause action</dfn> with
- arguments <var>source id</var>, <var>action object</var>,
- <var>input state</var> and <var>tick duration</var> a
- <a>remote end</a> must run the following steps:
+<p>To <dfn>dispatch a pause action</dfn> given <var>input
+id</var>, <var>action object</var>, <var>source</var>, <var>global key
+state</var>, <var>tick duration</var>, and <var>browsing
+context</var>:
 
-<ol>
+<ol class="algorithm">
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
-</section>
+</section> <!-- /General actions -->
 
 
 <section>
@@ -8667,7 +8741,7 @@ Return <a>success</a> with data <var>action</var>.
  <tr><td><code>"y"</code></td><td><code>"Y"</code></td><td><code>"KeyY"</code></td></tr>
  <tr><td><code>"z"</code></td><td><code>"Z"</code></td><td><code>"KeyZ"</code></td></tr>
  <tr><td><code>"-"</code></td><td><code>"_"</code></td><td><code>"Minus"</code></td></tr>
- <tr><td><code>"."</code></td><td><code>">"."</code></td><td><code>"Period"</code></td></tr>
+ <tr><td><code>"."</code></td><td><code>"."</code></td><td><code>"Period"</code></td></tr>
  <tr><td><code>"'"</code></td><td><code>"&quot;"</code></td><td><code>"Quote"</code></td></tr>
  <tr><td><code>";"</code></td><td><code>":"</code></td><td><code>"Semicolon"</code></td></tr>
  <tr><td><code>"/"</code></td><td><code>"?"</code></td><td><code>"Slash"</code></td></tr>
@@ -8775,19 +8849,19 @@ Return <a>success</a> with data <var>action</var>.
  <tr><td><code>\uE05D</code></td><td>Numpad Delete<td><code>3</code></td></tr>
 </table>
 
-<p>When required to <dfn>dispatch a keyDown action</dfn> with arguments
- <var>source id</var>, <var>action object</var>,
- <var>input state</var> and <var>tick duration</var> a <a>remote end</a>
- must run the following steps:
+<p>To <dfn>dispatch a keyDown action</dfn> given
+<var>input id</var>, <var>action object</var>,
+<var>source</var>, <var>global key state</var>, <var>tick
+duration</var>, and <var>browsing context</var>:
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>raw key</var> be equal to the
   <var>action object</var>’s <code>value</code> property.
 
  <li><p>Let <var>key</var> be equal to the <a>normalized key value</a>
   for <var>raw key</var>.
 
- <li><p>If the <var>input state</var>’s <code>pressed</code> property
+ <li><p>If the <var>source</var>’s <code>pressed</code> property
   contains <var>key</var>, let <var>repeat</var> be true, otherwise
   let <var>repeat</var> be false.
 
@@ -8804,26 +8878,22 @@ Return <a>success</a> with data <var>action</var>.
   keyboard, following the guidelines in [[UI-EVENTS]].
 
  <li><p>If <var>key</var> is <code>"Alt"</code>, let
-  <var>device state’s</var> <code>alt</code> property be true.
+  <var>source</var>'s <code>alt</code> property be true.
 
  <li><p>If <var>key</var> is <code>"Shift"</code>, let
-  <var>device state’s</var> <code>shift</code> property be true.
+  <var>source</var>'s <code>shift</code> property be true.
 
  <li><p>If <var>key</var> is <code>"Control"</code>, let
-  <var>device state’s</var> <code>ctrl</code> property be true.
+  <var>source</var>'s <code>ctrl</code> property be true.
 
  <li><p>If <var>key</var> is <code>"Meta"</code>, let
-  <var>device state’s</var> <code>meta</code> property be true.
+  <var>source</var>'s <code>meta</code> property be true.
 
- <li><p>Add <var>key</var> to the set corresponding to
-  <var>input state</var>’s <code>pressed</code> property.
+ <li><p>Add <var>key</var> to <var>source</var>’s <code>pressed</code>
+ property.
 
- <li><p>Append a copy of <var>action object</var> with
-  the <var>subtype</var> property changed to "<code>keyUp</code>"
-  to <a>current session</a>’s <a>input cancel list</a>.
-
- <li><p><a>Perform implementation-specific
-  action dispatch steps</a> equivalent to pressing a key on the
+ <li><p><a>Perform implementation-specific action dispatch steps</a>
+  on <var>browsing context</var> equivalent to pressing a key on the
   keyboard in accordance with the requirements of [[UI-EVENTS]], and
   producing the following events, as appropriate, with the specified
   properties.  This will always produce events including at least
@@ -8839,10 +8909,10 @@ Return <a>success</a> with data <var>action</var>.
      <tr><td><code>key</code><td><var>key</var>
      <tr><td><code>code</code><td><var>code</var>
      <tr><td><code>location</code><td><var>location</var>
-     <tr><td><code>altKey</code><td><var>device state</var>’s <code>alt</code> property
-     <tr><td><code>shiftKey</code><td><var>device state</var>’s <code>shift</code> property
-     <tr><td><code>ctrlKey</code><td><var>device state</var>’s <code>ctrl</code> property
-     <tr><td><code>metaKey</code><td><var>device state</var>’s <code>meta</code> property
+     <tr><td><code>altKey</code><td><var>source</var>’s <code>alt</code> property
+     <tr><td><code>shiftKey</code><td><var>source</var>’s <code>shift</code> property
+     <tr><td><code>ctrlKey</code><td><var>source</var>’s <code>ctrl</code> property
+     <tr><td><code>metaKey</code><td><var>source</var>’s <code>meta</code> property
      <tr><td><code>repeat</code><td><var>repeat</var>
      <tr><td><code>isComposing</code><td><var>false</var>
      <tr><td><code>charCode</code><td><var>charCode</var>
@@ -8860,10 +8930,10 @@ Return <a>success</a> with data <var>action</var>.
      <tr><td><code>key</code><td><var>key</var>
      <tr><td><code>code</code><td><var>code</var>
      <tr><td><code>location</code><td><var>location</var>
-     <tr><td><code>altKey</code><td><var>device state</var>’s <code>alt</code> property
-     <tr><td><code>shiftKey</code><td><var>device state</var>’s <code>shift</code> property
-     <tr><td><code>ctrlKey</code><td><var>device state</var>’s <code>ctrl</code> property
-     <tr><td><code>metaKey</code><td><var>device state</var>’s <code>meta</code> property
+     <tr><td><code>altKey</code><td><var>source</var>’s <code>alt</code> property
+     <tr><td><code>shiftKey</code><td><var>source</var>’s <code>shift</code> property
+     <tr><td><code>ctrlKey</code><td><var>source</var>’s <code>ctrl</code> property
+     <tr><td><code>metaKey</code><td><var>source</var>’s <code>meta</code> property
      <tr><td><code>repeat</code><td><var>repeat</var>
      <tr><td><code>isComposing</code><td><var>false</var>
      <tr><td><code>charCode</code><td><var>charCode</var>
@@ -8881,20 +8951,20 @@ Return <a>success</a> with data <var>action</var>.
   key repetition.
 </aside>
 
-<p>When required to <dfn>dispatch a keyUp action</dfn> with
- arguments <var>source id</var>, <var>action object</var>,
- <var>input state</var> and <var>tick duration</var>
- a <a>remote end</a> must run the following steps:</p>
+<p>To <dfn>dispatch a keyUp action</dfn> given <var>input
+id</var>, <var>action object</var>, <var>source</var>,
+<var>global key state</var>, <var>tick duration</var>,
+and <var>browsing context</var>:</p>
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>raw key</var> be equal to
   <var>action object</var>’s <code>value</code> property.
 
  <li><p>Let <var>key</var> be equal to the
   <a>normalized key value</a> for <var>raw key</var>.
 
- <li><p>If the <var>input state</var>’s <code>pressed</code>
-  property does not contain <var>key</var>, return.
+ <li><p>If the <var>source</var>’s <code>pressed</code> item
+  does not contain <var>key</var>, return.
 
  <li><p>Let <var>code</var> be the <a>code</a> for
   <var>raw key</var>.
@@ -8909,23 +8979,23 @@ Return <a>success</a> with data <var>action</var>.
   key <var>key</var> and location <var>location</var> on a 102 key US
   keyboard, following the guidelines in [[UI-EVENTS]].
 
- <li><p>If <var>key</var> is <code>"Alt"</code>, let
-  <var>device state’s</var> <code>alt</code> property be false.
+ <li><p>If <var>key</var> is "<code>Alt</code>", let
+  <var>source</var>'s <code>alt</code> property be false.
 
- <li><p>If <var>key</var> is <code>"Shift"</code>, let
-  <var>device state’s</var> <code>shift</code> property be false.
+ <li><p>If <var>key</var> is "<code>Shift</code>", let
+  <var>source</var>'s <code>shift</code> property be false.
 
  <li><p>If <var>key</var> is <code>"Control"</code>, let
-  <var>device state’s</var> <code>ctrl</code> property be false.
+  <var>source</var>'s <code>ctrl</code> property be false.
 
  <li><p>If <var>key</var> is <code>"Meta"</code>, let
-  <var>device state’s</var> <code>meta</code> property be false.
+  <var>source</var>'s <code>meta</code> property be false.
 
- <li><p>Remove <var>key</var> from the set corresponding
-  to <var>input state</var>’s <code>pressed</code> property.
+ <li><p>Remove <var>key</var>
+ from <var>sources</var>’s <code>pressed</code> property.
 
- <li><p><a>Perform implementation-specific
-  action dispatch steps</a> equivalent to releasing a key on the
+ <li><p><a>Perform implementation-specific action dispatch steps</a>
+  on <var>browsing context</var> equivalent to releasing a key on the
   keyboard in accordance with the requirements of [[UI-EVENTS]], and
   producing at least the following events with the specified
   properties:
@@ -8940,10 +9010,10 @@ Return <a>success</a> with data <var>action</var>.
      <tr><td><code>key</code><td><var>key</var></tr>
      <tr><td><code>code</code><td><var>code</var></tr>
      <tr><td><code>location</code><td><var>location</var></tr>
-     <tr><td><code>altKey</code><td><var>device state</var>’s <code>alt</code> property</tr>
-     <tr><td><code>shiftKey</code><td><var>device state</var>’s <code>shift</code> property</tr>
-     <tr><td><code>ctrlKey</code><td><var>device state</var>’s <code>ctrl</code> property</tr>
-     <tr><td><code>metaKey</code><td><var>device state</var>’s <code>meta</code> property</tr>
+     <tr><td><code>altKey</code><td><var>source</var>’s <code>altKey</code> property</tr>
+     <tr><td><code>shiftKey</code><td><var>source</var>’s <code>shift</code> property</tr>
+     <tr><td><code>ctrlKey</code><td><var>source</var>’s <code>ctrl</code> property</tr>
+     <tr><td><code>metaKey</code><td><var>source</var>’s <code>meta</code> property</tr>
      <tr><td><code>repeat</code><td><var>false</var></tr>
      <tr><td><code>isComposing</code><td><var>false</var></tr>
      <tr><td><code>charCode</code><td><var>charCode</var></tr>
@@ -8954,18 +9024,16 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
 
-</section> <!-- /keyboard-actions -->
-
+</section> <!-- /Keyboard actions -->
 
 <section>
 <h4>Pointer actions</h4>
 
-<p>When required to <dfn>dispatch a pointerDown action</dfn> with
- arguments <var>source id</var>, <var>action object</var>,
- <var>input state</var> and <var>tick duration</var> a
- <a>remote end</a> must run the following steps:
+<p>To <dfn>dispatch a pointerDown action</dfn> given <var>input id</var>,
+ <var>action object</var>, <var>input state</var>, <var>global key state</var>,
+ <var>tick duration</var>, and <var>browsing context</var>:
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>pointerType</var> be equal to
   <var>action object</var>’s <code>pointerType</code> property.
 
@@ -9012,26 +9080,22 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Let <var>azimuthAngle</var> be equal to <var>action object</var>’s
   <code>azimuthAngle</code> property.
 
- <li><p>Append a copy of <var>action object</var> with
-  the <var>subtype</var> property changed to "<code>pointerUp</code>" to
-  the <a>current session</a>’s <a>input cancel list</a>.
-
- <li><p><a>Perform implementation-specific
-  action dispatch steps</a> equivalent to pressing the button
+ <li><p><a>Perform implementation-specific action dispatch steps</a>
+  on <var>browsing context</var> equivalent to pressing the button
   numbered <var>button</var> on the pointer with ID
-  <var>source id</var>, having type <var>pointerType</var> at
+  <var>input id</var>, having type <var>pointerType</var> at
   viewport x coordinate <var>x</var>, viewport y
   coordinate <var>y</var>, <var>width</var>, <var>height</var>,
   <var>pressure</var>, <var>tangentialPressure</var>, <var>tiltX</var>,
   <var>tiltY</var>, <var>twist</var>, <var>altitudeAngle</var>,
   <var>azimuthAngle</var>, with buttons <var>buttons</var> depressed
   in accordance with the requirements of [[UI-EVENTS]] and
-  [[POINTER-EVENTS]]. The generated events must
-  set <code>ctrlKey</code>, <code>shiftKey</code>, <code>altKey</code>,
-  and <code>metaKey</code> from the <a>calculated global key state</a>.
-  Type specific properties for the pointer that are not
-  exposed through the WebDriver API must be set to the default value
-  specified for hardware that doesn’t support that property.
+  [[POINTER-EVENTS]]. set <code>ctrlKey</code>, <code>shiftKey</code>,
+  <code>altKey</code>, and <code>metaKey</code> equal to the
+  corresponding items in <var>global key state</var>. Type specific
+  properties for the pointer that are not exposed through the
+  webdriver API must be set to the default value specified for
+  hardware that doesn’t support that property.
 
  <!-- TODO: add some events that should be emitted? This is a bit
   complicated in this case because e.g. pointerDown is only emitted
@@ -9040,46 +9104,46 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
 
-<p>When required to <dfn>dispatch a pointerUp action</dfn> with
- arguments <var>source id</var>, <var>action object</var>,
- <var>input state</var> and <var>tick duration</var> a
- <a>remote end</a> must run the following steps:
+<p>To <dfn>dispatch a pointerUp action</dfn> given <var>input
+id</var>, <var>action object</var>, <var>source</var>,
+<var>global key state</var>, <var>tick duration</var>,
+and <var>browsing context</var>:
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>pointerType</var> be equal to
   <var>action object</var>’s <code>pointerType</code> property.
 
  <li><p>Let <var>button</var> be equal to
   <var>action object</var>’s <code>button</code> property.
 
- <li><p>If the <var>input state</var>’s <code>pressed</code> property
+ <li><p>If the <var>source</var>’s <code>pressed</code> property
   does not contain <var>button</var>,
   return <a>success</a> with data <a><code>null</code></a>.
 
- <li><p>Let <var>x</var> be equal to <var>input state</var>’s
+ <li><p>Let <var>x</var> be equal to <var>source</var>’s
   <code>x</code> property.
 
- <li><p>Let <var>y</var> be equal to <var>input state</var>’s
+ <li><p>Let <var>y</var> be equal to <var>source</var>’s
   <code>y</code> property.
 
  <li><p>Remove <var>button</var> from the set corresponding
-  to <var>input state</var>’s <code>pressed</code> property, and
+  to <var>source</var>’s <code>pressed</code> property, and
   let <var>buttons</var> be the resulting value of that
   property.
 
- <li><p><a>Perform implementation-specific
-  action dispatch steps</a> equivalent to releasing the button
+ <li><p><a>Perform implementation-specific action dispatch steps</a>
+  on <var>browsing context</var> equivalent to releasing the button
   numbered <var>button</var> on the pointer of ID
-  <var>source id</var> having type <var>pointerType</var> at
-  viewport x coordinate <var>x</var>, viewport y
-  coordinate <var>y</var>, with buttons <var>buttons</var> depressed,
-  in accordance with the requirements of [[UI-EVENTS]] and
-  [[POINTER-EVENTS]].  The generated events must
-  set <code>ctrlKey</code>, <code>shiftKey</code>, <code>altKey</code>,
-  and <code>metaKey</code> from the <a>calculated global key state</a>.
-  Type specific properties for the pointer that are not
-  exposed through the WebDriver API must be set to the default value
-  specified for hardware that doesn’t support that property.
+  <var>input id</var> having type <var>pointerType</var> at viewport x
+  coordinate <var>x</var>, viewport y coordinate <var>y</var>, with
+  buttons <var>buttons</var> depressed, in accordance with the
+  requirements of [[UI-EVENTS]] and [[POINTER-EVENTS]]. The generated
+  events must set <code>ctrlKey</code>, <code>shiftKey</code>,
+  <code>altKey</code>, and <code>metaKey</code> equal to the
+  corresponding items in <var>global key state</var>. Type specific
+  properties for the pointer that are not exposed through the
+  webdriver API must be set to the default value specified for
+  hardware that doesn’t support that property.
 
   <!-- TODO: add some events that should be emitted? This is a bit
    complicated in this case because e.g. pointerDown is only emitted
@@ -9088,12 +9152,11 @@ Return <a>success</a> with data <var>action</var>.
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
 
-<p>When required to <dfn>dispatch a pointerMove action</dfn> with
- arguments <var>source id</var>, <var>action object</var>,
- <var>input state</var> and <var>tick duration</var> a
- <a>remote end</a> must run the following steps:
+<p>To <dfn>dispatch a pointerMove action</dfn> given <var>input id</var>,
+<var>action object</var>, <var>source</var>, <var>global key state</var>,
+<var>tick duration</var>, and <var>browsing context</var>:
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>x offset</var> be equal to the <code>x</code>
   property of <var>action object</var>.
 
@@ -9101,10 +9164,10 @@ Return <a>success</a> with data <var>action</var>.
   property of <var>action object</var>.
 
  <li><p>Let <var>start x</var> be equal to the <code>x</code>
-  property of <var>input state</var>.
+  property of <var>source</var>.
 
  <li><p>Let <var>start y</var> be equal to the <code>y</code>
-  property of <var>input state</var>.
+  property of <var>source</var>.
 
  <li><p>Let <var>origin</var> be equal to the <code>origin</code>
   property of <var>action object</var>.
@@ -9193,25 +9256,24 @@ Return <a>success</a> with data <var>action</var>.
   <code>azimuthAngle</code> property.
 
  <li><p><a>Perform a pointer move</a> with arguments
-  <var>source id</var>, <var>input state</var>, <var>duration</var>,
-  <var>start x</var>, <var>start y</var>, <var>x</var>, <var>y</var>,
-  <var>width</var>, <var>height</var>, <var>pressure</var>,
-  <var>tangentialPressure</var>, <var>tiltX</var>, <var>tiltY</var>,
-  <var>twist</var>, <var>altitudeAngle</var>, <var>azimuthAngle</var>.
+  <var>input id</var>, <var>source</var>, <var>global key
+  state</var>, <var>duration</var>, <var>start x</var>, <var>start
+  y</var>, <var>x</var>, <var>y</var>, <var>width</var>, <var>height</var>,
+  <var>pressure</var>, <var>tangentialPressure</var>, <var>tiltX</var>,
+  <var>tiltY</var>, <var>twist</var>, <var>altitudeAngle</var>,
+  <var>azimuthAngle</var>.
 
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
 
-<p>When required to <dfn>perform a pointer move</dfn> with
- arguments <var>source id</var>, <var>input state</var>,
- <var>duration</var>, <var>start x</var>, <var>start y</var>,
- <var>target x</var> and <var>target y</var>, <var>width</var>,
- <var>height</var>, <var>pressure</var>, <var>tangentialPressure</var>,
- <var>tiltX</var>, <var>tiltY</var>, <var>twist</var>,
- <var>altitudeAngle</var>, <var>azimuthAngle</var>, an implementation must
- run the following steps:
+<p>To <dfn>perform a pointer move</dfn> given <var>input id</var>,
+ <var>source</var>, <var>global key state</var>, <var>duration</var>,
+ <var>start x</var>, <var>start y</var>, <var>target x</var>,
+ <var>target y</var>, <var>width</var>, <var>height</var>, <var>pressure</var>,
+ <var>tangentialPressure</var>, <var>tiltX</var>, <var>tiltY</var>,
+ <var>twist</var>, <var>altitudeAngle</var>, and <var>azimuthAngle</var>:
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>time delta</var> be the time since the beginning of
   the current <a>tick</a>, measured in milliseconds on a monotonic
   clock.
@@ -9248,25 +9310,27 @@ Return <a>success</a> with data <var>action</var>.
    <li><p>Let <var>buttons</var> be equal to input
     state’s <code>buttons</code> property.
 
-   <li><p><a>Perform implementation-specific
-    action dispatch steps</a> equivalent to moving the pointer with
-    ID <var>source id</var> having type <var>pointerType</var> from
-    viewport x coordinate <var>current x</var>, viewport y
-    coordinate <var>current y</var> to viewport x coordinate <var>x</var> and
-    viewport y coordinate <var>y</var>, <var>width</var>, <var>height</var>,
+   <li><p><a>Perform implementation-specific action dispatch steps</a>
+    on <var>browsing context</var> equivalent to moving the pointer
+    with ID <var>input id</var> having type <var>pointerType</var>
+    from viewport x coordinate <var>current x</var>, viewport y
+    coordinate <var>current y</var> to viewport x
+    coordinate <var>x</var> and viewport y
+    coordinate <var>y</var>, <var>width</var>, <var>height</var>,
     <var>pressure</var>, <var>tangentialPressure</var>, <var>tiltX</var>,
     <var>tiltY</var>, <var>twist</var>, <var>altitudeAngle</var>,
     <var>azimuthAngle</var>, with
     buttons <var>buttons</var> depressed, in accordance with the
-    requirements of [[UI-EVENTS]] and [[POINTER-EVENTS]]. The
-    generated events must set <code>ctrlKey</code>, <code>shiftKey</code>,
-    <code>altKey</code>, and <code>metaKey</code> from the
-    <a>calculated global key state</a>. Type specific properties for the
-    pointer that are not exposed through the WebDriver API must be set to
-    the default value specified for hardware that doesn’t support that
-    property. In the case where the <var>pointerType</var> is "<code>pen</code>"
-    or "<code>touch</code>", and <var>buttons</var> is empty, this may
-    be a no-op. For a pointer of type "<code>mouse</code>" this will
+    requirements of [[UI-EVENTS]] and [[POINTER-EVENTS]]. The generated
+    events must set <code>ctrlKey</code>, <code>shiftKey</code>,
+    <code>altKey</code>, and <code>metaKey</code> equal to the
+    corresponding items in <var>global key state</var>.  Type specific
+    properties for the pointer that are not exposed through the
+    WebDriver API must be set to the default value specified for
+    hardware that doesn’t support that property. In the case where
+    the <var>pointerType</var> is "<code>pen</code>" or
+    "<code>touch</code>", and <var>buttons</var> is empty, this may be
+    a no-op. For a pointer of type "<code>mouse</code>" this will
     always produce events including at least
     a <code>pointerMove</code> event.
 
@@ -9303,22 +9367,21 @@ Return <a>success</a> with data <var>action</var>.
     vsync).</aside>
 
    <li><p><a>Perform a pointer move</a> with arguments
-    <var>source id</var>, <var>input state</var>, <var>duration</var>,
+    <var>input id</var>, <var>input state</var>, <var>duration</var>,
     <var>start x</var>, <var>start y</var>, <var>target x</var>,
     <var>target y</var>.
  </ol>
 
 </ol>
 
-<p>When required to <dfn>dispatch a pointerCancel action</dfn> with
- arguments <var>source id</var>, <var>action object</var>,
- <var>input state</var> and <var>tick duration</var> a
- <a>remote end</a> must run the following steps:
+<p>To <dfn>dispatch a pointerCancel action</dfn> given  <var>input id</var>,
+<var>action object</var>, <var>source</var>, <var>global key state</var>,
+<var>tick duration</var>, and <var>browsing context</var>:
 
-<ol>
- <li><p><a>Perform implementation-specific
-  action dispatch steps</a> equivalent to cancelling the any action of
-  the pointer with ID <var>source id</var> having
+<ol class="algorithm">
+ <li><p><a>Perform implementation-specific action dispatch steps</a>
+  on <var>browsing context</var> equivalent to cancelling the any
+  action of the pointer with ID <var>input id</var> having
   type <var>pointerType</var>, in accordance with the requirements of
   [[UI-EVENTS]] and [[POINTER-EVENTS]].
 
@@ -9330,12 +9393,11 @@ Return <a>success</a> with data <var>action</var>.
 <section>
 <h4>Wheel actions</h4>
 
-<p>When required to <dfn>dispatch a scroll action</dfn> with
- arguments <var>source id</var>, <var>action object</var>,
- and <var>tick duration</var> a
- <a>remote end</a> must run the following steps:
+<p>To <dfn>dispatch a scroll action</dfn> given <var>input id</var>,
+<var>action object</var>, <var>source</var>, <var>global key state</var>,
+<var>tick duration</var>, and <var>browsing context</var>:
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>x offset</var> be equal to the <code>x</code>
   property of <var>action object</var>.
 
@@ -9403,21 +9465,19 @@ Return <a>success</a> with data <var>action</var>.
  </li>
 
  <li><p><a>Perform a scroll</a> with arguments
-  <var>source id</var>, <var>duration</var>,
+  <var>input id</var>, <var>global key state</var>, <var>duration</var>,
   <var>x</var>, <var>y</var>, <var>delta x</var>, <var>delta y</var>,
   <var>0</var>, <var>0</var>.
 
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
 
-<p>When required to <dfn>perform a scroll</dfn> with
- arguments <var>source id</var>,
+<p>To <dfn>perform a scroll</dfn> given <var>input id</var>,
  <var>duration</var>, <var>x</var>, <var>y</var>,
  <var>target delta x</var>, <var>target delta y</var>,
- <var>current delta x</var> and <var>current delta y</var>,
- an implementation must run the following steps:
+ <var>current delta x</var> and <var>current delta y</var>:
 
-<ol>
+<ol class="algorithm">
  <li><p>Let <var>time delta</var> be the time since the beginning of
   the current <a>tick</a>, measured in milliseconds on a monotonic
   clock.
@@ -9448,12 +9508,15 @@ Return <a>success</a> with data <var>action</var>.
   run the following steps:
 
   <ol>
-   <li><p><a>Perform implementation-specific
-    action dispatch steps</a> equivalent to wheel scroll with
-    ID <var>source id</var> at viewport x coordinate <var>x</var>,
-    viewport y coordinate <var>y</var>, deltaX value <var>delta x</var>,
-    deltaY value <var>delta y</var>, in accordance with the
-    requirements of [[UI-EVENTS]].
+   <li><p><a>Perform implementation-specific action dispatch steps</a>
+    on <var>browsing context</var> equivalent to wheel scroll with
+    ID <var>input id</var> at viewport x coordinate <var>x</var>,
+    viewport y coordinate <var>y</var>, deltaX value <var>delta
+    x</var>, deltaY value <var>delta y</var>, in accordance with the
+    requirements of [[UI-EVENTS]]. The generated
+    events must set <code>ctrlKey</code>, <code>shiftKey</code>,
+    <code>altKey</code>, and <code>metaKey</code> equal to the
+    corresponding items in <var>global key state</var>.
 
    <li><p>Let <code>current delta x</code> property
     equal <var>delta x</var>  + <var>current delta x</var> and
@@ -9489,7 +9552,7 @@ Return <a>success</a> with data <var>action</var>.
     vsync).</aside>
 
    <li><p><a>Perform a scroll</a> with arguments
-    <var>source id</var>, <var>duration</var>,
+    <var>input id</var>, <var>duration</var>,
     <var>x</var>, <var>y</var>,
     <var>target delta x</var>, <var>target delta y</var>,
     <var>current delta x</var>, <var>current delta y</var>.
@@ -9517,10 +9580,13 @@ Return <a>success</a> with data <var>action</var>.
 
 <p>The <a>remote end steps</a> are:
 
-<ol>
+<ol class="algorithm">
+ <li><p>Let <var>input state</var> be <a>current
+ session</a>'s <a>input state</a>
+
  <li><p>Let <var>actions by tick</var> be the result of <a>trying</a>
-  to <a>extract an action sequence</a> with
-  argument <var>parameters</var>.
+  to <a>extract an action sequence</a> given <var>input state</var>,
+  and <var>parameters</var>.
 
  <li><p>If the <a>current browsing context</a> is <a>no longer
   open</a>, return <a>error</a> with <a>error code</a> <a>no such
@@ -9529,9 +9595,9 @@ Return <a>success</a> with data <var>action</var>.
  <li><p><a>Handle any user prompts</a>. If this results in
   an <a>error</a>, return that <a>error</a>.
 
- <li><p><a>Dispatch actions</a> with argument
-  <var>actions by tick</var>. If this results in an <a>error</a>
-  return that error.
+ <li><p><a>Dispatch actions</a> given <var>input state</var>,
+  <var>actions by tick</var>, and <a>current browsing context</a>. If
+  this results in an <a>error</a> return that error.
 
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
@@ -9566,20 +9632,18 @@ It also clears all the internal state of the virtual devices.
  <li><p>If the <a>current browsing context</a> is <a>no longer open</a>,
   return <a>error</a> with <a>error code</a> <a>no such window</a>.
 
- <li><p>Let <var>undo actions</var> be equal to the
-  <a>current session</a>’s <a>input cancel list</a> in reverse order.
+ <li><p>Let <var>input state</var> be <a>current
+ session</a>’s <a>input state</a>.
 
- <li><p><a>Dispatch tick actions</a> with arguments
-  <var>undo actions</var> and duration 0.
+ <li><p>Let <var>undo actions</var> be <var>input
+ state</var>’s <a>input cancel list</a> in reverse order.
 
- <li><p>Let the <a>current session</a>’s <a>input cancel list</a> be
-  an empty <a>List</a>.
+ <li><p><a>Try</a> to <a>dispatch tick actions</a> with arguments
+  <var>undo actions</var>, <code>0</code>, and <a>current browsing
+  context</a>.
 
- <li><p>Let the <a>current session</a>’s <a>input state table</a> be
-  an empty map.
-
- <li><p>Let the <a>current session</a>’s <a>active input sources</a>
-  be an empty <a>list</a>.
+ <li><p>Set the <a>current session</a>’s <a>input state</a> to
+ the result of <a>create an input state</a>.
 
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>


### PR DESCRIPTION
The main point of this change is to factor global state out of the
actions processing and dispatch algorithms, so that they can also be
used from BiDi where we don't have the same notion of a current
session, or a specific browsing context.

Along the way it turned out there were a few existing spec-internal
bugs in the way we were using the actions algorithms (e.g. calling
things with the wrong arguments), so this turned into a larger
refactor.

The biggest change is that we now don't make a distinction between an
input source and the state of the input source, which means we don't
have to take care to use the state object instead of the source
itself.

In addition, the list of active input sources is removed in favour of
just having a single input state map with one entry per active source.