### PR TITLE
Update key codes

### DIFF
--- a/index.html
+++ b/index.html
@@ -9029,8 +9029,9 @@ and <var>actions options</var>:
  <tr><td><code>"\uE009"</code></td><td><code></code></td><td><code>"ControlLeft"</code></td></tr>
  <tr><td><code>"\uE051"</code></td><td><code></code></td><td><code>"ControlRight"</code></td></tr>
  <tr><td><code>"\uE006"</code></td><td><code></code></td><td><code>"Enter"</code></td></tr>
- <tr><td><code>"\uE03D"</code></td><td><code></code></td><td><code>"OSLeft"</code></td></tr>
- <tr><td><code>"\uE053"</code></td><td><code></code></td><td><code>"OSRight"</code></td></tr>
+ <tr><td><code>"\uE00B"</code></td><td><code></code></td><td><code>"Pause"</code></td></tr>
+ <tr><td><code>"\uE03D"</code></td><td><code></code></td><td><code>"MetaLeft"</code></td></tr>
+ <tr><td><code>"\uE053"</code></td><td><code></code></td><td><code>"MetaRight"</code></td></tr>
  <tr><td><code>"\uE008"</code></td><td><code></code></td><td><code>"ShiftLeft"</code></td></tr>
  <tr><td><code>"\uE050"</code></td><td><code></code></td><td><code>"ShiftRight"</code></td></tr>
  <tr><td><code>" "</code></td><td><code>"\uE00D"</code></td><td><code>"Space"</code></td></tr>
@@ -9059,6 +9060,7 @@ and <var>actions options</var>:
  <tr><td><code>"\uE03A"</code></td><td><code></code></td><td><code>"F10"</code></td></tr>
  <tr><td><code>"\uE03B"</code></td><td><code></code></td><td><code>"F11"</code></td></tr>
  <tr><td><code>"\uE03C"</code></td><td><code></code></td><td><code>"F12"</code></td></tr>
+ <tr><td><code>"\uE019"</code></td><td><code></code></td><td><code>"NumpadEqual"</code></td></tr>
  <tr><td><code>"\uE01A"</code></td><td><code>"\uE05C"</code></td><td><code>"Numpad0"</code></td></tr>
  <tr><td><code>"\uE01B"</code></td><td><code>"\uE056"</code></td><td><code>"Numpad1"</code></td></tr>
  <tr><td><code>"\uE01C"</code></td><td><code>"\uE05B"</code></td><td><code>"Numpad2"</code></td></tr>
@@ -9093,6 +9095,7 @@ and <var>actions options</var>:
  <tr><td><code>\uE008</code></td><td>Left Shift</td><td><code>1</code></td></tr>
  <tr><td><code>\uE009</code></td><td>Left Control</td><td><code>1</code></td></tr>
  <tr><td><code>\uE00A</code></td><td>Left Alt</td><td><code>1</code></td></tr>
+ <tr><td><code>\uE019</code></td><td>Numpad =</td><td><code>3</code></td></tr>
  <tr><td><code>\uE01A</code></td><td>Numpad 0</td><td><code>3</code></td></tr>
  <tr><td><code>\uE01B</code></td><td>Numpad 1</td><td><code>3</code></td></tr>
  <tr><td><code>\uE01C</code></td><td>Numpad 2</td><td><code>3</code></td></tr>


### PR DESCRIPTION
The key codes for `\uE00B`, `\uE03D`, `\uE053` are either incorrect or missing. The key code for `\uE019` should be `NumpadEqual` to distinguish it from `=`.

See https://github.com/web-platform-tests/wpt/pull/40122 for tests

#### Manual tests

On the two major platforms (macOS and Windows), we have:

 - `=` has the code value `NumpadEqual` for the numpad value.
 - `Pause` has the code value `Pause`

This is on a US-layout extended keyboard.

#### Reference

 - https://www.w3.org/TR/uievents-code/
 - https://www.w3.org/TR/uievents-key/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jrandolf/webdriver/pull/1740.html" title="Last updated on Jul 24, 2023, 1:11 PM UTC (9e37f98)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1740/a65f9fb...jrandolf:9e37f98.html" title="Last updated on Jul 24, 2023, 1:11 PM UTC (9e37f98)">Diff</a>