### PR TITLE
[Set Window Rect] Change parameter requirement from Number to Integer and range to "maximum safe integer"

### DIFF
--- a/index.html
+++ b/index.html
@@ -4058,11 +4058,11 @@ variables</var> and <var>parameters</var> are:
  <li><p>If <var>y</var> is <a>undefined</a>, let <var>y</var> be null.
 
  <li><p>If <var>width</var> or <var>height</var> is neither null, nor
-  an integer from 0 to 2<sup>31</sup> − 1, return <a>error</a>
+  an integer from 0 to <a>maximum safe integer</a>, return <a>error</a>
   with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>If <var>x</var> or <var>y</var> is neither null, nor
-  an integer from −(2<sup>31</sup>) to 2<sup>31</sup> − 1,
+  an integer from <a>minimum safe integer</a> to <a>maximum safe integer</a>,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>If the <a>remote end</a> does not support
@@ -11658,6 +11658,7 @@ to automatically sort each list alphabetically.
    <!-- Boolean type --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-4.3.14>Boolean</a></dfn> type
    <!-- List --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-8.8>List</a></dfn>
    <!-- Max Safe Integer --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer>maximum safe integer</a></dfn>
+   <!-- Min Safe Integer --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/6.0/#sec-number.min_safe_integer>minimum safe integer</a></dfn>
    <!-- null --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-4.3.11><code>null</code></a></dfn>
    <!-- Number --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-4.3.19>Number</a></dfn>
    <!-- Object --> <li><dfn><a href=https://www.ecma-international.org/ecma-262/5.1/#sec-4.2.1>Object</a></dfn>

--- a/index.html
+++ b/index.html
@@ -4058,11 +4058,11 @@ variables</var> and <var>parameters</var> are:
  <li><p>If <var>y</var> is <a>undefined</a>, let <var>y</var> be null.
 
  <li><p>If <var>width</var> or <var>height</var> is neither null, nor
-  a <a>Number</a> from 0 to 2<sup>31</sup> − 1, return <a>error</a>
+  an integer from 0 to 2<sup>31</sup> − 1, return <a>error</a>
   with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>If <var>x</var> or <var>y</var> is neither null, nor
-  a <a>Number</a> from −(2<sup>31</sup>) to 2<sup>31</sup> − 1,
+  an integer from −(2<sup>31</sup>) to 2<sup>31</sup> − 1,
   return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>If the <a>remote end</a> does not support


### PR DESCRIPTION
The spec says [Number](https://w3c.github.io/webdriver/#dfn-number), which is "double-precision 64-bit binary format IEEE 754 value". But the wpt test below clearly requires integer.

https://github.com/web-platform-tests/wpt/blob/b281d07f3ead48995b9a2e94259d292e22cd5dd9/webdriver/tests/classic/set_window_rect/set.py#L41-L49

This PR adds definition of [minimum safe integer](https://www.ecma-international.org/ecma-262/6.0/#sec-number.min_safe_integer) and change the valid range of parameter.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yezhizhen/webdriver/pull/1909.html" title="Last updated on Jul 8, 2025, 7:41 AM UTC (4c1d591)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1909/c1a2419...yezhizhen:4c1d591.html" title="Last updated on Jul 8, 2025, 7:41 AM UTC (4c1d591)">Diff</a>