### PR TITLE
Fix returning stale element reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -4171,7 +4171,7 @@ context</var>, and <var>reference</var> if the following steps return true:
      code</a> <a>no such element</a>.
    </ol>
 
-  <li>Return <a>success</a> with <var>node</var>.
+  <li>Return <a>success</a> with data <var>node</var>.
 </ol>
 
 <p>To <dfn>get or create a web element reference</dfn>
@@ -4462,7 +4462,7 @@ is given by:
        code</a> <a>no such shadow root</a>.
      </ol>
 
-   <li>Return <a>success</a> with <var>node</var>.
+   <li>Return <a>success</a> with data <var>node</var>.
  </ol>
 
  <p>To <dfn>get or create a shadow root reference</dfn>

--- a/index.html
+++ b/index.html
@@ -4075,7 +4075,7 @@ corresponding <a>WebDriver node id</a>.
 <p>A WebDriver <a>session</a> has a <dfn>navigable seen nodes map</dfn>
 which is a weak map between a [=navigable=] and a set.
 
-<p>To <dfn>get a node</dfn> given <var>session</var>, 
+<p>To <dfn>get a node</dfn> given <var>session</var>,
 <var>browsing context</var>, and <var>reference</var>:
 <ol class="algorithm">
   <li>Let <var>browsing context group node map</var>
@@ -4090,7 +4090,7 @@ which is a weak map between a [=navigable=] and a set.
   <li>Let <var>node id map</var> be <var>browsing context group node
   map</var>[<var>browsing context group</var>].
 
-  <li>Let <a>node</a> be the entry in <var>node id map</var> whose
+  <li>Let <var>node</var> be the entry in <var>node id map</var> whose
   value is <var>reference</var>, if such an entry exists, or null
   otherwise.
 
@@ -4156,18 +4156,20 @@ context</var>, and <var>reference</var> if the following steps return true:
   <li>Let <var>node</var> be <a>get a node</a> with <a>current session</a>,
   <a>current browsing context</a>, and <var>reference</var>.
 
-   <li>If <var>node</var> is null, or <var>node</var> does not implement
-   {{Element}}, or <var>node</var> <a>is stale</a>:
-     <ol>
-       <li><p>If <var>node</var> implements {{Element}} and <a>node
-       reference is known</a> with <a>current session</a>, <a>current
-       browsing context</a>, and <var>reference</var>,
-       return <a>error</a> with <a>error code</a> <a>stale element
-       reference</a>.
+  <li>If <var>node</var> is null, or <var>node</var> does not
+  implement {{Element}} return <a>error</a> with <a>error
+  code</a> <a>no such element</a>.
 
-       <p>Otherwise return <a>error</a> with <a>error
-       code</a> <a>no such element</a>.
-     </ol>
+  <li>If <var>node</var> <a>is stale</a>:
+   <ol>
+     <li><p>If <a>node reference is known</a> with <a>current
+     session</a>, <a>current browsing context</a>,
+     and <var>reference</var>, return <a>error</a> with <a>error
+     code</a> <a>stale element reference</a>.
+
+     <p>Otherwise return <a>error</a> with <a>error
+     code</a> <a>no such element</a>.
+   </ol>
 
   <li>Return <a>success</a> with <var>node</var>.
 </ol>
@@ -4445,14 +4447,16 @@ is given by:
    <li>Let <var>node</var> be <a>get a node</a> with <a>current session</a>,
    <a>current browsing context</a>, and <var>reference</var>.
 
-   <li>If <a>node</a> is null, or <a>node</a> does not implement
-   {{ShadowRoot}}, or <var>node</var> <a>is detached</a>:
+   <li>If <var>node</var> is null, or <var>node</var> does not
+   implement {{ShadowRoot}}, return <a>error</a> with <a>error
+   code</a> <a>no such shadow root</a>.
+
+   <li>If <var>node</var> <a>is detached</a>:
      <ol>
-       <li><p>If <var>node</var> implements {{ShadowRoot}}, and <a>node
-       reference is known</a> with <a>current session</a>, <a>current
-       browsing context</a>, and <var>reference</var>,
-       return <a>error</a> with <a>error code</a> <a>detached shadow
-       root</a>.
+       <li><p>If <a>node reference is known</a> with <a>current
+       session</a>, <a>current browsing context</a>,
+       and <var>reference</var>, return <a>error</a> with <a>error
+       code</a> <a>detached shadow root</a>.
 
        <p>Otherwise return <a>error</a> with <a>error
        code</a> <a>no such shadow root</a>.

