### PR TITLE
Use `Meta*` instead of `OS*`

### DIFF
--- a/index.html
+++ b/index.html
@@ -9029,8 +9029,8 @@ and <var>actions options</var>:
  <tr><td><code>"\uE009"</code></td><td><code></code></td><td><code>"ControlLeft"</code></td></tr>
  <tr><td><code>"\uE051"</code></td><td><code></code></td><td><code>"ControlRight"</code></td></tr>
  <tr><td><code>"\uE006"</code></td><td><code></code></td><td><code>"Enter"</code></td></tr>
- <tr><td><code>"\uE03D"</code></td><td><code></code></td><td><code>"OSLeft"</code></td></tr>
- <tr><td><code>"\uE053"</code></td><td><code></code></td><td><code>"OSRight"</code></td></tr>
+ <tr><td><code>"\uE03D"</code></td><td><code></code></td><td><code>"MetaLeft"</code></td></tr>
+ <tr><td><code>"\uE053"</code></td><td><code></code></td><td><code>"MetaRight"</code></td></tr>
  <tr><td><code>"\uE008"</code></td><td><code></code></td><td><code>"ShiftLeft"</code></td></tr>
  <tr><td><code>"\uE050"</code></td><td><code></code></td><td><code>"ShiftRight"</code></td></tr>
  <tr><td><code>" "</code></td><td><code>"\uE00D"</code></td><td><code>"Space"</code></td></tr>


### PR DESCRIPTION
See https://github.com/w3c/webdriver/issues/1457


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jrandolf/webdriver/pull/1739.html" title="Last updated on May 21, 2023, 11:24 AM UTC (6f268bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1739/a65f9fb...jrandolf:6f268bb.html" title="Last updated on May 21, 2023, 11:24 AM UTC (6f268bb)">Diff</a>