### PR TITLE
Raise "no such window" error in "dispatching actions" when browsing context (navigable) does no longer exist

### DIFF
--- a/index.html
+++ b/index.html
@@ -9161,6 +9161,9 @@ context</var>, and <var>actions options</var>:
   <var>actions by tick</var>:
 
   <ol>
+   <li>If <var>browsing context</var> is <a>no longer open</a>, return
+    <a>error</a> with <a>error code</a> <a>no such window</a>.
+
    <li><p>Let <var>tick duration</var> be the result of <a>computing
     the tick duration</a> with argument <var>tick actions</var>.
 


### PR DESCRIPTION
Basically any single action could cause the current (top-level) browsing context to get closed eg. clicking or pressing a key for an element that calls `window.close()`. The following action in the sequence needs to fail with a `no such window` error.

I'm going to add tests for classic and BiDi over on https://bugzilla.mozilla.org/show_bug.cgi?id=1932916.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1861.html" title="Last updated on Nov 27, 2024, 3:48 PM UTC (c58363c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1861/db06684...whimboo:c58363c.html" title="Last updated on Nov 27, 2024, 3:48 PM UTC (c58363c)">Diff</a>