### PR TITLE
Allow for specifying schema in "proxy"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1621,7 +1621,7 @@ with a "<code>moz:</code>" prefix:
  <tr>
   <td><code>httpProxy</code>
   <td>string
-  <td>Defines the proxy <a>host</a> for HTTP traffic when
+  <td>Defines the proxy configuration for HTTP traffic when
    the <a><code>proxyType</code></a> is "<code>manual</code>".
   <td>A <a>proxy specifier</a> for "<code>http</code>".
  </tr>
@@ -1637,7 +1637,7 @@ with a "<code>moz:</code>" prefix:
  <tr>
   <td><code>sslProxy</code>
   <td>string
-  <td>Defines the proxy <a>host</a> for encrypted TLS traffic
+  <td>Defines the proxy configuration for encrypted TLS traffic
    when the <a><code>proxyType</code></a> is "<code>manual</code>".
   <td>A <a>proxy specifier</a> "<code>https</code>".
  </tr>
@@ -1645,7 +1645,7 @@ with a "<code>moz:</code>" prefix:
  <tr>
   <td><code>socksProxy</code>
   <td>string
-  <td>Defines the proxy <a>host</a> for SOCKS traffic when the
+  <td>Defines the proxy configuration for SOCKS traffic when the
    <a><code>proxyType</code></a> is "<code>manual</code>".
   <td>A <a>proxy specifier</a> for "<code>socks</code>".
  </tr>

--- a/index.html
+++ b/index.html
@@ -1645,21 +1645,37 @@ with a "<code>moz:</code>" prefix:
  <tr>
   <td><code>socksProxy</code>
   <td>string
-  <td>Defines the proxy <a>host</a> for a <a>SOCKS proxy</a>
-   when the <a><code>proxyType</code></a> is "<code>manual</code>".
+  <td>Defines the proxy <a>host</a> for SOCKS traffic when the
+   <a><code>proxyType</code></a> is "<code>manual</code>".
   <td>A <a>proxy url</a>.
  </tr>
 
+ <tr>
+  <td><code>socksVersion</code>
+  <td>number
+  <td>Defines the <a>SOCKS proxy</a> version when the <a>proxy url</a>'s
+   <a>proxy scheme</a> is "<code>socks</code>".
+  <td>Any <a>integer</a> between 0 and 255 inclusive.
+  </tr>
+
 </table>
 
-<p>A <dfn>proxy url</dfn> consists of an optional <a>proxy scheme</a>
-followed by the string "<code>://</code>", a valid <a>host</a>,
-and optionally a colon followed by a valid <a>port</a>. The <a>host</a>
-may <a data-lt="includes credentials">include credentials</a>. If the
-  <var>scheme</var> is omitted, the <var>scheme</var> is implied to be
-  "<code>http</code>". If the port is omitted and <var>scheme</var> has a
-  <a>default port</a>, this is the implied port. Otherwise, the port is left
-  undefined.
+<p>A <dfn>proxy url</dfn> can be either "<code>direct</code>" or a string
+ consists of an optional <a>proxy scheme</a> <var>scheme</var> followed by the
+ string "<code>://</code>", a valid <a>host</a> <var>host</var>, and optionally
+ a colon followed by a valid <a>port</a> <var>port</var>.
+
+ <ol>
+ <li><p>The <var>host</var> may
+  <a data-lt="includes credentials">include credentials</a>.
+ <li><p>If the <var>port</var> is omitted and <var>scheme</var> has a
+  <a>default port</a>, this is the implied port. Otherwise, the <var>port</var>
+  is left undefined.
+
+ <li><p>If the <var>scheme</var> is omitted and the <var>port</var> is 443,
+  the <var>scheme</var> is implied to be "<code>https</code>". Otherwise, the
+  <var>scheme</var> is implied to be "<code>http</code>".
+ </ol>
 
 <p>A <dfn>proxy scheme</dfn> is defined as being one of the following strings:
  "<code>http</code>", "<code>https</code>", "<code>socks</code>",
