### PR TITLE
Fix issues with User Prompt Handler after PR #1791

### DIFF
--- a/index.html
+++ b/index.html
@@ -10510,6 +10510,9 @@ argument <var>value</var>:
    set <var>handler<var> to "<code>dismiss</code>"
    and <var>notify</var> to true.
 
+   <li><p>If <var>handler</var> is "<code>ignore</code>",
+   set <var>notify</var> to true.
+
    <li><p>Let <var>configuration</var> be a <a>prompt handler
    configuration</a> with [=prompt handler
    configuration/handler=] <var>handler</var> and [=prompt handler
@@ -10659,19 +10662,18 @@ given <var>requested prompt handler</var>:
  on <var>handler</var>&apos;s [=prompt handler configuration/handler=]:
 
 <dl class=switch>
-<dt>"<code>accept</code>"
-<dd><p><a>Accept</a> the <a>current user prompt</a>.
+ <dt>"<code>accept</code>"
+ <dd><p><a>Accept</a> the <a>current user prompt</a>.
 
-<dt>"<code>dismiss</code>"
-<dd><p><a>Dismiss</a> the <a>current user prompt</a>.
+ <dt>"<code>dismiss</code>"
+ <dd><p><a>Dismiss</a> the <a>current user prompt</a>.
 
-<dt>"<code>ignore</code>"
-<dd><p>Do nothing.
+ <dt>"<code>ignore</code>"
+ <dd><p>Do nothing.
 </dl>
 
-<li><p>If <var>handler</var>&apos;s [=prompt handler
-   configuration/notify=] is true, return <a>annotated unexpected
-   alert open error</a>.
+<li><p>If <var>handler</var>&apos;s [=prompt handler configuration/notify=]
+is true, return <a>annotated unexpected alert open error</a>.
 
 <li><p>Return <a>success</a>.
 </ol>

--- a/index.html
+++ b/index.html
@@ -10484,6 +10484,9 @@ argument <var>value</var>:
  <li><p>If <var>value</var> is a <a>string</a> set <var>value</var> to
  the <a data-cite=infra>map</a> «["<code>default</code>" → <var>value</var>]».
 
+ <li><p>If <var>value</var> is not an <a>Object</a> return <a>error</a>
+ with <a>error code</a> <a>invalid argument</a>.
+
  <li>Let <var>user prompt handler</var> be an empty <a data-cite=infra>map</a>.
 
  <li><p>For each <var>prompt type</var> → <var>handler</var> in <var>value</var>:

--- a/index.html
+++ b/index.html
@@ -10516,7 +10516,7 @@ argument <var>value</var>:
    configuration/notify=] <var>notify</var>.
 
    <li><p>[=map/Set=] <var>user prompt
-   handler</var>[<var>handler</var>] to <var>configuration</var>.
+   handler</var>[<var>prompt type</var>] to <var>configuration</var>.
 
   </ol>
  </li>

--- a/index.html
+++ b/index.html
@@ -10484,8 +10484,8 @@ argument <var>value</var>:
  <li><p>If <var>value</var> is a <a>string</a> set <var>value</var> to
  the <a data-cite=infra>map</a> «["<code>default</code>" → <var>value</var>]».
 
- <li><p>If <var>value</var> is not an <a>Object</a> return <a>error</a>
- with <a>error code</a> <a>invalid argument</a>.
+ <li><p>If <var>value</var> is not a <a data-cite=infra>map</a> return
+ <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li>Let <var>user prompt handler</var> be an empty <a data-cite=infra>map</a>.
 
@@ -10565,12 +10565,12 @@ given <var>requested prompt handler</var>:
  <li><p>If the <a>user prompt handler</a> is null, set the <a>user prompt
  handler</a> to an empty map.
 
- <li><p>For each <var>request key</var> → <var>request handler</var>
+ <li><p>For each <var>request prompt type</var> → <var>request handler</var>
  in <var>requested prompt handler</var>:
 
   <ol>
-   <li><p>Set <a>user prompt handler</a>[<var>key</var>] to <var>value</var>.
-
+   <li><p>Set <a>user prompt handler</a>[<var>request prompt type</var>]
+   to <var>request handler</var>.
   </ol>
 
 </ol>

--- a/index.html
+++ b/index.html
@@ -10533,12 +10533,12 @@ given <var>requested prompt handler</var>:
 <ol class="algorithm">
  <li><p>If the <a>user prompt handler</a> is null, return true.
 
- <li><p>For each <var>request key</var> → <var>request handler</var>
+ <li><p>For each <var>request prompt type</var> → <var>request handler</var>
  in <var>requested prompt handler</var>:
 
   <ol>
    <li><p>If the <a>user prompt handler</a>
-   [=map/contains=] <var>key</var>:
+   [=map/contains=] <var>request prompt type</var>:
 
     <ol>
 


### PR DESCRIPTION
With PR #1791 we got extended support for the `unhandledPromptBehavior` landed which added a new Object type to define handlers for all the prompt handlers more granularly.

While implementing the capability handling for that new type in Firefox I noticed a couple of issue. This PR fixes these and also updates some cases to make it better understandable what specific variables actually are.

FYI @sadym-chromium @nechaev-chromium @gsnedders for when you get started to implement these changes in the drivers.

Updated tests will be part of my work on https://bugzilla.mozilla.org/show_bug.cgi?id=1895738.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1812.html" title="Last updated on May 21, 2024, 9:01 PM UTC (76573d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1812/3b12477...whimboo:76573d3.html" title="Last updated on May 21, 2024, 9:01 PM UTC (76573d3)">Diff</a>