### PR TITLE
Extend `get a node` and `get or create a node reference` algorithms

### DIFF
--- a/index.html
+++ b/index.html
@@ -4072,14 +4072,17 @@ and a <a>node id map</a>.
 <p>A <dfn>node id map</dfn> is weak map between nodes and their
 corresponding <a>WebDriver node id</a>.
 
-<p>To <dfn>get a node</dfn> given <var>session</var>
-and <var>reference</var>:
+<p>To <dfn>get a node</dfn> given <var>session</var>, <var>reference</var> and
+optional argument <var>browsing context</var>:
 <ol>
+  <li><p>If <var>browsing context</var> is not provided, let
+  <var>browsing context</var> be the <a>current browsing context</a>.
+
   <li>Let <var>browsing context group node map</var>
   be <var>session</var>'s <a>browsing context group node map</a>.
 
-  <li>Let <var>browsing context group</var> be <a>current browsing
-  context</a>'s <a>browsing context group</a>.
+  <li>Let <var>browsing context group</var> be <var>browsing context</var>'s
+  <a>browsing context group</a>.
 
   <li>If <var>browsing context group node map</var> does not
   contain <var>browsing context group</var>, return null.
@@ -4094,14 +4097,17 @@ and <var>reference</var>:
   <li>Return <var>node</var>.
 </ol>
 
-<p>To <dfn>get or create a node reference</dfn>
-given <var>session</var> and <var>node</var>:
+<p>To <dfn>get or create a node reference</dfn> given <var>session</var>,
+<var>node</var> and optional argument <var>browsing context</var>:
 <ol>
+  <li><p>If <var>browsing context</var> is not provided, let
+  <var>browsing context</var> be the <a>current browsing context</a>.
+
   <li>Let <var>browsing context group node map</var>
   be <var>session</var>'s <a>browsing context group node map</a>.
 
-  <li>Let <var>browsing context group</var> be <a>current browsing
-  context</a>'s <a>browsing context group</a>.
+  <li>Let <var>browsing context group</var> be <var>browsing context</var>'s
+  <a>browsing context group</a>.
 
   <li>If <var>browsing context group node map</var> does not
   contain <var>browsing context group</var>, set <var>browsing context


### PR DESCRIPTION
To implement interoperability between WebDriver Classic's and WebDriver BiDi's references, the `browsing context` should be passed to some algorithms.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sadym-chromium/webdriver/pull/1703.html" title="Last updated on Dec 19, 2022, 4:32 PM UTC (ae90735)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1703/6c3b67a...sadym-chromium:ae90735.html" title="Last updated on Dec 19, 2022, 4:32 PM UTC (ae90735)">Diff</a>