### PR TITLE
Fix "coordinates" typo in pointer input source description

### DIFF
--- a/index.html
+++ b/index.html
@@ -7547,7 +7547,7 @@ input source</a> with the items initalized to their default values.
  <tr>
   <td>y
   <td>An unsigned integer representing the pointer y location in
-  viewport coordindates.
+  viewport coordinates.
   <td>0
  </tr>
 </table>


### PR DESCRIPTION
coordindates -> coordinates


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aprotyas/webdriver/pull/1762.html" title="Last updated on Sep 22, 2023, 8:58 PM UTC (e345780)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1762/35a868a...aprotyas:e345780.html" title="Last updated on Sep 22, 2023, 8:58 PM UTC (e345780)">Diff</a>