### PR TITLE
Fix wrong link for first element of `getClientRects`

### DIFF
--- a/index.html
+++ b/index.html
@@ -4585,7 +4585,7 @@ and <var>element</var> is:
 
 <ol>
  <li><p>Let <var>rectangle</var> be
-  the first <a>element</a> of the {{DOMRect}} sequence
+  the first element of the {{DOMRect}} sequence
   returned by calling {{Element/getClientRects()}} on <a><var>element</var></a>.
 
  <li><p>Let <var>left</var> be


### PR DESCRIPTION
Previously the `element` leads us to https://dom.spec.whatwg.org/#concept-element. But it really means the first item of the array.