### PR TITLE
Fix wrong link for `source` in Dispatch Tick Actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -9241,7 +9241,7 @@ context</var>, and <var>actions options</var>:
    <li><p>Let <var>source</var> be the result of <a>get an input
     source</a> given <var>input state</var> and <var>input id</var>.
 
-   <li><p>Assert: <a>source</a> is not undefined.
+   <li><p>Assert: <var>source</var> is not undefined.
 
    <li><p>Let <var>global key state</var> be the result of <a>get the
    global key state</a> with <var>input state</var>.


### PR DESCRIPTION
Previously, this points us to https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element
But it really means the variable. And it created a redundant entry "source element" in https://w3c.github.io/webdriver/#index-defined-elsewhere


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yezhizhen/webdriver/pull/1913.html" title="Last updated on Jul 17, 2025, 6:35 AM UTC (08bf809)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1913/3055808...yezhizhen:08bf809.html" title="Last updated on Jul 17, 2025, 6:35 AM UTC (08bf809)">Diff</a>