@@ -1716,10 +1732,10 @@ may <a data-lt="includes credentials">include credentials</a>. If the
   <a>own property</a> for "<code>proxyAutoconfigUrl</code>" return
   an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
- <li><p>If <var>proxy</var> has an <a>own property</a> for
-  "<code>socksProxy</code>" and does not have an <a>own property</a>
-  for "<code>socksVersion</code>" return an <a>error</a> with <a>error
-  code</a> <a>invalid argument</a>.
+ <li><p>If <var>proxy</var> contains <a>proxy url</a> with <a>proxy scheme</a>
+  "<code>socks</code>" and does not have an <a>own property</a>
+  for "<code>socksVersion</code>", return an <a>error</a> with <a>error code</a>
+  <a>invalid argument</a>.
 
  <li><p>Return <a>success</a> with data <var>proxy</var>.
 </ol>

--- a/index.html
+++ b/index.html
@@ -1652,16 +1652,16 @@ with a "<code>moz:</code>" prefix:
 
 </table>
 
-<p>A <dfn>proxy url</dfn> consists of an optional <a>proxy scheme</a> 
-followed by the string "<code>://</code>", a valid <a>host</a>, 
-and optionally a colon followed by a valid <a>port</a>. The <a>host</a> 
+<p>A <dfn>proxy url</dfn> consists of an optional <a>proxy scheme</a>
+followed by the string "<code>://</code>", a valid <a>host</a>,
+and optionally a colon followed by a valid <a>port</a>. The <a>host</a>
 may <a data-lt="includes credentials">include credentials</a>. If the
   <var>scheme</var> is omitted, the <var>scheme</var> is implied to be
   "<code>http</code>". If the port is omitted and <var>scheme</var> has a
   <a>default port</a>, this is the implied port. Otherwise, the port is left
   undefined.
 
-<p>A <dfn>proxy schema</dfn> is defined as being one of the following strings:
+<p>A <dfn>proxy scheme</dfn> is defined as being one of the following strings:
  "<code>http</code>", "<code>https</code>", "<code>socks</code>",
  "<code>socks4</code>", "<code>socks5</code>".
 

--- a/index.html
+++ b/index.html
@@ -1623,8 +1623,7 @@ with a "<code>moz:</code>" prefix:
   <td>string
   <td>Defines the proxy <a>host</a> for HTTP traffic when
    the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>host and optional port</a> for
-   scheme "<code>http</code>".
+  <td>A <a>proxy url</a>.
  </tr>
 
  <tr>
@@ -1640,8 +1639,7 @@ with a "<code>moz:</code>" prefix:
   <td>string
   <td>Defines the proxy <a>host</a> for encrypted TLS traffic
    when the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>host and optional port</a> for
-   scheme "<code>https</code>".
+  <td>A <a>proxy url</a>.
  </tr>
 
  <tr>
@@ -1649,7 +1647,7 @@ with a "<code>moz:</code>" prefix:
   <td>string
   <td>Defines the proxy <a>host</a> for a <a>SOCKS proxy</a>
    when the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>host and optional port</a> with an <a>undefined</a> scheme.
+  <td>A <a>proxy url</a>.
  </tr>
 
  <tr>
@@ -1662,12 +1660,14 @@ with a "<code>moz:</code>" prefix:
 
 </table>
 
-<p>A <dfn>host and optional port</dfn> for a <var>scheme</var> is
-  defined as being a valid <a>host</a>, optionally followed by a colon
-  and a valid <a>port</a>. The <a>host</a> may
+<p>A <dfn>proxy url</dfn> is a valid <a>host</a>, optionally followed by a colon
+  and a valid <a>port</a>, and optionally prefixed by a <var>scheme</var> and
+  "<code>://</code>" string. The <a>host</a> may
   <a data-lt="includes credentials">include credentials</a>. If the
-  port is omitted and <var>scheme</var> has a <a>default port</a>,
-  this is the implied port. Otherwise, the port is left undefined.
+  <var>scheme</var> is omitted, the <var>scheme</var> is implied to be
+  "<code>http</code>". If the port is omitted and <var>scheme</var> has a
+  <a>default port</a>, this is the implied port. Otherwise, the port is left
+  undefined.
 
 <p>A <a><code>proxyType</code></a> of "<code>direct</code>" indicates
  that the browser should not use a proxy at all.

