### PR TITLE
Update user prompt handler configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -10545,11 +10545,7 @@ given <var>requested prompt handler</var>:
      <li><p>If the <var>requested prompt handler</var>&apos;s [=prompt
      handler configuration/handler=] is not equal to the <a>user
      prompt handler</a>&apos;s [=prompt handler
-     configuration/handler=], or the <var>requested prompt
-     handler</var>&apos;s [=prompt handler configuration/notify=]
-     is not equal to the <a>user prompt
-     handler</a>&apos;s [=prompt handler configuration/handler=],
-     return false.
+     configuration/handler=], return false.
 
     </ol>
    </li>
@@ -10557,6 +10553,12 @@ given <var>requested prompt handler</var>:
 
  <li>Return true</li>
 </ol>
+
+<p class="note">This does not check the <var>requested prompt
+handler</var>&apos;s [=prompt handler configuration/notify=] matches
+the [=prompt handler configuration/handler=], because the [=prompt
+handler configuration/notify=] component only affects the [=HTTP
+session=], if any.
 
 <p>To <dfn>update the user prompt handler</dfn> given <var>requested prompt handler</var>:
 

--- a/index.html
+++ b/index.html
@@ -2304,8 +2304,7 @@ flags</a> <var>flags</var>:
   <li><p>Let <var>serialized user prompt handler</var>
    be <a>serialize the user prompt handler</a>.
 
-  <li><p>If <var>serialized user prompt handler</var> is not null, set
-   a property on <var>capabilities</var> with the name
+  <li><p>Set a property on <var>capabilities</var> with the name
    "<code>unhandledPromptBehavior</code>", and the value <var>serialized
    user prompt handler</var>.
 
@@ -10583,7 +10582,8 @@ session=], if any.
 <p>To <dfn>serialize the user prompt handler</dfn>:
 
 <ol class=algorithm>
- <li><p>If the <a>user prompt handler</a> is null, return null.
+ <li><p>If the <a>user prompt handler</a> is null, return
+ "<code>dismiss and notify</code>".
 
  <li><p>If the <a>user prompt handler</a> has [=map/size=] 1,
  and <a>user prompt handler</a> [=list/contains=]

--- a/index.html
+++ b/index.html
@@ -10481,8 +10481,11 @@ argument <var>value</var>:
  <p class="note">This is to avoid [[WebDriver-BiDi]] monkey-patching
  the current spec.
 
+ <li><p>Let <var>is string value</var> be false.
+
  <li><p>If <var>value</var> is a <a>string</a> set <var>value</var> to
- the <a data-cite=infra>map</a> «["<code>default</code>" → <var>value</var>]».
+ the <a data-cite=infra>map</a> «["<code>fallbackDefault</code>"
+ → <var>value</var>]» and set <var>is string value</var> to true.
 
  <li><p>If <var>value</var> is not a <a data-cite=infra>map</a> return
  <a>error</a> with <a>error code</a> <a>invalid argument</a>.
@@ -10492,9 +10495,9 @@ argument <var>value</var>:
  <li><p>For each <var>prompt type</var> → <var>handler</var> in <var>value</var>:
 
   <ol>
-   <li><p>If <a>valid prompt types</a> does
-   not [=map/contain=] <var>prompt type</var> return <a>error</a>
-   with <a>error code</a> <a>invalid argument</a>.
+   <li><p>If <var>is string value</var> is false and <a>valid prompt
+   types</a> does not [=map/contain=] <var>prompt type</var>
+   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
    <li><p>If <a>known prompt handlers</a> does not contain an entry
    with <a>handler key</a> <var>handler</var> return <a>error</a>
@@ -10584,9 +10587,9 @@ session=], if any.
 
  <li><p>If the <a>user prompt handler</a> has [=map/size=] 1,
  and <a>user prompt handler</a> [=list/contains=]
- "<code>default</code>", return the result of <a>serialize a prompt
+ "<code>fallbackDefault</code>", return the result of <a>serialize a prompt
  handler configuration</a> with <a>user prompt
- handler</a>["<code>default</code>"].
+ handler</a>["<code>fallbackDefault</code>"].
 
  <li><p>Let <var>serialized</var> be an empty <a data-cite=infra>map</a>.
 
@@ -10623,12 +10626,15 @@ session=], if any.
  <li><p>If <var>handlers</var> contains <var>type</var>
  return <var>handlers</var>[<var>type</var>].
 
+ <li><p>If <var>handlers</var> contains "<code>default</code>"
+ return <var>handlers</var>["<code>default</code>"].
+
  <li><p>If <var>type</var> is "<code>beforeUnload</code>", return a
    <a>prompt handler configuration</a> with [=prompt
    handler configuration/handler=] "<code>accept</code>"
    and [=prompt handler configuration/notify=] false.
 
- <li><p>If <var>handlers</var> contains "<code>default</code>"
+ <li><p>If <var>handlers</var> contains "<code>fallbackDefault</code>"
  return <var>handlers</var>["<code>default</code>"].
 
  <li><p>Return a <a>prompt handler


### PR DESCRIPTION
* Make string valued handlers only set the alert/confirm/prompt modals, but object valued handlers with a `default` key set the default for all prompt types including `beforeUnload`
* Unconditionally return the user prompt handler in the new session response


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1819.html" title="Last updated on Jun 14, 2024, 9:55 AM UTC (add07f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1819/34f9efa...add07f9.html" title="Last updated on Jun 14, 2024, 9:55 AM UTC (add07f9)">Diff</a>