### PR TITLE
Clarify when an element is disabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -4505,8 +4505,8 @@ and <var>element</var> is:
 <dl class=subcategories>
  <dt><dfn data-lt="mutable form control element">Mutable form control elements</dfn>
  <dd><p>Denotes [^input^] elements
-  that are <a>mutable</a> (e.g. that are not <a>read only</a> or <a>actually disabled</a>)
-  and whose [^input/type^] attribute
+  that are <a>mutable</a> (e.g. that are not <a>read only</a> or
+  <a>disabled</a>) and whose [^input/type^] attribute
   is in one of the following states:
 
   <ul class=brief>
@@ -4601,6 +4601,22 @@ and <var>element</var> is:
  <li><p>Let <var>y</var> be <a>floor</a>((<var>top</var> + <var>bottom</var>) ÷ 2.0).
 
  <li><p>Return the pair of (<var>x</var>, <var>y</var>).
+</ol>
+
+<p>An <a>element</a> |element| is <dfn>disabled</dfn> if the following steps
+ return true:
+
+<ol>
+ <li><p>If |element| is an <a>option</a> element or |element| is an <a>optgroup</a> element:
+  <ol>
+   <li><p>For each [=tree/inclusive ancestor=] |ancestor| of |element|:
+    <ol>
+     <li><p>If |ancestor| is an <a>optgroup</a> element or |ancestor| is a <a>select</a>
+      element, and |ancestor| is [=actually disabled=], return true.
+    </ol>
+   <li><p>Return false.
+  </ol>
+ <li><p>Return |element| is [=actually disabled=].
 </ol>
 
 <p>An <a>element</a> is <dfn>in view</dfn>
@@ -5912,7 +5928,7 @@ variables</var> and <var>parameters</var> are:
   <p>Otherwise, let <var>enabled</var> to false
    and jump to the last step of this algorithm.
 
- <li><p>Set <var>enabled</var> to false if a form control is <a>actually disabled</a>.
+ <li><p>Set <var>enabled</var> to false if a form control is <a>disabled</a>.
 
  <li><p>Return <a>success</a> with data <var>enabled</var>.
 </ol>
@@ -6099,7 +6115,7 @@ variables</var> and <var>parameters</var> are:
 
        <li><p>Run the <a>focusing steps</a> on <var>parent node</var>.
 
-       <li><p>If <var>element</var> is not <a>actually disabled</a>:
+       <li><p>If <var>element</var> is not <a>disabled</a>:
 
         <ol>
          <li><p>[=fire an event|Fire=] an <a><code>input</code></a> event at <var>parent node</var>.


### PR DESCRIPTION
Selenium's atom "Is Element Enabled" special-cases the disabled state for "option" and "optgroup" elements when the nearest anchestor "select" is disabled as well.

@jgraham please let me know if that is what you would imagine based on your comment from:
https://bugzilla.mozilla.org/show_bug.cgi?id=1863266#c12


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1807.html" title="Last updated on Apr 16, 2024, 12:51 PM UTC (8f951ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1807/43903d0...whimboo:8f951ba.html" title="Last updated on Apr 16, 2024, 12:51 PM UTC (8f951ba)">Diff</a>