### PR TITLE
Allow `file` prompt type

### DIFF
--- a/index.html
+++ b/index.html
@@ -10481,7 +10481,7 @@ The <dfn>known prompt handlers</dfn> are:
 
 <p>The <dfn>valid prompt types</dfn> are «"<code>alert</code>",
 "<code>beforeUnload</code>", "<code>confirm</code>",
-"<code>default</code>", "<code>prompt</code>"».
+"<code>default</code>", "<code>fileUpload</code>", "<code>prompt</code>"».
 
 <p class="note">The "<code>default</code>" type represents a fallback
 when no specific handler is defined for a given prompt type, including
@@ -10496,6 +10496,9 @@ the internal type "<code>fallbackDefault</code>". The
 allow the "<code>beforeUnload</code>" handler to be customized, and enabling
 other protocols isn&apos;t expected to change the user prompt handling as a
 side effect.
+
+<p class="note">The "<code>fileUpload</code>" prompt type is respected only in
+[[WebDriver-BiDi]] sessions.
 
 <p>To <dfn>deserialize as an unhandled prompt behavior</dfn> given
 argument <var>value</var>:

--- a/index.html
+++ b/index.html
@@ -10481,7 +10481,7 @@ The <dfn>known prompt handlers</dfn> are:
 
 <p>The <dfn>valid prompt types</dfn> are «"<code>alert</code>",
 "<code>beforeUnload</code>", "<code>confirm</code>",
-"<code>default</code>", "<code>fileDialog</code>", "<code>prompt</code>"».
+"<code>default</code>", "<code>file</code>", "<code>prompt</code>"».
 
 <p class="note">The "<code>default</code>" type represents a fallback
 when no specific handler is defined for a given prompt type, including
@@ -10497,7 +10497,7 @@ allow the "<code>beforeUnload</code>" handler to be customized, and enabling
 other protocols isn&apos;t expected to change the user prompt handling as a
 side effect.
 
-<p class="note">The "<code>fileDialog</code>" prompt type is respected only in
+<p class="note">The "<code>file</code>" prompt type is respected only in
 [[WebDriver-BiDi]] sessions.
 
 <p>To <dfn>deserialize as an unhandled prompt behavior</dfn> given

--- a/index.html
+++ b/index.html
@@ -10481,7 +10481,7 @@ The <dfn>known prompt handlers</dfn> are:
 
 <p>The <dfn>valid prompt types</dfn> are «"<code>alert</code>",
 "<code>beforeUnload</code>", "<code>confirm</code>",
-"<code>default</code>", "<code>fileUpload</code>", "<code>prompt</code>"».
+"<code>default</code>", "<code>fileDialog</code>", "<code>prompt</code>"».
 
 <p class="note">The "<code>default</code>" type represents a fallback
 when no specific handler is defined for a given prompt type, including
@@ -10497,7 +10497,7 @@ allow the "<code>beforeUnload</code>" handler to be customized, and enabling
 other protocols isn&apos;t expected to change the user prompt handling as a
 side effect.
 
-<p class="note">The "<code>fileUpload</code>" prompt type is respected only in
+<p class="note">The "<code>fileDialog</code>" prompt type is respected only in
 [[WebDriver-BiDi]] sessions.
 
 <p>To <dfn>deserialize as an unhandled prompt behavior</dfn> given


### PR DESCRIPTION
Allow for `file` prompt type in capabilities.

Required for https://github.com/w3c/webdriver-bidi/pull/883.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1884.html" title="Last updated on Feb 25, 2025, 12:15 PM UTC (2b36293)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1884/a67669c...2b36293.html" title="Last updated on Feb 25, 2025, 12:15 PM UTC (2b36293)">Diff</a>