--- a/index.html
+++ b/index.html
@@ -1623,7 +1623,7 @@ with a "<code>moz:</code>" prefix:
   <td>string
   <td>Defines the proxy <a>host</a> for HTTP traffic when
    the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>proxy url</a>.
+  <td>A <a>proxy url</a> for "<code>http</code>".
  </tr>
 
  <tr>
@@ -1639,7 +1639,7 @@ with a "<code>moz:</code>" prefix:
   <td>string
   <td>Defines the proxy <a>host</a> for encrypted TLS traffic
    when the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>proxy url</a>.
+  <td>A <a>proxy url</a> "<code>https</code>".
  </tr>
 
  <tr>
@@ -1647,7 +1647,7 @@ with a "<code>moz:</code>" prefix:
   <td>string
   <td>Defines the proxy <a>host</a> for SOCKS traffic when the
    <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>proxy url</a>.
+  <td>A <a>proxy url</a> for "<code>socks</code>".
  </tr>
 
  <tr>
@@ -1660,21 +1660,38 @@ with a "<code>moz:</code>" prefix:
 
 </table>
 
-<p>A <dfn>proxy url</dfn> can be either "<code>direct</code>" or a string
- consists of an optional <a>proxy scheme</a> <var>scheme</var> followed by the
- string "<code>://</code>", a valid <a>host</a> <var>host</var>, and optionally
- a colon followed by a valid <a>port</a> <var>port</var>.
+ <p>A <dfn>proxy url</dfn> for <a>proxy scheme</a> <var>protocol</var> can be
+  either "<code>direct</code>" or a string consists of an optional
+  <a>proxy scheme</a> <var>scheme</var> followed by the string
+  "<code>://</code>", a valid <a>host</a> <var>host</var>, and optionally a
+  colon followed by a valid <a>port</a> <var>port</var>.
 
- <ol>
- <li><p>The <var>host</var> may
-  <a data-lt="includes credentials">include credentials</a>.
- <li><p>If the <var>port</var> is omitted and <var>scheme</var> has a
-  <a>default port</a>, this is the implied port. Otherwise, the <var>port</var>
-  is left undefined.
+  <p class=note>There <var>scheme</var> can be different from
+   <var>protocol</var>. If so it means that the <var>protocol</var> traffic will
+   be proxied via <var>scheme</var>.
 
- <li><p>If the <var>scheme</var> is omitted and the <var>port</var> is 443,
-  the <var>scheme</var> is implied to be "<code>https</code>". Otherwise, the
-  <var>scheme</var> is implied to be "<code>http</code>".
+  <ol>
+  <li><p>If <var>scheme</var> is omitted, let <var>scheme</var> be null.
+
+  <li><p>If <var>scheme</var> is null and <var>port</var> is <code>80</code>,
+   let <var>scheme</var> be "<code>http</code>".
+
+  <li><p>If <var>scheme</var> is null and <var>port</var> is <code>443</code>,
+   let <var>scheme</var> be "<code>https</code>".
+
+  <li><p>If <var>scheme</var> is null and <var>port</var> is <code>1080</code>,
+   let <var>scheme</var> be "<code>socks</code>".
+
+  <li><p>If <var>scheme</var> is null, let <var>scheme</var> be
+   <var>protocol</var>.
+
+  <li><p>If <var>scheme</var> is "<code>http</code>" or "<code>https</code>",
+    the <var>host</var> may
+    <a data-lt="includes credentials">include credentials</a>.
+
+  <li><p>If the <var>port</var> is omitted and <var>scheme</var> has a
+    <a>default port</a>, this is the implied port. Otherwise, the <var>port</var>
+    is left undefined.
  </ol>
 
 <p>A <dfn>proxy scheme</dfn> is defined as being one of the following strings:

--- a/index.html
+++ b/index.html
@@ -1673,15 +1673,6 @@ with a "<code>moz:</code>" prefix:
   <ol>
   <li><p>If <var>scheme</var> is omitted, let <var>scheme</var> be null.
 
