### PR TITLE
editorial: Use "content navigable" instead of "nested navigable"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3573,8 +3573,8 @@ make the tab containing the <a>browsing context</a> the selected tab.
       return <a>error</a> with <a>error code</a> <a>no such frame</a>.
 
      <li><p><a>Set the current browsing context</a>
-     with <var>element</var>’s <a>nested navigable</a>'s <a>active
-     browsing context</a>.
+     with <var>element</var>’s [=navigable container/content navigable=]'s
+     [=navigable/active browsing context=].
     </ol>
  </dl>
 
@@ -11059,7 +11059,6 @@ to automatically sort each list alphabetically.
    <!-- 2D context creation algorithm --> <li><dfn><a href=https://html.spec.whatwg.org/#2d-context-creation-algorithm>2D context creation algorithm</a></dfn>
    <!-- A serialization of the bitmap as a file --> <li><dfn data-lt="a serialization of the bitmap as a file"><a href=https://html.spec.whatwg.org/#a-serialisation-of-the-bitmap-as-a-file>A serialization of the bitmap as a file</a></dfn>
    <!-- API length --> <li><dfn><a href="https://html.spec.whatwg.org/#concept-fe-api-value">API value</a></dfn>
-   <!-- Active browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#nav-bc>active browsing context</a></dfn>
    <!-- Active document --> <li><dfn><a href=https://html.spec.whatwg.org/#active-document>active document</a></dfn>
    <!-- Active element --> <li><dfn>Active element</dfn> being the <a href=https://html.spec.whatwg.org/#dom-document-activeelement><code>activeElement</code></a> attribute on <a href=https://html.spec.whatwg.org/#document><code>Document</code></a>
    <!-- Associated window --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-document-window>Associated window</a></dfn>
@@ -11089,7 +11088,6 @@ to automatically sort each list alphabetically.
    <!-- Mature (navigation) --> <li><dfn data-lt="matured"><a href=https://html.spec.whatwg.org/#concept-navigate-mature>Mature</a></dfn> navigation.
    <!-- Mutable --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-mutable>Mutable</a></dfn>
    <!-- Navigate --> <li><dfn data-lt="navigating|navigation"><a href=https://html.spec.whatwg.org/#navigate>Navigate</a></dfn>
-   <!-- Nested navigable --> <li><dfn><a href=https://html.spec.whatwg.org/#nested-navigable>nested navigable</a></dfn>
    <!-- Origin-clean --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-canvas-origin-clean>Origin-clean</a></dfn>
    <!-- Overridden reload --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/dom.html#an-overridden-reload">An overridden reload</a></dfn>
    <!-- Parent browsing context --> <li><dfn><a href=https://html.spec.whatwg.org/#parent-browsing-context>Parent browsing context</a></dfn>


### PR DESCRIPTION
The term was renamed in the HTML spec in whatwg/html#8712 so the current reference was broken as mentioned in #1735.

While here, use ReSpec's shorthand syntax to refer to these sub concepts directly and avoid having to specifically link to them in the index at the end of the document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/webdriver/pull/1750.html" title="Last updated on Aug 7, 2023, 9:27 AM UTC (7679754)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1750/866fedb...rakuco:7679754.html" title="Last updated on Aug 7, 2023, 9:27 AM UTC (7679754)">Diff</a>