### PR TITLE
Don't require user prompt handler notify to match when creating session

### DIFF
--- a/index.html
+++ b/index.html
@@ -10545,11 +10545,7 @@ given <var>requested prompt handler</var>:
      <li><p>If the <var>requested prompt handler</var>&apos;s [=prompt
      handler configuration/handler=] is not equal to the <a>user
      prompt handler</a>&apos;s [=prompt handler
-     configuration/handler=], or the <var>requested prompt
-     handler</var>&apos;s [=prompt handler configuration/notify=]
-     is not equal to the <a>user prompt
-     handler</a>&apos;s [=prompt handler configuration/handler=],
-     return false.
+     configuration/handler=], return false.
 
     </ol>
    </li>
@@ -10557,6 +10553,12 @@ given <var>requested prompt handler</var>:
 
  <li>Return true</li>
 </ol>
+
+<p class="note">This does not check the <var>requested prompt
+handler</var>&apos;s [=prompt handler configuration/notify=] matches
+the [=prompt handler configuration/handler=], because the [=prompt
+handler configuration/notify=] component only affects the [=HTTP
+session=], if any.
 
 <p>To <dfn>update the user prompt handler</dfn> given <var>requested prompt handler</var>:
 


### PR DESCRIPTION
This would prevent creating a BiDi session for a browser that already has a HTTP session with the notify flag set for some prompt handler.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1818.html" title="Last updated on Jun 14, 2024, 9:53 AM UTC (d95609c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1818/34f9efa...d95609c.html" title="Last updated on Jun 14, 2024, 9:53 AM UTC (d95609c)">Diff</a>