-  <li><p>If <var>scheme</var> is null and <var>port</var> is <code>80</code>,
-   let <var>scheme</var> be "<code>http</code>".
-
-  <li><p>If <var>scheme</var> is null and <var>port</var> is <code>443</code>,
-   let <var>scheme</var> be "<code>https</code>".
-
-  <li><p>If <var>scheme</var> is null and <var>port</var> is <code>1080</code>,
-   let <var>scheme</var> be "<code>socks</code>".
-
   <li><p>If <var>scheme</var> is null, let <var>scheme</var> be
    <var>protocol</var>.
 

--- a/index.html
+++ b/index.html
@@ -1623,7 +1623,7 @@ with a "<code>moz:</code>" prefix:
   <td>string
   <td>Defines the proxy <a>host</a> for HTTP traffic when
    the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>proxy url</a> for "<code>http</code>".
+  <td>A <a>proxy specifier</a> for "<code>http</code>".
  </tr>
 
  <tr>
@@ -1639,7 +1639,7 @@ with a "<code>moz:</code>" prefix:
   <td>string
   <td>Defines the proxy <a>host</a> for encrypted TLS traffic
    when the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>proxy url</a> "<code>https</code>".
+  <td>A <a>proxy specifier</a> "<code>https</code>".
  </tr>
 
  <tr>
@@ -1647,21 +1647,21 @@ with a "<code>moz:</code>" prefix:
   <td>string
   <td>Defines the proxy <a>host</a> for SOCKS traffic when the
    <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>proxy url</a> for "<code>socks</code>".
+  <td>A <a>proxy specifier</a> for "<code>socks</code>".
  </tr>
 
  <tr>
   <td><code>socksVersion</code>
   <td>number
-  <td>Defines the <a>SOCKS proxy</a> version when the <a>proxy url</a>'s
+  <td>Defines the <a>SOCKS proxy</a> version when the <a>proxy specifier</a>'s
    <a>proxy scheme</a> is "<code>socks</code>".
   <td>Any <a>integer</a> between 0 and 255 inclusive.
   </tr>
 
 </table>
 
- <p>A <dfn>proxy url</dfn> for <a>proxy scheme</a> <var>protocol</var> can be
-  either "<code>direct</code>" or a string consists of an optional
+ <p>A <dfn>proxy specifier</dfn> for <a>proxy scheme</a> <var>protocol</var> can
+  be either "<code>direct</code>" or a string consists of an optional
   <a>proxy scheme</a> <var>scheme</var> followed by the string
   "<code>://</code>", a valid <a>host</a> <var>host</var>, and optionally a
   colon followed by a valid <a>port</a> <var>port</var>.
@@ -1749,10 +1749,10 @@ with a "<code>moz:</code>" prefix:
   <a>own property</a> for "<code>proxyAutoconfigUrl</code>" return
   an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
- <li><p>If <var>proxy</var> contains <a>proxy url</a> with <a>proxy scheme</a>
-  "<code>socks</code>" and does not have an <a>own property</a>
-  for "<code>socksVersion</code>", return an <a>error</a> with <a>error code</a>
-  <a>invalid argument</a>.
+ <li><p>If <var>proxy</var> contains <a>proxy specifier</a> with
+  <a>proxy scheme</a> "<code>socks</code>" and does not have an
+  <a>own property</a> for "<code>socksVersion</code>", return an <a>error</a>
+  with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>Return <a>success</a> with data <var>proxy</var>.
 </ol>

--- a/index.html
+++ b/index.html
@@ -1645,24 +1645,8 @@ with a "<code>moz:</code>" prefix:
  <tr>
   <td><code>socksProxy</code>
   <td>string
-  <td>(deprecated) defines the proxy <a>host</a> for a <a>SOCKS proxy</a>
+  <td>Defines the proxy <a>host</a> for a <a>SOCKS proxy</a>
    when the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>A <a>proxy url</a>.
