### PR TITLE
Editorial: remove inaccurate qualifier

### DIFF
--- a/index.html
+++ b/index.html
@@ -1769,15 +1769,15 @@ with a "<code>moz:</code>" prefix:
 
   <ol>
    <li><p>If <var>all first match capabilities</var> is <a>undefined</a>,
-    set the value to a JSON <a>List</a> with a single entry of an empty JSON <a>Object</a>.
+    set the value to a <a>List</a> with a single entry of an empty JSON <a>Object</a>.
 
    <li><p>If <var>all first match capabilities</var> is not a
-   JSON <a>List</a> with one or more entries, return <a>error</a>
+   <a>List</a> with one or more entries, return <a>error</a>
    with <a>error code</a> <a>invalid argument</a>.
   </ol>
 
  <li><p>Let <var>validated first match capabilities</var> be an empty
-  JSON <a>List</a>.
+  <a>List</a>.
 
  <!-- Validate all entries first so we fail as quickly as possible -->
  <li><p>For each <var>first match capabilities</var> corresponding
@@ -3390,7 +3390,7 @@ make the tab containing the <a>browsing context</a> the selected tab.
 <p>The <a>remote end steps</a> are:
 
 <ol>
- <li><p>Let <var>handles</var> be a JSON <a>List</a>.
+ <li><p>Let <var>handles</var> be a <a>List</a>.
 
  <li><p>For each <a>top-level browsing context</a> in the <a>remote end</a>,
   push the associated <a>window handle</a> onto <var>handles</var>.
@@ -4554,7 +4554,7 @@ is given by:
   is less than <var>end time</var> return to step 4. Otherwise,
   continue to the next step.
 
- <li><p>Let <var>result</var> be an empty JSON <a>List</a>.
+ <li><p>Let <var>result</var> be an empty <a>List</a>.
 
  <li><p>For each <var>element</var> in <var>elements returned</var>,
   append the <a>web element reference object</a> for <var>element</var>,
@@ -7076,7 +7076,7 @@ The first argument provided to the function will be serialized to JSON and retur
 
  <li><p><a>Handle any user prompts</a>, and return its value if it is an <a>error</a>.
 
- <li><p>Let <var>cookies</var> be a new JSON <a>List</a>.
+ <li><p>Let <var>cookies</var> be a new <a>List</a>.
 
  <li><p>For each <var>cookie</var> in <a>all associated cookies</a> of
   the <a>current browsing context</a>’s <a>active document</a>:


### PR DESCRIPTION
This specification uses the List type from WHATWG Infra [1]. It does so indirectly, working with a derivative which it refers to as a "JSON List." This type is not defined, but because its usage matches that of the List, the qualifier "JSON" appears to be superfluous.

Remove the qualifier to clarify the type of the specification values.

[1] https://infra.spec.whatwg.org/#lists


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver/pull/1748.html" title="Last updated on Jun 28, 2023, 2:01 AM UTC (76df041)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1748/441e433...bocoup:76df041.html" title="Last updated on Jun 28, 2023, 2:01 AM UTC (76df041)">Diff</a>