### PR TITLE
Add new category for typeable form controls with normalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -6400,6 +6400,13 @@ and a number keypad for [^input^] elements
 in the <a><code>number</code> state</a> on non-desktop devices.
 </div>
 
+<p>
+A <dfn>typeable form control with normalization</dfn> 
+is an [^input^] element 
+whose [^input/type^] attribute state 
+requires that user-provided values be normalized before being assigned to the element's value attribute.
+This applies to <code>type="date"</code> and <code>type="datetime-local"</code>.
+
 <p>The <a>key input source</a> used for input may be cleared mid-way
  through “typing” by sending the <dfn>null key</dfn>, which is U+E000
  (NULL).
@@ -6740,6 +6747,28 @@ variables</var> and <var>parameters</var> are:
       an <a>error</a> with <a>error code</a> <a>element not
       interactable</a>.
 
+     <li><p><a>Set a property</a> <code>value</code> to <var>text</var>
+      on <var>element</var>.
+
+     <li><p>If <var>element</var> is <a>suffering from bad input</a>
+      return an <a>error</a> with <a>error code</a> <a>invalid
+      argument</a>.
+
+     <li><p>Return <a>success</a> with data <a><code>null</code></a>.
+    </ol>
+   </dd>
+
+   <dt><var><a>element</a></var> is a <a>typeable form control with normalization</a>
+   <dd>
+    <ol>
+     <li><p>If <var>element</var> does not have an <a>own property</a>
+      named <code>value</code> return an <a>error</a> with <a>error
+      code</a> <a>element not interactable</a>
+
+     <li><p>If <var>element</var> is not <a>mutable</a> return
+      an <a>error</a> with <a>error code</a> <a>element not
+      interactable</a>.
+     <li><p>Normalize the <code>value</code> to conform to the expected input format of <var>element</var>.
      <li><p><a>Set a property</a> <code>value</code> to <var>text</var>
       on <var>element</var>.
 


### PR DESCRIPTION
There looks to be a popular demand for normalized date and datetime-local as seen in [1470](https://github.com/w3c/webdriver/issues/1470) and [42322342](https://issues.chromium.org/issues/42322342).
This introduces a new category to make the expected behavior explicit.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Holo-xy/webdriver/pull/1910.html" title="Last updated on Jul 6, 2025, 11:43 PM UTC (f8c808c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1910/c1a2419...Holo-xy:f8c808c.html" title="Last updated on Jul 6, 2025, 11:43 PM UTC (f8c808c)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1910)
<!-- Reviewable:end -->