- </tr>
-
- <tr>
-  <td><code>socksVersion</code>
-  <td>number
-  <td>(deprecated) defines the <a>SOCKS proxy</a> version
-   when the <a><code>proxyType</code></a> is "<code>manual</code>".
-  <td>Any <a>integer</a> between 0 and 255 inclusive.
-  </tr>
-
- <tr>
-  <td><code>other</code>
-  <td>string
-  <td>Defines the proxy for traffic which is not HTTP nor TLS
-    when the <a><code>proxyType</code></a> is "<code>manual</code>".
   <td>A <a>proxy url</a>.
  </tr>
 

--- a/index.html
+++ b/index.html
@@ -1645,7 +1645,7 @@ with a "<code>moz:</code>" prefix:
  <tr>
   <td><code>socksProxy</code>
   <td>string
-  <td>Defines the proxy <a>host</a> for a <a>SOCKS proxy</a>
+  <td>(deprecated) defines the proxy <a>host</a> for a <a>SOCKS proxy</a>
    when the <a><code>proxyType</code></a> is "<code>manual</code>".
   <td>A <a>proxy url</a>.
  </tr>
@@ -1653,21 +1653,33 @@ with a "<code>moz:</code>" prefix:
  <tr>
   <td><code>socksVersion</code>
   <td>number
-  <td>Defines the <a>SOCKS proxy</a> version
+  <td>(deprecated) defines the <a>SOCKS proxy</a> version
    when the <a><code>proxyType</code></a> is "<code>manual</code>".
   <td>Any <a>integer</a> between 0 and 255 inclusive.
   </tr>
 
+ <tr>
+  <td><code>other</code>
+  <td>string
+  <td>Defines the proxy for traffic which is not HTTP nor TLS
+    when the <a><code>proxyType</code></a> is "<code>manual</code>".
+  <td>A <a>proxy url</a>.
+ </tr>
+
 </table>
 
 <p>A <dfn>proxy url</dfn> is a valid <a>host</a>, optionally followed by a colon
-  and a valid <a>port</a>, and optionally prefixed by a <var>scheme</var> and
-  "<code>://</code>" string. The <a>host</a> may
+  and a valid <a>port</a>, and optionally prefixed by a <a>proxy schema</a>
+  <var>scheme</var> and "<code>://</code>" string. The <a>host</a> may
   <a data-lt="includes credentials">include credentials</a>. If the
   <var>scheme</var> is omitted, the <var>scheme</var> is implied to be
   "<code>http</code>". If the port is omitted and <var>scheme</var> has a
   <a>default port</a>, this is the implied port. Otherwise, the port is left
   undefined.
+
+<p>A <dfn>proxy schema</dfn> is defined as being one of the following strings:
+ "<code>http</code>", "<code>https</code>", "<code>socks4</code>",
+ "<code>socks5</code>".
 
 <p>A <a><code>proxyType</code></a> of "<code>direct</code>" indicates
  that the browser should not use a proxy at all.

--- a/index.html
+++ b/index.html
@@ -1652,10 +1652,10 @@ with a "<code>moz:</code>" prefix:
 
 </table>
 
-<p>A <dfn>proxy url</dfn> is an optional <a>proxy schema</a> and
-  "<code>://</code>" string, followed by a valid <a>host</a>, optionally
-  followed by a colon and a valid <a>port</a>. The <a>host</a> may
-  <a data-lt="includes credentials">include credentials</a>. If the
+<p>A <dfn>proxy url</dfn> consists of an optional <a>proxy scheme</a> 
+followed by the string "<code>://</code>", a valid <a>host</a>, 
+and optionally a colon followed by a valid <a>port</a>. The <a>host</a> 
+may <a data-lt="includes credentials">include credentials</a>. If the
   <var>scheme</var> is omitted, the <var>scheme</var> is implied to be
   "<code>http</code>". If the port is omitted and <var>scheme</var> has a
   <a>default port</a>, this is the implied port. Otherwise, the port is left

--- a/index.html
+++ b/index.html
@@ -1652,9 +1652,9 @@ with a "<code>moz:</code>" prefix:
 
 </table>
 
