### PR TITLE
Add url to contributor name

### DIFF
--- a/index.html
+++ b/index.html
@@ -11512,7 +11512,7 @@ This standard is authored by
 <!-- Simon Stewart --> <a href=http://www.rocketpoweredjetpants.com/>Simon Stewart</a>,
 <!-- Sri Harsha --> Sri Harsha,
 <!-- Titus Fortner --> Titus Fortner,
-<!-- Vangelis Katsikaros --> and Vangelis Katsikaros.
+<!-- Vangelis Katsikaros --> and <a href=http://www.vkatsikaros.com/>Vangelis Katsikaros</a>.
 
 <!-- ~~~ end sort ~~~ -->
 


### PR DESCRIPTION
I noticed I hadn't a url against my name, now adding.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/vkatsikaros/webdriver/pull/1846.html" title="Last updated on Oct 22, 2024, 2:24 PM UTC (14364fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1846/db06684...vkatsikaros:14364fe.html" title="Last updated on Oct 22, 2024, 2:24 PM UTC (14364fe)">Diff</a>