### PR TITLE
Fix typos in algorithm for Element Send Keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -6145,7 +6145,7 @@ given <var>input state</var>, <var>input id</var>, <var>source</var>,
    with the subtype property changed to "<code>keyUp</code>".
 
    <li><p>Let <var>actions</var> be the list «<var>keydown
-   action</var>, </var>keyup action</var>»
+   action</var>, <var>keyup action</var>».
 
    <li><p><a>Dispatch a list of actions</a> with <var>input
    state</var>, <var>actions</var>, <a>current browsing


### PR DESCRIPTION
Correct the markup so the build system recognizes the reference to the variable named "keyup action" and add a period to end the statement.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver/pull/1721.html" title="Last updated on Mar 2, 2023, 3:20 AM UTC (3dd448b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1721/883ea38...bocoup:3dd448b.html" title="Last updated on Mar 2, 2023, 3:20 AM UTC (3dd448b)">Diff</a>