-<p>A <dfn>proxy url</dfn> is a valid <a>host</a>, optionally followed by a colon
-  and a valid <a>port</a>, and optionally prefixed by a <a>proxy schema</a>
-  <var>scheme</var> and "<code>://</code>" string. The <a>host</a> may
+<p>A <dfn>proxy url</dfn> is an optional <a>proxy schema</a> and
+  "<code>://</code>" string, followed by a valid <a>host</a>, optionally
+  followed by a colon and a valid <a>port</a>. The <a>host</a> may
   <a data-lt="includes credentials">include credentials</a>. If the
   <var>scheme</var> is omitted, the <var>scheme</var> is implied to be
   "<code>http</code>". If the port is omitted and <var>scheme</var> has a
@@ -1662,8 +1662,8 @@ with a "<code>moz:</code>" prefix:
   undefined.
 
 <p>A <dfn>proxy schema</dfn> is defined as being one of the following strings:
- "<code>http</code>", "<code>https</code>", "<code>socks4</code>",
- "<code>socks5</code>".
+ "<code>http</code>", "<code>https</code>", "<code>socks</code>",
+ "<code>socks4</code>", "<code>socks5</code>".
 
 <p>A <a><code>proxyType</code></a> of "<code>direct</code>" indicates
  that the browser should not use a proxy at all.

--- a/index.html
+++ b/index.html
@@ -1666,9 +1666,9 @@ with a "<code>moz:</code>" prefix:
   "<code>://</code>", a valid <a>host</a> <var>host</var>, and optionally a
   colon followed by a valid <a>port</a> <var>port</var>.
 
-  <p class=note>There <var>scheme</var> can be different from
-   <var>protocol</var>. If so it means that the <var>protocol</var> traffic will
-   be proxied via <var>scheme</var>.
+  <p class=note>The <var>scheme</var> can be different from <var>protocol</var>.
+   If so, it means that the <var>protocol</var> traffic will be proxied via
+   <var>scheme</var>.
 
   <ol>
   <li><p>If <var>scheme</var> is omitted, let <var>scheme</var> be null.

--- a/index.html
+++ b/index.html
@@ -1677,12 +1677,12 @@ with a "<code>moz:</code>" prefix:
    <var>protocol</var>.
 
   <li><p>If <var>scheme</var> is "<code>http</code>" or "<code>https</code>",
-    the <var>host</var> may
-    <a data-lt="includes credentials">include credentials</a>.
+   the <var>host</var> may
+   <a data-lt="includes credentials">include credentials</a>.
 
   <li><p>If the <var>port</var> is omitted and <var>scheme</var> has a
-    <a>default port</a>, this is the implied port. Otherwise, the <var>port</var>
-    is left undefined.
+   <a>default port</a>, then <a>remote end</a> should use this port. Otherwise,
+   the <var>port</var> is left undefined.
  </ol>
 
 <p>A <dfn>proxy scheme</dfn> is defined as being one of the following strings:


### PR DESCRIPTION
Addressing https://github.com/w3c/webdriver/issues/1920.

Currently, WebDriver capabilities allow for configuring proxy by protocol. Meaning the protocol traffic can be proxied via the same protocol proxy.

Chromium can proxy traffic via different proxy protocols, and can configure which proxy to use for which protocol. In Chromium, the possible proxy schemas are `http`, `https`, `socks4`, `socks5`. Also user can configure separately proxy for `HTTP`, `HTTPS` and all other requests (`SOCKS`).

In order to allow for such configurations, we propose the following:
* Allow for schemas (`http`, `https`, `socks`, `socks4`, `socks5`) in the proxy url.

Here is the details list of options can be provided in the capabilities:

