### PR TITLE
Add "DOMTokenList" to collections

### DIFF
--- a/index.html
+++ b/index.html
@@ -6477,6 +6477,7 @@ and whose:
 <ul>
 <li><a>initial value</a> of the <code>toString</code> <a>own property</a> is "<code>Arguments</code>"
 <li>instance of {{Array}}
+<li>instance of {{DOMTokenList}}
 <li>instance of {{FileList}}
 <li>instance of {{HTMLAllCollection}}
 <li>instance of {{HTMLCollection}}


### PR DESCRIPTION
Right now the `DOMTokenList` is not handled as collection and as such falls back to an arbitrary object. 

The serialization results in an empty object to be returned because there are no enumerable properties. To actually allow `Get Element Property` to return the `classList` it needs to be handled as a collection.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1728.html" title="Last updated on Mar 20, 2023, 5:31 PM UTC (3bbccc1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1728/a638d46...whimboo:3bbccc1.html" title="Last updated on Mar 20, 2023, 5:31 PM UTC (3bbccc1)">Diff</a>