### PR TITLE
Add a capability for returning the main PID of the browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -1578,6 +1578,13 @@ with a "<code>moz:</code>" prefix:
   <td>string
   <td>Identifies the <a>default User-Agent value</a> of the <a>endpoint node</a>.
  </tr>
+
+ <tr>
+  <td>ProcessID
+  <td>"<code>processID</code>"
+  <td>string
+  <td>Identifies the main process ID of the <a>endpoint node</a>.
+ </tr>
 </table>
 
 <section>
@@ -2009,6 +2016,9 @@ with a "<code>moz:</code>" prefix:
 
    <dt>"<code>userAgent</code>"
    <dd>String containing the <a>default User-Agent value</a>.
+
+   <dt>"<code>processID</code>"
+   <dd>The main PID of the user agent as a <a>number</a>.
   </dl>
 
  <li><p>If <var>flags</var> contains "<code>http</code>", add the


### PR DESCRIPTION
Closes https://github.com/w3c/webdriver/issues/1823

As discussed in the issue, returning the main PID of the browser will allow us to do accessibility testing of platform accessibility APIs exposed by the browser. Otherwise, we have to rely on the browser name, which is less reliable.

This value obviously cannot be used for matching and only is an returned value.

It doesn't look like there is precedent for this, but I wonder if this should be optional capability, in case there is a reason to no return the PID?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Igalia/webdriver/pull/1833.html" title="Last updated on Jul 24, 2024, 4:47 PM UTC (172882a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1833/7a23ea0...Igalia:172882a.html" title="Last updated on Jul 24, 2024, 4:47 PM UTC (172882a)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1833)
<!-- Reviewable:end -->
