### PR TITLE
Input events dispatch to top-level frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -8339,12 +8339,14 @@ from a machine utilisation perspective.
  input JSON, such that the actions to be performed in a single <a>tick</a>
  are grouped together.
 
-<p>To <dfn>get parent offset</dfn> of <var>context</var>:
+ <p>To <dfn>get parent offset</dfn> of <var>context</var>:
  <ol class="algorithm">
   <li>Let <var>offsetLeft</var> equal to 0 and <var>offsetTop</var> equal to 0.
   </li>
-  Let <var>navigable</var> be <var>context</var>'s <a>active document</a>'s
-  [=navigable/parent=].  </p></li>
+  <li>
+   Let <var>navigable</var> be <var>context</var>'s <a>active document</a>'s
+   [=navigable/parent=].
+  </li>
   <li>Let <var>parent navigable</var> be <var>navigable</var>'s parent.</li>
   <li>If <var>parent navigable</var> is not null:
    <ol>
@@ -8375,10 +8377,11 @@ from a machine utilisation perspective.
      <code>offsetTop</code>.
     </li>
    </ol>
+  </li>
   <li>Return (<var>offsetLeft</var>, <var>offsetTop</var>).</li>
-  <span class=issue>TODO: clarify if the algo respect transforms?</span>
-  <span class=issue>TODO: respect iframe's viewport's intersections</span>
-</ol>
+ </ol>
+ <span class=issue>TODO: clarify if the algo respect transforms?</span>
+ <span class=issue>TODO: respect iframe's viewport's intersections</span>
 
 <p>To <dfn>get coordinates relative to an origin</dfn>
 given <var>source</var>, <var>x offset</var>, <var>y offset</var>,

--- a/index.html
+++ b/index.html
@@ -2212,8 +2212,8 @@ sessions</a> will be the only entry.
  browsing context</dfn>, which is set to the parent of the <a>current
  browsing context</a> when changing browsing contexts, and an
  associated <dfn>current top-level browsing context</dfn>, which is
- set to the <a>top-level browsing context of</a> the <a>current browsing
- context</a>, when changing browsing contexts.</p>
+ set to the [=browsing context/top-level browsing context=] of the
+ <a>current browsing context</a>, when changing browsing contexts.</p>
 
 <p>An <a>HTTP session</a> has an associated <dfn>session
 timeouts</dfn> which is a <a>timeouts configuration</a>. This is
@@ -8286,10 +8286,10 @@ and <var>subtype</var>:
  content observable effects that must be consistent across
  implementations. To accommodate this, the specification requires
  that <a>remote ends</a> <dfn>perform implementation-specific action
- dispatch steps</dfn> on a <a>top-level browsing context of</a>
+ dispatch steps</dfn> on a [=browsing context/top-level browsing context=] of
  <var>context</var>, and a <var>list of events</var> and their properties.
  These steps must be equivalent to performing the given input device
- manipulations on the <a>top-level browsing context of</a> the
+ manipulations on the [=browsing context/top-level browsing context=] of the
  <var>context</var>, such that trusted events corresponding to the entries in
  <var>list of events</var> are dispatched.
 
@@ -11743,7 +11743,7 @@ to automatically sort each list alphabetically.
    <!-- Simple dialogs --> <li><dfn data-lt="simple dialog"><a href=https://html.spec.whatwg.org/#simple-dialogs>Simple dialogs</a></dfn>
    <!-- Steps to fire beforeunload --> <li><dfn><a href=https://html.spec.whatwg.org/#steps-to-fire-beforeunload>Steps to fire beforeunload</a></dfn>
    <!-- Suffering from bad input --> <li><dfn><a href=https://html.spec.whatwg.org/#suffering-from-bad-input>Suffering from bad input</a></dfn>
-   <!-- Top-level browsing context of --> <li><dfn><a href=https://html.spec.whatwg.org/#bc-tlbc>Top-level browsing context of</a></dfn>
+   <!-- Top-level browsing context --> <li><dfn data-dfn-for="browsing context"><a href=https://html.spec.whatwg.org/#bc-tlbc>Top-level browsing context</a></dfn>
    <!-- Traverse the history by a delta --> <li><dfn><a href=https://html.spec.whatwg.org/#traverse-the-history-by-a-delta>Traverse the history by a delta</a></dfn>
    <!-- Unfocusing steps --><li><dfn><a href=https://html.spec.whatwg.org/#unfocusing-steps>unfocusing steps</a></dfn>
    <!-- User prompt --> <li><dfn data-lt="user prompts"><a href=https://html.spec.whatwg.org/#user-prompts>User prompt</a></dfn>

