### PR TITLE
Rename "capability" to "capabilities" in validation algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -1820,21 +1820,21 @@ with a "<code>moz:</code>" prefix:
 </ol>
 
 <p>When required to <dfn>validate capabilities</dfn> with
- argument <var>capability</var>:
+ argument <var>capabilities</var>:
 
 <ol>
- <li><p>If <var>capability</var> is not a JSON <a>Object</a> return
+ <li><p>If <var>capabilities</var> is not a JSON <a>Object</a> return
   an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>Let <var>result</var> be an empty JSON <a>Object</a>.
 
  <li><p>For each enumerable <a>own property</a>
-  in <var>capability</var>, run the following substeps:
+  in <var>capabilities</var>, run the following substeps:
   <ol>
    <li><p>Let <var>name</var> be the name of the property.
 
    <li><p>Let <var>value</var> be the result of <a>getting a
-    property</a> named <var>name</var> from <var>capability</var>.
+    property</a> named <var>name</var> from <var>capabilities</var>.
 
    <li><p>Run the substeps of the first matching condition:
     <dl class=switch>


### PR DESCRIPTION
It seems like in [validation algorithm](https://w3c.github.io/webdriver/#dfn-validate-capabilities), we should use `capabilities` instead `capability` similar to other algorithms in this section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/webdriver/pull/1745.html" title="Last updated on Jun 6, 2023, 6:29 AM UTC (f247c19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1745/a638d46...lutien:f247c19.html" title="Last updated on Jun 6, 2023, 6:29 AM UTC (f247c19)">Diff</a>