### PR TITLE
Fix reference for element disabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -4251,7 +4251,7 @@ is given by:
 <dl class=subcategories>
  <dt><dfn data-lt="mutable form control element">Mutable form control elements</dfn>
  <dd><p>Denotes [^input^] elements
-  that are <a>mutable</a> (e.g. that are not <a>read only</a> or <a>disabled</a>)
+  that are <a>mutable</a> (e.g. that are not <a>read only</a> or <a>actually disabled</a>)
   and whose [^input/type^] attribute</a>
   is in one of the following states:
 
@@ -5605,7 +5605,7 @@ Width of the <a>web element</a>’s
   <p>Otherwise, let <var>enabled</var> to false
    and jump to the last step of this algorithm.
 
- <li><p>Set <var>enabled</var> to false if a form control is <a>disabled</a>.
+ <li><p>Set <var>enabled</var> to false if a form control is <a>actually disabled</a>.
 
  <li><p>Return <a>success</a> with data <var>enabled</var>.
 </ol>
@@ -5784,7 +5784,7 @@ an <a>element not interactable</a> <a>error</a> is returned.
 
        <li><p>Run the <a>focusing steps</a> on <var>parent node</var>.
 
-       <li><p>If <var>element</var> is not <a>disabled</a>:
+       <li><p>If <var>element</var> is not <a>actually disabled</a>:
 
         <ol>
          <li><p>[=fire an event|Fire=] an <a><code>input</code></a> event at <var>parent node</var>.
@@ -11072,7 +11072,7 @@ to automatically sort each list alphabetically.
    <!-- Cookie-averse Document object --> <li><dfn><a href=https://html.spec.whatwg.org/#cookie-averse-document-object>Cookie-averse <code>Document</code> object</a></dfn>
    <!-- Dirty checkedness flag --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-input-checked-dirty-flag>Dirty checkedness flag</a></dfn>
    <!-- Dirty value flag --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-dirty>Dirty value flag</a></dfn>
-   <!-- Disabled --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-disabled>Disabled</a></dfn>
+   <!-- Disabled --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-element-disabled>Actually disabled</a></dfn>
    <!-- Document readiness --> <li><dfn><a href=https://html.spec.whatwg.org/#current-document-readiness>Document readiness</a></dfn>
    <!-- Element contexts --> <li><dfn data-lt="element context"><a href=https://html.spec.whatwg.org/#concept-element-contexts>Element contexts</a></dfn>
    <!-- Enumerated attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#enumerated-attribute>Enumerated attribute</a></dfn>


### PR DESCRIPTION
To properly check an element for `disabled` we have to reference the `actually disabled` section of the HTML spec. 

It means the link changes from https://html.spec.whatwg.org/#concept-fe-disabled to https://html.spec.whatwg.org/#concept-element-disabled.

@jgraham can you please review?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1769.html" title="Last updated on Nov 20, 2023, 4:05 PM UTC (5e44158)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1769/35a868a...whimboo:5e44158.html" title="Last updated on Nov 20, 2023, 4:05 PM UTC (5e44158)">Diff</a>