--- a/index.html
+++ b/index.html
@@ -8289,8 +8289,9 @@ and <var>subtype</var>:
  dispatch steps</dfn> on a <a>browsing context</a> <var>context</var>,
  and a <var>list of events</var> and their properties. These steps
  must be equivalent to performing the given input device manipulations
- on <var>context</var>, such that trusted events corresponding to the
- entries in <var>list of events</var>are dispatched.
+ on the top-browsing context ancestor of the <var>context</var>, such
+ that trusted events corresponding to the entries in <var>list of events</var>
+ are dispatched.
 
 <aside class=note>
  <p>The list of events is not comprehensive; in particular the default

--- a/index.html
+++ b/index.html
@@ -8353,7 +8353,7 @@ from a machine utilisation perspective.
     <li> Let <var>parent context</var> be <var>parent navigable</var>'s
      [=navigable/document=]'s [=document/browsing context=].
     </li>
-    <li>Let <code>(parentOffsetLeft, parentOffsetTop)</code> be result of
+    <li>Let <code>(parentOffsetLeft, parentOffsetTop)</code> be the result of
      [=get parent offset=] of <var>parent context</var>.
     </li>
     <li>Add <code>parentOffsetLeft</code> to <code>offsetLeft</code>.</li>

--- a/index.html
+++ b/index.html
@@ -8286,11 +8286,11 @@ and <var>subtype</var>:
  content observable effects that must be consistent across
  implementations. To accommodate this, the specification requires
  that <a>remote ends</a> <dfn>perform implementation-specific action
- dispatch steps</dfn> on a [=browsing context/top-level browsing context=] of
- <var>context</var>, and a <var>list of events</var> and their properties.
- These steps must be equivalent to performing the given input device
- manipulations on the [=browsing context/top-level browsing context=] of the
- <var>context</var>, such that trusted events corresponding to the entries in
+ dispatch steps</dfn> on a <var>context</var>, and a <var>list of events</var>
+ and their properties. These steps must be equivalent to performing the given
+ input device manipulations on the
+ [=browsing context/top-level browsing context=] of the <var>context</var>,
+ such that trusted events corresponding to the entries in
  <var>list of events</var> are dispatched.
 
 <aside class=note>
@@ -8339,6 +8339,45 @@ from a machine utilisation perspective.
  input JSON, such that the actions to be performed in a single <a>tick</a>
  are grouped together.
 
+<p>To <dfn>get parent offset</dfn> of <var>context</var>:
+ <ol class="algorithm">
+  <li>Let <var>offsetLeft</var> equal to 0 and <var>offsetTop</var> equal to 0.
+  </li>
+  Let <var>navigable</var> be <var>context</var>'s <a>active document</a>'s
+  [=navigable/parent=].  </p></li>
+  <li>Let <var>parent navigable</var> be <var>navigable</var>'s parent.</li>
+  <li>If <var>parent navigable</var> is not null:
+   <ol>
+    <li> Let <var>parent context</var> be <var>parent navigable</var>'s
+     [=navigable/document=]'s [=document/browsing context=].
+    </li>
+    <li>Let <code>(parentOffsetLeft, parentOffsetTop)</code> be result of
+     [=get parent offset=] of <var>parent context</var>.
+    </li>
+    <li>Add <code>parentOffsetLeft</code> to <code>offsetLeft</code>.</li>
+    <li>Add <code>parentOffsetTop</code> to <code>offsetTop</code>.</li>
+    <li>Let <var>containerElement</var> be an <a>element</a> which <a>navigable
+     container</a> presents <var>parent navigable</var>.
+    </li>
+    <li>Let <code>containerRect</code> be the result of calling
+     {{Element/getBoundingClientRect()}} of <var>containerElement</var>.
+    </li>
+    <li>Let <code>borderLeftWidth</code> be the computed [=border-left-width=]
+     of <code>containerElement</code> in <a>CSS pixels</a>.
+    </li>
+    <li>Let <code>borderTopWidth</code> be the computed [=border-top-width=] of
+     <code>containerElement</code> in <a>CSS pixels</a>.
+    </li>
+    <li>Add <code>containerRect.left</code> + <code>borderLeftWidth</code> to
+     <code>offsetLeft</code>.
+    </li>
+    <li>Add <code>containerRect.top</code> + <code>borderTopWidth</code> to
+     <code>offsetTop</code>.
+    </li>
+   </ol>
+  <li>Return (<var>offsetLeft</var>, <var>offsetTop</var>).</li>
+  <span class=issue>The algo does not respect transforms</span>
+</ol>
 
 <p>To <dfn>get coordinates relative to an origin</dfn>
 given <var>source</var>, <var>x offset</var>, <var>y offset</var>,
