### PR TITLE
Replace misleading term

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,7 +349,7 @@ In all other cases it must be true.
  <dfn class="export">success</dfn> or <dfn class="export">error</dfn>.
  A <a>success</a> value has an associated <var>data</var> field
  which encapsulates the value returned,
- whereas an <a>error</a> response has an associated <a>error code</a>.
+ whereas an <a>error</a> value has an associated <a>error code</a>.
 
 <p>When calling a fallible algorithm,
  the construct “Let <var>result</var> be the result


### PR DESCRIPTION
This specification relies on the term "response" as defined by the Fetch standard. The "error" type which is returned by fallible algorithms does not qualify as such a response. This makes the use of the phrase "error response" to define the "error" type somewhat confusing.

Replace "error response" with the more generic "error value" to avoid insinuating a non-existent relationship.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver/pull/1710.html" title="Last updated on Jan 3, 2023, 10:49 PM UTC (7c743be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1710/6c3b67a...bocoup:7c743be.html" title="Last updated on Jan 3, 2023, 10:49 PM UTC (7c743be)">Diff</a>