--- a/index.html
+++ b/index.html
@@ -4156,7 +4156,7 @@ context</var>, and <var>reference</var> if the following steps return true:
   <li>Let <var>node</var> be <a>get a node</a> with <a>current session</a>,
   <a>current browsing context</a>, and <var>reference</var>.
 
-   <li>If <a>node</a> is null, or <a>node</a> does not implement
+   <li>If <var>node</var> is null, or <var>node</var> does not implement
    {{Element}}, or <var>node</var> <a>is stale</a>:
      <ol>
        <li>If <a>node reference is known</a> with <a>current

--- a/index.html
+++ b/index.html
@@ -4072,13 +4072,16 @@ and a <a>node id map</a>.
 <p>A <dfn>node id map</dfn> is weak map between nodes and their
 corresponding <a>WebDriver node id</a>.
 
+<p>A WebDriver <a>session</a> has a <dfn>navigable seen nodes map</dfn>
+which is a weak map between a [=navigable=] and a set.
+
 <p>To <dfn>get a node</dfn> given <var>session</var>
-and <var>reference</var>:
-<ol>
+<var>browsing context</var>, and <var>reference</var>:
+<ol class="algorithm">
   <li>Let <var>browsing context group node map</var>
   be <var>session</var>'s <a>browsing context group node map</a>.
 
-  <li>Let <var>browsing context group</var> be <a>current browsing
+  <li>Let <var>browsing context group</var> be <a>browsing
   context</a>'s <a>browsing context group</a>.
 
   <li>If <var>browsing context group node map</var> does not
@@ -4095,13 +4098,13 @@ and <var>reference</var>:
 </ol>
 
 <p>To <dfn>get or create a node reference</dfn>
-given <var>session</var> and <var>node</var>:
-<ol>
+given <var>session</var>, <var>browsing context</var>, and <var>node</var>:
+<ol class="algorithm">
   <li>Let <var>browsing context group node map</var>
   be <var>session</var>'s <a>browsing context group node map</a>.
 
-  <li>Let <var>browsing context group</var> be <a>current browsing
-  context</a>'s <a>browsing context group</a>.
+  <li>Let <var>browsing context group</var> be <var>browsing
+  context</var>'s <a>browsing context group</a>.
 
   <li>If <var>browsing context group node map</var> does not
   contain <var>browsing context group</var>, set <var>browsing context
@@ -4110,25 +4113,59 @@ given <var>session</var> and <var>node</var>:
   <li>Let <var>node id map</var> be<var>browsing context group node
   map</var>[<var>browsing context group</var>].
 
-  <li>If <var>node id map</var> does not contain <var>node</var>,
-  set <var>node id map</var>[<var>node</var>] to a new globally
-  unique string.
+  <li>If <var>node id map</var> does not contain <var>node</var>:
 
+    <ol>
+      <li>Let <var>node id</var> be a new globally unique string.
+
+      <li>Set <var>node id map</var>[<var>node</var>] to <var>node id</var>.
+
+      <li>Let <var>navigable</var> be <var>browsing
+      context</var>'s <a>active document</a>'s <a>node navigable</a>.
+
+      <li>Let <var>navigable seen nodes map</var>
+      be <var>session</var>'s <a>navigable seen nodes map</a>.
+
+      <li>If <var>navigable seen nodes map</var> does not
+      contain <var>navigable</var>, set <var>navigable seen nodes
+      map</var>[<var>navigable</var>] to an empty set.
+
+      <li>Append <var>node id</var> to <var>navigable seen nodes
+      map</var>[<var>navigable</var>].
+    </ol>
  <li><p>Return <var>node id map</var>[<var>node</var>].
 </ol>
 
+<p>A <dfn>node reference is known</dfn> given <var>session</var>, <var>browsing
+context</var>, and <var>reference</var> if the following steps return true:
+<ol class="algorithm">
+  <li>Let <var>navigable</var> be <var>browsing
+  context</var>'s <a>active document</a>'s <a>node navigable</a>.
+
+  <li>Let <var>navigable seen nodes map</var>
+  be <var>session</var>'s <a>navigable seen nodes map</a>.
+
+  <li>If <var>navigable seen nodes map</var>
+  [=map/contains=] <var>navigable</var> and <var>navigable seen nodes
+  map</var>[<var>navigable</var>] [=set/contains=] <var>reference</var>,
+  return true, otherwise return false.
+</ol>
+
 <p>To <dfn>get a known element</dfn> given <var>reference</var>:
-<ol>
-  <li>Let <var>node</var> be <a>get a node</a> with <a>current session</a>
-  and <var>reference</var>.
+<ol class="algorithm">
+  <li>Let <var>node</var> be <a>get a node</a> with <a>current session</a>,
+  <a>current browsing context</a>, and <var>reference</var>.
 