@@ -8346,6 +8385,8 @@ given <var>source</var>, <var>x offset</var>, <var>y offset</var>,
 options</var>:
 
 <ol class="algorithm">
+ <li>Let <code>(parentOffsetLeft, parentOffsetTop)</code> be result of
+  [=get parent offset=] of <var>browsing context</var>.</li>
  <li><p>Run the substeps of the first matching value
   of <var>origin</var>
   <dl>
@@ -8393,7 +8434,7 @@ options</var>:
    </dd>
   </dl>
 
- <li><p>Return (<var>x</var>, <var>y</var>)
+ <li><p>Return (<var>x</var> + <var>parentOffsetLeft</var>, <var>y</var> + <var>parentOffsetTop</var>)
 </ol>
 
 <p>To <dfn>extract an action sequence</dfn> given
@@ -11715,6 +11756,7 @@ to automatically sort each list alphabetically.
    <!-- Dirty value flag --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-dirty>Dirty value flag</a></dfn>
    <!-- Disabled --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-element-disabled>Actually disabled</a></dfn>
    <!-- Document readiness --> <li><dfn><a href=https://html.spec.whatwg.org/#current-document-readiness>Document readiness</a></dfn>
+   <!-- Document's browsing context --> <li><dfn data-dfn-for="document"><a href=https://html.spec.whatwg.org/#concept-document-bc>Browsing context</a></dfn>
    <!-- Element contexts --> <li><dfn data-lt="element context"><a href=https://html.spec.whatwg.org/#concept-element-contexts>Element contexts</a></dfn>
    <!-- Enumerated attribute --> <li><dfn><a href=https://html.spec.whatwg.org/#enumerated-attribute>Enumerated attribute</a></dfn>
    <!-- Event loop --> <li><dfn><a href=https://html.spec.whatwg.org/#event-loop>Event loop</a></dfn>
@@ -11726,6 +11768,8 @@ to automatically sort each list alphabetically.
    <!-- Joint session history --> <li><dfn><a href=https://html.spec.whatwg.org/#joint-session-history>Joint session history</a></dfn>
    <!-- Mature (navigation) --> <li><dfn data-lt="matured"><a href=https://html.spec.whatwg.org/#concept-navigate-mature>Mature</a></dfn> navigation.
    <!-- Mutable --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-fe-mutable>Mutable</a></dfn>
+   <!-- Navigable's document --> <li><dfn data-dfn-for="navigable"><a href=https://html.spec.whatwg.org/#nav-document>Document</a></dfn>
+   <!-- Navigable's parent --> <li><dfn data-dfn-for="navigable"><a href=https://html.spec.whatwg.org/#nav-parent>Parent</a></dfn>
    <!-- Navigate --> <li><dfn data-lt="navigating|navigation"><a href=https://html.spec.whatwg.org/#navigate>Navigate</a></dfn>
    <!-- Origin-clean --> <li><dfn><a href=https://html.spec.whatwg.org/#concept-canvas-origin-clean>Origin-clean</a></dfn>
    <!-- Overridden reload --> <li><dfn><a href="https://html.spec.whatwg.org/multipage/dom.html#an-overridden-reload">An overridden reload</a></dfn>
@@ -11870,6 +11914,15 @@ to automatically sort each list alphabetically.
    <!-- absolute lengths --> <li><dfn><a href=https://www.w3.org/TR/css-values-3/#absolute-lengths>absolute lengths</a></dfn>
    <!-- CSS pixels --> <li><dfn><a href=https://www.w3.org/TR/css-values-3/#px>CSS pixels</a></dfn>
   </ul>
+
+ <dd>The following properties are defined in
+  the CSS Backgrounds and Borders Module Level 3: [[CSS3-BACKGROUND]]
+   <ul>
+    <!-- border-left-width property --> <li>The <dfn><a href=https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width><code>border-left-width</code></a></dfn> property
+   </ul>
+   <ul>
+    <!-- border-top-width property --> <li>The <dfn><a href=https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width><code>border-top-width</code></a></dfn> property
+   </ul>
 
  <dd>The following properties are defined in
   the CSS Basic Box Model Level 3 specification: [[CSS3-BOX]]

