### PR TITLE
Serialization also calls inherited toJSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -6581,8 +6581,8 @@ a <a>remote end</a> must run the following steps:
     <li><p>Return <a>success</a> with data <var>reference</var>.
   </ol>
 
- <dt>has an <a>own property</a> named "<code>toJSON</code>" that is
-  a <a>Function</a>
+ <dt>has an <a>own property</a> or <a>inherited property</a> named
+    "<code>toJSON</code>" that is a <a>Function</a>
  <dd>Return <a>success</a> with the value returned by
   <a>Function.[[\Call]]</a>(<code>toJSON</code>) with <var>value</var>
   as the this value.
@@ -10979,6 +10979,7 @@ to automatically sort each list alphabetically.
    <!-- FunctionCreate --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-functioncreate>FunctionCreate</a></dfn>
    <!-- Get --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-get-o-p>Get</a></dfn>
    <!-- Global environment --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-10.2.3>Global environment</a></dfn>
+   <!-- Inherited property --> <li><dfn data-lt="inherited properties"><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-4.3.31>Inherited property</a></dfn>
    <!-- IsCallable --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-iscallable>IsCallable</a></dfn>
    <!-- Own property --> <li><dfn data-lt="own properties"><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-4.3.30>Own property</a></dfn>
    <!-- Promise --> <li><dfn><a href=https://tc39.github.io/ecma262/#sec-promise-constructor>Promise</a></dfn>


### PR DESCRIPTION
Serialization mechanism calls not only own toJSON method but also inherited toJSON method of the serialized object

Fixing [Call of toJSON in the internal JSON clone algorithm](https://github.com/w3c/webdriver/issues/1730).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nechaev-chromium/webdriver/pull/1732.html" title="Last updated on Apr 5, 2023, 3:28 PM UTC (1992c6e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1732/a65f9fb...nechaev-chromium:1992c6e.html" title="Last updated on Apr 5, 2023, 3:28 PM UTC (1992c6e)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1732)
<!-- Reviewable:end -->