-  <li>If <a>node</a> is null, or <a>node</a> does not implement {{Element}},
-  or if <a>node</a>'s [=Node/node document=] is not <a>current browsing
-  context</a>'s <a>active document</a>, return <a>error</a>
-  with <a>error code</a> <a>no such element</a>.
-
-  <li>If <var>node</var> <a>is stale</a>, return <a>error</a>
-  with <a>error code</a> <a>stale element reference</a>.
+   <li>If <a>node</a> is null, or <a>node</a> does not implement
+   {{Element}}, or <var>node</var> <a>is stale</a>:
+     <ol>
+       <li>If <a>node reference is known</a> with <a>current
+       session</a>, <a>current browsing context</a>,
+       and <var>reference</var>, return <a>error</a> with <a>error
+       code</a> <a>stale element reference</a>. Otherwise
+       return <a>error</a> with <a>error code</a> <a>no such shadow
+       root</a>.
+     </ol>
 
   <li>Return <a>success</a> with <var>node</var>.
 </ol>
@@ -4140,7 +4177,8 @@ given <var>session</var> and <var>node</var>:
   <li>Assert: <var>element</var> implements {{Element}}.
 
   <li>Return the result of <a>trying</a> to <a>get or create a node
-  reference</a> given <a>current session</a> and <var>element</var>.
+  reference</a> given <a>current session</a>, <a>current browsing
+  context</a>, and <var>element</var>.
 </ol>
 
 <p>The <dfn>web element reference object</dfn> for <var>element</var>
@@ -4400,20 +4438,23 @@ is given by:
 
  <p>To <dfn>get a known shadow root</dfn> given <var>session</var>
  and <var>reference</var>:
- <ol>
-   <li>Let <var>node</var> be <a>get a node</a> with <a>current session</a>
-   and <var>reference</var>.
 
-   <li>If <a>node</a> is null, or <a>node</a> does not implement {{ShadowRoot}},
-   or if <a>node</a>'s [=Node/node document=] is not <a>current browsing
-   context</a>'s <a>active document</a>, return <a>error</a>
-   with <a>error code</a> <a>no such shadow root</a>.
+ <ol class="algorithm">
+   <li>Let <var>node</var> be <a>get a node</a> with <a>current session</a>,
+   <a>current browsing context</a>, and <var>reference</var>.
 
-   <li>If <var>shadow</var> <a>is detached</a>, return
-   <a>error</a> with <a>error code</a>
-   <a>detached shadow root</a>.
+   <li>If <a>node</a> is null, or <a>node</a> does not implement
+   {{ShadowRoot}}, or <var>node</var> <a>is detached</a>:
+     <ol>
+       <li>If <a>node reference is known</a> with <a>current
+       session</a>, <a>current browsing context</a>,
+       and <var>reference</var>, return <a>error</a> with <a>error
+       code</a> <a>detached shadow root</a>. Otherwise
+       return <a>error</a> with <a>error code</a> <a>no such shadow
+       root</a>.
+     </ol>
 
-   <li>Return <a>success</a> with <var>shadow</var>.
+   <li>Return <a>success</a> with <var>node</var>.
  </ol>
 
  <p>To <dfn>get or create a shadow root reference</dfn>
@@ -4423,7 +4464,8 @@ is given by:
    <li>Assert: <var>element</var> implements {{ShadowRoot}}.
 
    <li>Return the result of <a>trying</a> to <a>get or create a node
-   reference</a> given <a>current session</a> and <var>element</var>.
+   reference</a> given <a>current session</a>, <a>current browsing
+   context</a>, and <var>element</var>.
  </ol>
 
  <p>The <dfn>shadow root reference object</dfn> for <var>shadow
@@ -10942,7 +10984,6 @@ to automatically sort each list alphabetically.
    <!-- Active browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#nav-bc>active browsing context</a></dfn>
    <!-- Active document --> <li><dfn><a href=https://html.spec.whatwg.org/#active-document>active document</a></dfn>
    <!-- Active element --> <li><dfn>Active element</dfn> being the <a href=https://html.spec.whatwg.org/#dom-document-activeelement><code>activeElement</code></a> attribute on <a href=https://html.spec.whatwg.org/#document><code>Document</code></a>
-   <!-- Active window --> <li><dfn><a href=https://html.spec.whatwg.org/#nav-window>Active window</a></dfn>
    <!-- Associated window --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-document-window>Associated window</a></dfn>
    <!-- Boolean attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#boolean-attribute>Boolean attribute</a></dfn>
    <!-- Browsing context --> <li><dfn data-lt="browsing contexts"><a href=https://html.spec.whatwg.org/#browsing-context>Browsing context</a></dfn>

