### PR TITLE
Correct element click actions list

### DIFF
--- a/index.html
+++ b/index.html
@@ -5925,7 +5925,7 @@ an <a>element not interactable</a> <a>error</a> is returned.
       to <code>0</code> on <var>pointer up action</var>.
 
      <li><p>Let <var>actions</var> be the list «<var>pointer move
-     action</var>, <var>pointer down action</var>, <var>pointer move
+     action</var>, <var>pointer down action</var>, <var>pointer up
      action</var>».
 
      <li><p><a>Dispatch a list of actions</a> with <var>input

--- a/index.html
+++ b/index.html
@@ -5919,7 +5919,7 @@ an <a>element not interactable</a> <a>error</a> is returned.
 
      <li><p>Let <var>pointer up action</var> be an <a>action
       object</a> constructed with arguments <var>input id</var>,
-      "<code>mouse</code>", and "<code>pointerUp</code>" as arguments.
+      "<code>pointer</code>", and "<code>pointerUp</code>" as arguments.
 
      <li><p><a>Set a property</a> <code>button</code>
       to <code>0</code> on <var>pointer up action</var>.


### PR DESCRIPTION
element click is erroneously defined as `«pointer move action, pointer down action, pointer move action».` but should obviously be `«pointer move action, pointer down action, pointer up action».` making use of the pointer up action defined


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dten/webdriver/pull/1779.html" title="Last updated on Dec 13, 2023, 10:24 AM UTC (337f29f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1779/e91f9d8...dten:337f29f.html" title="Last updated on Dec 13, 2023, 10:24 AM UTC (337f29f)">Diff</a>