### PR TITLE
Require pointerMove and wheel coordinates to be integers

### DIFF
--- a/index.html
+++ b/index.html
@@ -8136,9 +8136,8 @@ to <var>origin</var>.
 Let <var>x</var> be the result of <a>getting the property</a>
 <code>x</code> from <var>action item</var>.
 
-<li><p>
-If <var>x</var> is not <a>undefined</a> and is not an <a>Integer</a>,
-return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+<li><p> If <var>x</var> is not an <a>Integer</a>, return <a>error</a>
+with <a>error code</a> <a>invalid argument</a>.
 
 <li><p>
 Set the <code>x</code> property of <var>action</var> to <var>x</var>.
@@ -8147,9 +8146,8 @@ Set the <code>x</code> property of <var>action</var> to <var>x</var>.
 Let <var>y</var> be the result of <a>getting the property</a>
 <code>y</code> from <var>action item</var>.
 
-<li><p>
-If <var>y</var> is not <a>undefined</a> and is not an <a>Integer</a>,
-return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+<li><p> If <var>y</var> is not an <a>Integer</a>, return <a>error</a>
+with <a>error code</a> <a>invalid argument</a>.
 
 <li><p>
 Set the <code>y</code> property of <var>action</var> to <var>y</var>.
@@ -8158,8 +8156,7 @@ Set the <code>y</code> property of <var>action</var> to <var>y</var>.
 Let <var>deltaX</var> be the result of <a>getting the property</a>
 <code>deltaX</code> from <var>action item</var>.
 
-<li><p>
-If <var>deltaX</var> is not <a>undefined</a> and is not an <a>Integer</a>,
+<li><p> If <var>deltaX</var> is not an <a>Integer</a>,
 return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
 <li><p>
@@ -8169,8 +8166,7 @@ Set the <code>deltaX</code> property of <var>action</var> to <var>deltaX</var>.
 Let <var>deltaY</var> be the result of <a>getting the property</a>
 <code>deltaY</code> from <var>action item</var>.
 
-<li><p>
-If <var>deltaY</var> is not <a>undefined</a> and is not an <a>Integer</a>,
+<li><p> If <var>deltaY</var> is not an <a>Integer</a>,
 return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
 <li><p>
@@ -8358,19 +8354,18 @@ item</var>, and <var>action</var>:</p>
   of <a>getting the property</a> <code>x</code>
   from <var>action item</var>.
 
- <li><p>If <var>x</var> is not <a>undefined</a> and is not an <a>Integer</a>,
-  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+ <li><p>If <var>x</var> is not an <a>Integer</a>, return <a>error</a>
+  with <a>error code</a> <a>invalid argument</a>.
 
- <li><p>Set the <code>x</code> property
-  of <var>action</var> to <var>x</var>.
+ <li><p>Set the <code>x</code> property of <var>action</var>
+  to <var>x</var>.
 
  <li><p>Let <var>y</var> be the result
   of <a>getting the property</a> <code>y</code>
   from <var>action item</var>.
 
- <li><p>If <var>y</var> is not <a>undefined</a>
-  and is not an <a>Integer</a>,
-  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+ <li><p>If <var>y</var> is not an <a>Integer</a>, return <a>error</a>
+  with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>Set the <code>y</code> property of <var>action</var>
   to <var>y</var>.


### PR DESCRIPTION
Prevously we allowed these properties to be undefined, and then later
tried to do computations on the values. That doesn't work; they either
need to have an integer default value or require that a value is
supplied.

Since implementations currently seem to raise an exception for these
values being undefined, the easiest approach is to require that they
are supplied, so that's what's implemented here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1676.html" title="Last updated on Jul 25, 2022, 2:28 PM UTC (b5e4651)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1676/e3b112f...b5e4651.html" title="Last updated on Jul 25, 2022, 2:28 PM UTC (b5e4651)">Diff</a>