### PR TITLE
Fix link for page loading strategy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1531,7 +1531,7 @@ with a "<code>moz:</code>" prefix:
   <td><dfn>Page load strategy</dfn>
   <td>"<code>pageLoadStrategy</code>"
   <td>string
-  <td>Defines the <a>current session</a>’s <a>page load strategy</a>.
+  <td>Defines the <a>current session</a>’s <a>page loading strategy</a>.
  </tr>
 
  <tr>


### PR DESCRIPTION
The existing link was self-referential.  This was unhelpful for understanding the document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tomgilligan/webdriver/pull/1752.html" title="Last updated on Aug 4, 2023, 10:33 AM UTC (b74a693)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1752/441e433...tomgilligan:b74a693.html" title="Last updated on Aug 4, 2023, 10:33 AM UTC (b74a693)">Diff</a>