### PR TITLE
Fix setting cursor position in send keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -6220,9 +6220,6 @@ state</var>, <var>input id</var>, <var>source</var>,
 
    <li><p>If <var>element</var> is not <a>keyboard-interactable</a>,
     return <a>error</a> with <a>error code</a> <a>element not interactable</a>.
-
-   <li><p>If <var>element</var> is not the <a>active element</a> run
-    the <a>focusing steps</a> for the <var>element</var>.
   </ol>
 
  <li><p>Run the substeps of the first matching condition:
@@ -6230,6 +6227,10 @@ state</var>, <var>input id</var>, <var>source</var>,
    <dt><var>file</var> is true
    <dd>
     <ol>
+     <li><p>If the <a>current session</a>’s <a>strict file interactability</a> is true,
+     and <var>element</var> is not the <a>active element</a> run the <a>focusing
+     steps</a> for <var>element</var>.
+
      <li><p>Let <var>files</var> be the result of splitting <var>text</var>
       on the newline (<code>\n</code>) character.
 
@@ -6275,6 +6276,9 @@ state</var>, <var>input id</var>, <var>source</var>,
       an <a>error</a> with <a>error code</a> <a>element not
       interactable</a>.
 
+     <li><p>If <var>element</var> is not the <a>active element</a> run the
+     <a>focusing steps</a> for <var>element</var>.
+
      <li><p><a>Set a property</a> <code>value</code> to <var>text</var>
       on <var>element</var>.
 
@@ -6287,18 +6291,37 @@ state</var>, <var>input id</var>, <var>source</var>,
    </dd>
 
    <dt><var><a>element</a></var> is <a>content editable</a>
-    <dd>If <var><a>element</a></var> does not currently have focus,
-      set the text insertion caret after any child content.
+    <dd>
+      <ol>
+        <li><p>If <var>element</var> is not the <a>active element</a>:
+          <ol>
+           <li><p>Run the <a>focusing steps</a> for <var>element</var>.
+
+            <li><p>Let <var>child count</var> be the [=map/size=]
+            of <var>element</var>'s [=tree/children=].
+
+            <li><p>Let <var>range</var> be a <a>live range</a> with [=range/start=]
+            and [=range/end=] (<var>element</var>, <var>child count</var>).
+
+            <li><p>Set the <a>active document</a>'s <a>selection</a>
+            to <var>range</var>.
+          </ol>
+      </ol>
+    </dd>
     <dt>Otherwise
     <dd>
      <ol>
-       <li><p>If <var>element</var> does not currently have focus,
-        let <var>current text length</var> be the
-        [=string/length=] of <var><a>element</a></var>’s <a>API value</a>.
+       <li><p>If <var>element</var> is not the <a>active element</a>:
+         <ol>
+           <li><p>Let <var>current text length</var> be the
+           [=string/length=] of <var><a>element</a></var>’s <a>API value</a>.
 
-      <li><p>Set the text insertion caret using <a>set selection range</a>
-       using <var>current text length</var> for both the <code>start</code>
-       and <code>end</code> parameters.
+           <li><p>Run the <a>focusing steps</a> for <var>element</var>.
+
+           <li><p>Set the text insertion caret using <a>set selection range</a>
+           using <var>current text length</var> for both the <code>start</code>
+           and <code>end</code> parameters.
+         </ol>
      </ol>
     </dd>
   </dl>
@@ -11155,6 +11178,13 @@ to automatically sort each list alphabetically.
     <!-- visibility state --> <li><dfn>Visibility state</dfn> being the <a href="https://www.w3.org/TR/page-visibility/#visibility-states-and-the-visibilitystate-enum"><code>visibilityState</code></a> attribute on <a>Document</a>
     <!-- visibility visible --> <li><dfn data-lt="visibility visible"><a href="https://www.w3.org/TR/page-visibility/#dom-visibilitystate-visible">Visibility state <code>visible</code></a></dfn>
    </ul>
+
+ <dd><p>The following attributes are defined
+  in the Selection API specification: [[SELECTION-API]]
+  <ul>
+   <!-- selection --> <li><dfn data-lt=selection><a href=https://w3c.github.io/selection-api/#dfn-selection>selection</a></dfn>
+  </ul>
+
 
  <dt>Selenium
  <dd>The following functions are defined within


### PR DESCRIPTION
I believe the expected behaviour is:
* If the target already has focus, do nothing
* Otherwise, if the target is focusable, set the selection to the last editable point in the element.

Previously the spec was unconditionally focusing the target element (execpting some cases with file uploads), and therefore the letter of the spec was to never move the caret.

This change updates it to only focus the target if it's not already the active element, and then move the caret to the end.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1686.html" title="Last updated on Apr 1, 2026, 8:07 AM UTC (8857c92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1686/fa23c93...8857c92.html" title="Last updated on Apr 1, 2026, 8:07 AM UTC (8857c92)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1686)
<!-- Reviewable:end -->
