### PR TITLE
Fix typo for "specficiations" in Sessions section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2240,7 +2240,7 @@ processing.
 flags</dfn> are provided that define the features of the session. This
 specification always creates sessions with "<code>http</code>"
 in <a>session configuration flags</a>, which corresponds to
-the <a>HTTP flag</a>. External specficiations may define additional
+the <a>HTTP flag</a>. External specifications may define additional
 flags, or create sessions without the <a>HTTP flag</a>.
 
 <h3>Global State</h3>


### PR DESCRIPTION
Fixes https://github.com/w3c/webdriver/issues/1821


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/katranci/webdriver/pull/1822.html" title="Last updated on Jun 28, 2024, 11:39 AM UTC (ba144ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1822/0d759c9...katranci:ba144ba.html" title="Last updated on Jun 28, 2024, 11:39 AM UTC (ba144ba)">Diff</a>