### PR TITLE
Fix Typo of "Find Element From Shadow Root" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -5302,7 +5302,7 @@ variables</var> and <var>parameters</var> are:
   <li><p>If <var>selector</var> is <a>undefined</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
-  <li><p>If the <var>ssession</var>&apos;s <a>current browsing
+  <li><p>If <var>session</var>&apos;s <a>current browsing
   context</a> is <a>no longer open</a>, return <a>error</a>
   with <a>error code</a> <a>no such window</a>.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yezhizhen/webdriver/pull/1904.html" title="Last updated on Jun 20, 2025, 4:42 AM UTC (6bad0f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1904/87062f7...yezhizhen:6bad0f5.html" title="Last updated on Jun 20, 2025, 4:42 AM UTC (6bad0f5)">Diff</a>