### PR TITLE
Automatically accept any "beforeunload" prompt upon navigation or close window.

### DIFF
--- a/index.html
+++ b/index.html
@@ -9984,7 +9984,7 @@ It also clears all the internal state of the virtual devices.
 
 <p><a>User prompts</a> that are spawned
  from <a><code>beforeunload</code></a> event handlers,
- are <a>dismissed</a> implicitly upon <a>navigation</a>
+ are <a>accepted</a> implicitly upon <a>navigation</a>
  or <a>close window</a>,
  regardless of the defined <a>user prompt handler</a>.
 


### PR DESCRIPTION
Right now the spec says that we should automatically dismiss any `beforeunload` prompt upon navigation or window close:

> [User prompts](https://w3c.github.io/webdriver/#dfn-user-prompts) that are spawned from [beforeunload](https://w3c.github.io/webdriver/#dfn-beforeunload) event handlers, are [dismissed](https://w3c.github.io/webdriver/#dfn-dismissed) implicitly upon [navigation](https://w3c.github.io/webdriver/#dfn-navigating) or [close window](https://w3c.github.io/webdriver/#dfn-close-window), regardless of the defined [user prompt handler](https://w3c.github.io/webdriver/#dfn-user-prompt-handler).

But the problem is the definition of `dismissed`:

> To dismiss the [current user prompt](https://w3c.github.io/webdriver/#dfn-current-user-prompt), do so as if the user would click the Cancel or OK button, whichever is present, in that order.

Given that such prompts have both an `OK` and `Cancel` button, we would have to click on `Cancel`. But that will cause the page to never get unloaded for a navigation, and the [`wait for navigation to complete`](https://w3c.github.io/webdriver/#dfn-waiting-for-the-navigation-to-complete) steps to hang until the page timeout because.

I'll check for proper tests when implementing this type of prompt for Marionette in Firefox on https://bugzilla.mozilla.org/show_bug.cgi?id=1693857.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1782.html" title="Last updated on Jan 12, 2024, 8:23 PM UTC (98a5ef8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1782/ec2663f...whimboo:98a5ef8.html" title="Last updated on Jan 12, 2024, 8:23 PM UTC (98a5ef8)">Diff</a>