### PR TITLE
Limiting locator validation steps to endpoint node

### DIFF
--- a/index.html
+++ b/index.html
@@ -4709,7 +4709,8 @@ session.execute("arguments[0].remove()", [body]);
 </code></pre>
 </aside>
 
-<p>The <a>remote end steps</a> are:
+<p>The <a>remote end steps</a> in 
+<a data-lt="endpoint node">endpoint nodes</a> are:
 
 <ol>
  <li><p>Let <var>location strategy</var> be the result
@@ -4761,7 +4762,8 @@ session.execute("arguments[0].remove()", [body]);
  </tr>
 </table>
 
-<p>The <a>remote end steps</a> are:
+<p>The <a>remote end steps</a> in 
+  <a data-lt="endpoint node">endpoint nodes</a> are:
 
 <ol>
  <li><p>Let <var>location strategy</var> be the result
@@ -4808,7 +4810,8 @@ session.execute("arguments[0].remove()", [body]);
  </tr>
 </table>
 
-<p>The <a>remote end steps</a> are:
+<p>The <a>remote end steps</a> in 
+  <a data-lt="endpoint node">endpoint nodes</a> are:
 
 <ol>
  <li><p>Let <var>location strategy</var> be the result
@@ -4858,7 +4861,8 @@ session.execute("arguments[0].remove()", [body]);
  </tr>
 </table>
 
-<p>The <a>remote end steps</a> are:
+<p>The <a>remote end steps</a> in 
+  <a data-lt="endpoint node">endpoint nodes</a> are:
 
 <ol>
  <li><p>Let <var>location strategy</var> be the result
@@ -4903,7 +4907,8 @@ session.execute("arguments[0].remove()", [body]);
   </tr>
 </table>
 
-<p>The <a>remote end steps</a> are:
+<p>The <a>remote end steps</a> in 
+  <a data-lt="endpoint node">endpoint nodes</a> are:
 
 <ol>
   <li><p>Let <var>location strategy</var> be the result
@@ -4953,7 +4958,8 @@ session.execute("arguments[0].remove()", [body]);
   </tr>
 </table>
 
-<p>The <a>remote end steps</a> are:
+<p>The <a>remote end steps</a> in 
+  <a data-lt="endpoint node">endpoint nodes</a> are:
 
 <ol>
   <li><p>Let <var>location strategy</var> be the result


### PR DESCRIPTION
Context for this PR can be seen at #1649

The approach this PR takes is to limit the execution environment for the steps to validate a locator to only the endpoint node. Selenium Grid is an intermediary node and it essentially sends back and forth WebDriver commands. Blocking non-W3C locator strategies limits folks to use different types of endpoint nodes (such as cloud providers or Appium servers).

Another approach could be to indicate that the steps are optional for intermediary nodes but mandatory for endpoint nodes.

Looking forward to your feedback, 

@shs96c @AutomatedTester @whimboo @titusfortner @jgraham 