--- a/index.html
+++ b/index.html
@@ -4159,11 +4159,14 @@ context</var>, and <var>reference</var> if the following steps return true:
    <li>If <var>node</var> is null, or <var>node</var> does not implement
    {{Element}}, or <var>node</var> <a>is stale</a>:
      <ol>
-       <li>If <a>node reference is known</a> with <a>current
-       session</a>, <a>current browsing context</a>,
-       and <var>reference</var>, return <a>error</a> with <a>error
-       code</a> <a>stale element reference</a>. Otherwise
-       return <a>error</a> with <a>error code</a> <a>no such element</a>.
+       <li><p>If <var>node</var> implements {{Element}} and <a>node
+       reference is known</a> with <a>current session</a>, <a>current
+       browsing context</a>, and <var>reference</var>,
+       return <a>error</a> with <a>error code</a> <a>stale element
+       reference</a>.
+
+       <p>Otherwise return <a>error</a> with <a>error
+       code</a> <a>no such element</a>.
      </ol>
 
   <li>Return <a>success</a> with <var>node</var>.
@@ -4445,12 +4448,14 @@ is given by:
    <li>If <a>node</a> is null, or <a>node</a> does not implement
    {{ShadowRoot}}, or <var>node</var> <a>is detached</a>:
      <ol>
-       <li>If <a>node reference is known</a> with <a>current
-       session</a>, <a>current browsing context</a>,
-       and <var>reference</var>, return <a>error</a> with <a>error
-       code</a> <a>detached shadow root</a>. Otherwise
-       return <a>error</a> with <a>error code</a> <a>no such shadow
+       <li><p>If <var>node</var> implements {{ShadowRoot}}, and <a>node
+       reference is known</a> with <a>current session</a>, <a>current
+       browsing context</a>, and <var>reference</var>,
+       return <a>error</a> with <a>error code</a> <a>detached shadow
        root</a>.
+
+       <p>Otherwise return <a>error</a> with <a>error
+       code</a> <a>no such shadow root</a>.
      </ol>
 
    <li>Return <a>success</a> with <var>node</var>.

--- a/index.html
+++ b/index.html
@@ -4075,14 +4075,14 @@ corresponding <a>WebDriver node id</a>.
 <p>A WebDriver <a>session</a> has a <dfn>navigable seen nodes map</dfn>
 which is a weak map between a [=navigable=] and a set.
 
-<p>To <dfn>get a node</dfn> given <var>session</var>
+<p>To <dfn>get a node</dfn> given <var>session</var>, 
 <var>browsing context</var>, and <var>reference</var>:
 <ol class="algorithm">
   <li>Let <var>browsing context group node map</var>
   be <var>session</var>'s <a>browsing context group node map</a>.
 
-  <li>Let <var>browsing context group</var> be <a>browsing
-  context</a>'s <a>browsing context group</a>.
+  <li>Let <var>browsing context group</var> be <var>browsing
+  context</var>'s <a>browsing context group</a>.
 
   <li>If <var>browsing context group node map</var> does not
   contain <var>browsing context group</var>, return null.
@@ -4110,7 +4110,7 @@ given <var>session</var>, <var>browsing context</var>, and <var>node</var>:
   contain <var>browsing context group</var>, set <var>browsing context
   group node map</var>[<var>browsing context group</var>] to a new weak map.
 
-  <li>Let <var>node id map</var> be<var>browsing context group node
+  <li>Let <var>node id map</var> be <var>browsing context group node
   map</var>[<var>browsing context group</var>].
 
   <li>If <var>node id map</var> does not contain <var>node</var>:
@@ -4163,8 +4163,7 @@ context</var>, and <var>reference</var> if the following steps return true:
        session</a>, <a>current browsing context</a>,
        and <var>reference</var>, return <a>error</a> with <a>error
        code</a> <a>stale element reference</a>. Otherwise
-       return <a>error</a> with <a>error code</a> <a>no such shadow
-       root</a>.
+       return <a>error</a> with <a>error code</a> <a>no such element</a>.
      </ol>
 
   <li>Return <a>success</a> with <var>node</var>.


### PR DESCRIPTION
If we've previously seen an element in the current window, but it was GC'd we should return "stale element reference". To support this, add a set of seen node ids to each Window, so we can check if the element is stale.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1707.html" title="Last updated on Jan 6, 2023, 11:35 AM UTC (e30204d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1707/6c3b67a...e30204d.html" title="Last updated on Jan 6, 2023, 11:35 AM UTC (e30204d)">Diff</a>