### PR TITLE
Fix error in "get a known shadow root" algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -4446,7 +4446,7 @@ is given by:
  <ol class="algorithm">
   <li>If not <a>node reference is known</a> with <a>current session</a>,
   <a>current browsing context</a>, and <var>reference</var> return
-  <a>error</a> with <a>error code</a> <a>no such element</a>.
+  <a>error</a> with <a>error code</a> <a>no such shadow root</a>.
 
   <li>Let <var>node</var> be the result of <a>get a node</a> with
   <a>current session</a>, <a>current browsing context</a>, and


### PR DESCRIPTION
Update error in [get a known shadow root](https://www.w3.org/TR/webdriver/#dfn-get-a-known-shadow-root) algorithm from [no such element](https://www.w3.org/TR/webdriver/#dfn-no-such-element) to [no such shadow root](https://pr-preview.s3.amazonaws.com/lutien/webdriver/pull/1726.html#dfn-no-such-shadow-root).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver/pull/1726.html" title="Last updated on Mar 15, 2023, 2:20 PM UTC (e15bce2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1726/a638d46...lutien:e15bce2.html" title="Last updated on Mar 15, 2023, 2:20 PM UTC (e15bce2)">Diff</a>