### PR TITLE
Update user prompt handler note for fallbackDefault

### DIFF
--- a/index.html
+++ b/index.html
@@ -10456,7 +10456,7 @@ The <dfn>known prompt handlers</dfn> are:
 <p class="note">The "<code>default</code>" type represents a fallback
 when no specific handler is defined for a given prompt type, including
 the "<code>beforeUnload</code>" prompt type. It can only be set if the
-unhandled prompt behavior is a <a data-cite=infra>map</a> wgucg
+unhandled prompt behavior is a <a data-cite=infra>map</a> which
 [=map/contains=] "<code>default</code>". For HTTP-only sessions setting
 unhandled prompt behavior as a string value, the value will be assigned to
 the internal type "<code>fallbackDefault</code>". The

--- a/index.html
+++ b/index.html
@@ -10454,13 +10454,18 @@ The <dfn>known prompt handlers</dfn> are:
 "<code>default</code>", "<code>prompt</code>"».
 
 <p class="note">The "<code>default</code>" type represents a fallback
-when no specific handler is defined for a given prompt type. The
-"<code>beforeUnload</code>" prompt type does not use this default
-handler, but instead falls back to the "<code>accept</code>" handler
-if no more specific handler is defined. This is because HTTP-only
-sessions do not allow the "<code>beforeUnload</code>" handler to be
-customized, and enabling other protocols isn&apos;t expected to change
-the user prompt handling as a side effect.
+when no specific handler is defined for a given prompt type, including
+the "<code>beforeUnload</code>" prompt type. It can only be set if the
+unhandled prompt behavior is a <a data-cite=infra>map</a> wgucg
+[=map/contains=] "<code>default</code>". For HTTP-only sessions setting
+unhandled prompt behavior as a string value, the value will be assigned to
+the internal type "<code>fallbackDefault</code>". The
+"<code>fallbackDefault</code>" value is not used for the
+"<code>beforeUnload</code>" prompt type, instead it falls back to the
+"<code>accept</code>" handler. This is because HTTP-only sessions do not
+allow the "<code>beforeUnload</code>" handler to be customized, and enabling
+other protocols isn&apos;t expected to change the user prompt handling as a
+side effect.
 
 <p>To <dfn>deserialize as an unhandled prompt behavior</dfn> given
 argument <var>value</var>:
@@ -10635,7 +10640,7 @@ session=], if any.
    and [=prompt handler configuration/notify=] false.
 
  <li><p>If <var>handlers</var> contains "<code>fallbackDefault</code>"
- return <var>handlers</var>["<code>default</code>"].
+ return <var>handlers</var>["<code>fallbackDefault</code>"].
 
  <li><p>Return a <a>prompt handler
    configuration</a> with [=prompt handler


### PR DESCRIPTION
- Update the note to reflect the fact that "default" now applies to before unload and mention fallbackDefault
- fix `get the prompt handler` to select fallbackDefault when relevant


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/juliandescottes/webdriver/pull/1831.html" title="Last updated on Jul 19, 2024, 8:41 PM UTC (6058d03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1831/af51973...juliandescottes:6058d03.html" title="Last updated on Jul 19, 2024, 8:41 PM UTC (6058d03)">Diff</a>