### PR TITLE
Corrects the use of an before Number to a for proper grammar.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8994,7 +8994,7 @@ item</var>, <var>action</var>, and <var>actions options</var>:</p>
   of <a>getting the property</a> <code>y</code>
   from <var>action item</var>.
 
- <li><p>If <var>y</var> is not an <a>Number</a>, return <a>error</a>
+ <li><p>If <var>y</var> is not a <a>Number</a>, return <a>error</a>
   with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>Set the <code>y</code> property of <var>action</var>


### PR DESCRIPTION
Sorry but my ocd had to do it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/GeorgiosVeropoulos/webdriver/pull/1896.html" title="Last updated on May 12, 2025, 9:01 PM UTC (26c1e65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1896/6b43932...GeorgiosVeropoulos:26c1e65.html" title="Last updated on May 12, 2025, 9:01 PM UTC (26c1e65)">Diff</a>