### PR TITLE
Raise "unsupported operation" error when "pointer" is used as origin for key and wheel input sources

### DIFF
--- a/index.html
+++ b/index.html
@@ -7908,8 +7908,10 @@ options</var>:
 
    <dt>"<code>pointer</code>"
    <dd>
-    <p class="note">This is only possible if <var>source</var> is
-    a <a>pointer input source</a></p>
+    <ol>
+      <li>If <var>source</var> is not of type "<code>pointer</code>" return
+        <a>error</a> with <a>error code</a> <a>unsupported operation</a>.
+    </ol>
 
     <ol>
      <li><p>Let <var>start x</var> be equal to the <code>x</code>

--- a/index.html
+++ b/index.html
@@ -7909,11 +7909,6 @@ options</var>:
    <dt>"<code>pointer</code>"
    <dd>
     <ol>
-      <li>If <var>source</var> is not of type "<code>pointer</code>" return
-        <a>error</a> with <a>error code</a> <a>unsupported operation</a>.
-    </ol>
-
-    <ol>
      <li><p>Let <var>start x</var> be equal to the <code>x</code>
      property of <var>source</var>.
 
@@ -8310,10 +8305,11 @@ Let <var>origin</var> be the result of <a>getting the property</a>
 If <var>origin</var> is <a>undefined</a> let
 <var>origin</var> equal "<code>viewport</code>".
 
-<li><p> If <var>origin</var> is not equal to "<code>viewport</code>"
-or "<code>pointer</code>", or <var>actions options</var>' <a>is element
-origin</a> steps given <var>origin</var> return false,
-return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+<li><p>
+If <var>origin</var> is not equal to "<code>viewport</code>",
+or <var>actions options</var>' <a>is element origin</a> steps given
+<var>origin</var> return false, return <a>error</a> with
+<a>error code</a> <a>invalid argument</a>.
 
 <li><p>
 Set the <code>origin</code> property of <var>action</var>


### PR DESCRIPTION
Short term fix for issue #1758 to raise a specific failure for unsupported origin types in `get coordinates relative to an origin`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1760.html" title="Last updated on Sep 5, 2023, 9:08 PM UTC (f19c38a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1760/d9be1ae...whimboo:f19c38a.html" title="Last updated on Sep 5, 2023, 9:08 PM UTC (f19c38a)">Diff</a>