### PR TITLE
Fix detached check for "get a known shadow root" step

### DIFF
--- a/index.html
+++ b/index.html
@@ -4459,7 +4459,7 @@ is given by:
   <!-- Since we already checked for known references, null here means that
   the object was GC'd -->
 
-  <li>If <var>node</var> is null or <var>node</var> <a>is stale</a> return
+  <li>If <var>node</var> is null or <var>node</var> <a>is detached</a> return
   <a>error</a> with <a>error code</a> <a>detached shadow root</a>.
 
   <li>Return <a>success</a> with data <var>node</var>.


### PR DESCRIPTION
Regression from #1712.

Edit: The issue here is that by copying and pasting in the other PR I accidentally used the term `is stale` instead of `is detached` for detached checks when deserializing ShadowRoot references.

@jgraham can you please review?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1714.html" title="Last updated on Jan 19, 2023, 12:26 PM UTC (39c13da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1714/80b6d5d...39c13da.html" title="Last updated on Jan 19, 2023, 12:26 PM UTC (39c13da)">Diff</a>