--- a/index.html
+++ b/index.html
@@ -8376,7 +8376,8 @@ from a machine utilisation perspective.
     </li>
    </ol>
   <li>Return (<var>offsetLeft</var>, <var>offsetTop</var>).</li>
-  <span class=issue>The algo does not respect transforms</span>
+  <span class=issue>TODO: clarify if the algo respect transforms?</span>
+  <span class=issue>TODO: respect iframe's viewport's intersections</span>
 </ol>
 
 <p>To <dfn>get coordinates relative to an origin</dfn>

--- a/index.html
+++ b/index.html
@@ -2212,7 +2212,7 @@ sessions</a> will be the only entry.
  browsing context</dfn>, which is set to the parent of the <a>current
  browsing context</a> when changing browsing contexts, and an
  associated <dfn>current top-level browsing context</dfn>, which is
- set to the top-browsing context ancestor of the <a>current browsing
+ set to the <a>top-level browsing context of</a> the <a>current browsing
  context</a>, when changing browsing contexts.</p>
 
 <p>An <a>HTTP session</a> has an associated <dfn>session
@@ -8286,12 +8286,12 @@ and <var>subtype</var>:
  content observable effects that must be consistent across
  implementations. To accommodate this, the specification requires
  that <a>remote ends</a> <dfn>perform implementation-specific action
- dispatch steps</dfn> on a <a>browsing context</a> <var>context</var>,
- and a <var>list of events</var> and their properties. These steps
- must be equivalent to performing the given input device manipulations
- on the top-browsing context ancestor of the <var>context</var>, such
- that trusted events corresponding to the entries in <var>list of events</var>
- are dispatched.
+ dispatch steps</dfn> on a <a>top-level browsing context of</a>
+ <var>context</var>, and a <var>list of events</var> and their properties.
+ These steps must be equivalent to performing the given input device
+ manipulations on the <a>top-level browsing context of</a> the
+ <var>context</var>, such that trusted events corresponding to the entries in
+ <var>list of events</var> are dispatched.
 
 <aside class=note>
  <p>The list of events is not comprehensive; in particular the default
@@ -11743,6 +11743,7 @@ to automatically sort each list alphabetically.
    <!-- Simple dialogs --> <li><dfn data-lt="simple dialog"><a href=https://html.spec.whatwg.org/#simple-dialogs>Simple dialogs</a></dfn>
    <!-- Steps to fire beforeunload --> <li><dfn><a href=https://html.spec.whatwg.org/#steps-to-fire-beforeunload>Steps to fire beforeunload</a></dfn>
    <!-- Suffering from bad input --> <li><dfn><a href=https://html.spec.whatwg.org/#suffering-from-bad-input>Suffering from bad input</a></dfn>
+   <!-- Top-level browsing context of --> <li><dfn><a href=https://html.spec.whatwg.org/#bc-tlbc>Top-level browsing context of</a></dfn>
    <!-- Traverse the history by a delta --> <li><dfn><a href=https://html.spec.whatwg.org/#traverse-the-history-by-a-delta>Traverse the history by a delta</a></dfn>
    <!-- Unfocusing steps --><li><dfn><a href=https://html.spec.whatwg.org/#unfocusing-steps>unfocusing steps</a></dfn>
    <!-- User prompt --> <li><dfn data-lt="user prompts"><a href=https://html.spec.whatwg.org/#user-prompts>User prompt</a></dfn>

--- a/index.html
+++ b/index.html
@@ -8389,7 +8389,7 @@ given <var>source</var>, <var>x offset</var>, <var>y offset</var>,
 options</var>:
 
 <ol class="algorithm">
- <li>Let <code>(parentOffsetLeft, parentOffsetTop)</code> be result of
+ <li>Let <code>(parentOffsetLeft, parentOffsetTop)</code> be the result of
   [=get parent offset=] of <var>browsing context</var>.</li>
  <li><p>Run the substeps of the first matching value
   of <var>origin</var>


### PR DESCRIPTION
As discussed in https://github.com/w3c/webdriver-bidi/issues/795, the actions should be dispatched from the top-level browsing context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1847.html" title="Last updated on Oct 24, 2024, 8:08 AM UTC (adf94ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1847/db06684...adf94ad.html" title="Last updated on Oct 24, 2024, 8:08 AM UTC (adf94ad)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1847)
<!-- Reviewable:end -->
