### PR TITLE
Scroll into view: scroll position `end` vs. `center`

### DIFF
--- a/index.html
+++ b/index.html
@@ -4146,7 +4146,7 @@ is given by:
 
   <dl>
    <dt><a>Logical scroll position "<code>block</code>"</a>
-   <dd>"<code>end</code>"
+   <dd>"<code>center</code>"
 
    <dt><a>Logical scroll position "<code>inline</code>"</a>
    <dd>"<code>nearest</code>"


### PR DESCRIPTION
The spec currently says that before interacting with an element, it needs to be scrolled into view:

> To scroll into view an [element](https://w3c.github.io/webdriver/#dfn-elements) perform the following steps only if the element is not already [in view](https://w3c.github.io/webdriver/#dfn-in-view):
> 
> Let options be the following [ScrollIntoViewOptions](https://w3c.github.io/webdriver/#dfn-scrollintoviewoptions):
> 
> [Logical scroll position "block"](https://w3c.github.io/webdriver/#dfn-logical-scroll-position-block)
"end"
> [Logical scroll position "inline"](https://w3c.github.io/webdriver/#dfn-logical-scroll-position-inline)
"nearest"

I would like to propose to change the position block from `end` to `center` given that many applications have `fixed` positioned elements at the bottom the screen, e.g.

- a footer element 
- a cookie compliance model (e.g. https://amazone.de/de-de/)
- some sort of check out modal (e.g. https://coffee-cart.netlify.app/)

I'ld argue scrolling the element into the center of the viewpoint has higher chances that there are less elements that could be blocking the interaction causing `element click intercepted` errors.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christian-bromann/webdriver/pull/1680.html" title="Last updated on Aug 25, 2022, 7:45 AM UTC (ebf083c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1680/e3b112f...christian-bromann:ebf083c.html" title="Last updated on Aug 25, 2022, 7:45 AM UTC (ebf083c)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1680)
<!-- Reviewable:end -->
