### PR TITLE
Element in-view: Fix circular definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -4580,8 +4580,7 @@ and <var>element</var> is:
  that is the intersection between
  the element&apos;s first {{DOMRect}} of {{Element/getClientRects()}}
  and the <a>initial viewport</a>.
- Given an <a>element</a> that is known to be <a>in view</a>,
- it can be calculated this way:
+ It can be calculated this way:
 
 <ol>
  <li><p>Let <var>rectangle</var> be


### PR DESCRIPTION
Currently, the definition of [element is in-view](https://w3c.github.io/webdriver/#dfn-in-view) needs to compute [pointer-interactive paint tree](https://w3c.github.io/webdriver/#dfn-pointer-interactable-paint-tree), whose step 4 computes [in-view center point](https://w3c.github.io/webdriver/#dfn-center-point), which again requires [element is in-view](https://w3c.github.io/webdriver/#dfn-in-view)!

But actually we can safely remove the in-view requirement of  [in-view center point](https://w3c.github.io/webdriver/#dfn-center-point), as step 5 of compute [pointer-interactive paint tree](https://w3c.github.io/webdriver/#dfn-pointer-interactable-paint-tree) feed center point to [elementsFromPoint](https://drafts.csswg.org/cssom-view/#dom-document-elementsfrompoint), which simply return a empty sequence if input is not in viewport.

As a result, we have empty [pointer-interactive paint tree](https://w3c.github.io/webdriver/#dfn-pointer-interactable-paint-tree) meaning that element is not in-view.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yezhizhen/webdriver/pull/1918.html" title="Last updated on Aug 18, 2025, 3:18 AM UTC (2850417)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1918/718c424...yezhizhen:2850417.html" title="Last updated on Aug 18, 2025, 3:18 AM UTC (2850417)">Diff</a>