### PR TITLE
Remove FTP proxy which is no longer supported by browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1619,15 +1619,6 @@ with a "<code>moz:</code>" prefix:
  </tr>
 
  <tr>
-  <td><code>ftpProxy</code>
-  <td>string
-  <td>Defines the proxy <a>host</a> for FTP traffic when
-   the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>host and optional port</a> for
-   scheme "<code>ftp</code>".
- </tr>
-
- <tr>
   <td><code>httpProxy</code>
   <td>string
   <td>Defines the proxy <a>host</a> for HTTP traffic when


### PR DESCRIPTION
Fixes #1900.

https://github.com/w3c/webdriver-bidi/pull/932 is the WebDriver-BiDi equivalent.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1901.html" title="Last updated on Jun 11, 2025, 6:48 AM UTC (d3440ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1901/b8a7cdb...whimboo:d3440ec.html" title="Last updated on Jun 11, 2025, 6:48 AM UTC (d3440ec)">Diff</a>