### PR TITLE
Remove Andreas Tolfsen from the list of code owners.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*	ato@sny.no @shs96c @AutomatedTester @jgraham
+*	@shs96c @AutomatedTester @jgraham


### PR DESCRIPTION
Andreas didn't contribute nor reviewed PRs for WebDriver
classic for some years. To not get him listed as reviewer
for newly created PRs it would be good to get him removed
from the list of owners.

Andreas, thanks a lot for all the work that you did for
the project!

@andreastt if you could reply and let us know if that PR is fine with you, we would appreciate. Thanks a lot.