### PR TITLE
Added note about possibility of capping the cookie expiry value

### DIFF
--- a/index.html
+++ b/index.html
@@ -7631,6 +7631,11 @@ variables</var> and <var>parameters</var> are:
    <dd><p>The value if the entry exists, otherwise leave unset to
     indicate that this is a session cookie.
 
+    <aside class=note>
+      <p>The cookie&apos;s expiry value might be limited by the remote end in
+       accordance with the <a>Cookie Lifetime Limits</a>.
+    </aside>
+
    <dt><a>Cookie same site</a>
    <dd><p>The value if the entry exists, otherwise leave unset to
     indicate that no same site policy is defined.
@@ -7638,7 +7643,6 @@ variables</var> and <var>parameters</var> are:
 
   <p>If there is an <a>error</a> during this step,
    return <a>error</a> with <a>error code</a> <a>unable to set cookie</a>.
-
 
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
@@ -11821,8 +11825,9 @@ to automatically sort each list alphabetically.
 
 <dd><p>The following terms are defined in the Same Site Cookie specification: [[RFC6265bis]]
   <ul>
-    <!-- lax --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-06#section-4.1.2.7"><code>Lax</code></a></dfn>
-    <!-- strict --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-06#section-4.1.2.7"><code>Strict</code></a></dfn>
+    <!-- Cookie Lifetime Limits --> <li><dfn><a href=https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-20#cookie-lifetime-limits>Cookie Lifetime Limits</a></dfn>
+    <!-- lax --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-20#section-4.1.2.7"><code>Lax</code></a></dfn>
+    <!-- strict --> <li><dfn><a href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-20#section-4.1.2.7"><code>Strict</code></a></dfn>
   </ul>
 
  <dd><p>The following terms are defined in


### PR DESCRIPTION
Remote ends can cap the expiry value to a certain amount of days in the future. For now this is only listed in https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-cookie-lifetime-limits so do we need to add a new reference?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1907.html" title="Last updated on Jul 1, 2025, 10:31 AM UTC (4d93620)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1907/6dc16d1...whimboo:4d93620.html" title="Last updated on Jul 1, 2025, 10:31 AM UTC (4d93620)">Diff</a>