### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*	@shs96c @AutomatedTester @jgraham


### PR DESCRIPTION
Align review policy with WebDriver-BiDi where anyone with write access can perform the change review (but substantive changes are still subject to the usual WG processes).