### PR TITLE
Fix inappropriate usage of "userPromptHandler" as capability name

### DIFF
--- a/index.html
+++ b/index.html
@@ -2132,7 +2132,7 @@ with a "<code>moz:</code>" prefix:
        used. The intent is that if this is not possible a new session
        will not be established.
 
-     <dt>"<code>userPromptHandler</code>"
+     <dt>"<code>unhandledPromptBehavior</code>"
      <dd><p>If <a>check user prompt handler matches</a>
      with <var>value</var> is false, return <a>success</a> with
      data <a><code>null</code></a>.
@@ -2295,18 +2295,18 @@ flags</a> <var>flags</var>:
   "<code>acceptInsecureCerts</code>" from <var>capabilities</var>.
 
   <li><p>Let <var>user prompt handler capability</var> be the result of getting property
-  "<code>userPromptHandler</code>" from <var>capabilities</var>.
+  "<code>unhandledPromptBehavior</code>" from <var>capabilities</var>.
 
-   <li><p>If <var>user prompt handler capability</var> is not
+  <li><p>If <var>user prompt handler capability</var> is not
    undefined, <a>update the user prompt handler</a> with <var>user
    prompt handler capability</var>.
 
-   <li><p>Let <var>serialized user prompt handler</var>
+  <li><p>Let <var>serialized user prompt handler</var>
    be <a>serialize the user prompt handler</a>.
 
-   <li><p>If <var>seralized user prompt handler</var> is not null, set
+  <li><p>If <var>serialized user prompt handler</var> is not null, set
    a property on <var>capabilities</var> with the name
-   "<code>userPromptHandler</code>", and the value <var>serialized
+   "<code>unhandledPromptBehavior</code>", and the value <var>serialized
    user prompt handler</var>.
 
   <li><p>If <var>flags</var> <var>contains</var> "<code>http</code>":


### PR DESCRIPTION
It was not intended to add a new `userPromptHandler` capability. Instead the existing `unhandledPromptBehavior` capability got enhanced for WebDriver BiDi.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1808.html" title="Last updated on Apr 10, 2024, 9:24 AM UTC (ade93c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1808/43903d0...whimboo:ade93c7.html" title="Last updated on Apr 10, 2024, 9:24 AM UTC (ade93c7)">Diff</a>