### `http` proxy
The list of cases, when the proxy is connected with HTTP protocol:
* **(existing)** `httpProxy: proxy.com`. The traffic type is used, as not scheme, nor port were set.
* **(existing)** `httpProxy: proxy.com:123`. The traffic type is used, as scheme was not set, and the port is not standard for any supported proxy protocol.
* **(new)** `sslProxy: http://proxy.com`. The scheme has priority over traffic type.
* **(new)** `socksProxy: http://proxy.com`. The scheme has priority over traffic type. `socksVersion` is not required.
* **(new)** `sslProxy: http://proxy.com:443`. The scheme has priority over port and traffic type.
* **(new)** `socksProxy: http://proxy.com:443`. The scheme has priority over port and traffic type. `socksVersion` is not required.
* **(new)** `sslProxy: proxy.com:80`. The port has priority over traffic type.
* **(new)** `socksProxy: proxy.com:80`. The port has priority over traffic type. `socksVersion` is not required.

### `https` proxy
The list of cases, when the proxy is connected with SSL protocol:
* **(existing)** `httpsProxy: proxy.com`. The traffic type is used, as not scheme, nor port were set.
* **(existing)** `httpsProxy: proxy.com:123`. The traffic type is used, as scheme was not set, and the port is not standard for any supported proxy protocol.
* **(new)** `httpProxy: https://proxy.com`. The scheme has priority over traffic type.
* **(new)** `socksProxy: https://proxy.com`. The scheme has priority over traffic type. `socksVersion` is not required.
* **(new)** `httpProxy: https://proxy.com:80`. The scheme has priority over port and traffic type.
* **(new)** `socksProxy: https://proxy.com:80`. The scheme has priority over port and traffic type. `socksVersion` is not required.
* **(new)** `httpProxy: proxy.com:443`. The port has priority over traffic type.
* **(new)** `socksProxy: proxy.com:443`. The port has priority over traffic type. `socksVersion` is not required.

### `socks` proxy
The list of cases, when the proxy is connected with SOCKS protocol:
* **(existing)** `socksProxy: proxy.com` + `socksVersion: 4/5`. The traffic type is used, as not scheme, nor port were set.
* **(existing)** `socksProxy: proxy.com:123` + `socksVersion: 4/5`. The traffic type is used, as scheme was not set, and the port is not standard for any supported proxy protocol.
* **(new)** `httpProxy: socks://proxy.com` + `socksVersion: 4/5`. The scheme has priority over traffic type.
* **(new)** `httpProxy: socks4://proxy.com`. The scheme has priority over traffic type. `socksVersion` is part of scheme.
* **(new)** `httpProxy: socks5://proxy.com`. The scheme has priority over traffic type. `socksVersion` is part of scheme.
* **(new)** `sslProxy: socks://proxy.com` + `socksVersion: 4/5`. The scheme has priority over traffic type.
* **(new)** `sslProxy: socks4://proxy.com`. The scheme has priority over traffic type. `socksVersion` is part of scheme.
* **(new)** `sslProxy: socks5://proxy.com`. The scheme has priority over traffic type. `socksVersion` is part of scheme.
* **(new)** `httpProxy: socks://proxy.com:80` + `socksVersion: 4/5`. The scheme has priority over port and traffic type.
* **(new)** `httpProxy: socks4://proxy.com:80`. The scheme has priority over port and traffic type. `socksVersion` is part of scheme.
* **(new)** `httpProxy: socks5://proxy.com:80`. The scheme has priority over port and traffic type. `socksVersion` is part of scheme.
* **(new)** `sslProxy: socks://proxy.com:80` + `socksVersion: 4/5`. The scheme has priority over port and traffic type.
* **(new)** `sslProxy: socks4://proxy.com:80`. The scheme has priority over port and traffic type. `socksVersion` is part of scheme.
* **(new)** `sslProxy: socks5://proxy.com:80`. The scheme has priority over port and traffic type. `socksVersion` is part of scheme.
* **(new)** `httpProxy: proxy.com:1080` + `socksVersion: 4/5`. The port has priority over traffic type.
* **(new)** `sslProxy: proxy.com:1080` + `socksVersion: 4/5`. The port has priority over traffic type.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1922.html" title="Last updated on Dec 23, 2025, 1:24 PM UTC (e370abf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1922/7528e5c...e370abf.html" title="Last updated on Dec 23, 2025, 1:24 PM UTC (e370abf)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1922)
<!-- Reviewable:end -->
