### PR TITLE
Fix description of computing pointer-interactable paint tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -4695,13 +4695,13 @@ and <var>element</var> is:
  is produced this way:
 
 <ol>
- <li><p>If <var>element</var> is <a>not in the same tree</a>
+ <li><p>If <a><var>element</var></a> is <a>not in the same tree</a>
   as <var>session</var>&apos;s <a>current browsing context</a>&apos;s
   <a>active document</a>, return an empty sequence.
 
  <li><p>Let <var>rectangles</var> be
   the {{DOMRect}} sequence
-  returned by calling {{Element/getClientRects()}}.
+  returned by calling {{Element/getClientRects()}} on <a><var>element</var></a>.
 
  <!--
   An element which style property `display` is "none"
@@ -4711,7 +4711,7 @@ and <var>element</var> is:
   return an empty sequence.
 
  <li><p>Let <var>center point</var> be the <a>in-view center point</a>
-  of the first indexed element in <var>rectangles</var>.
+  of <a><var>element</var></a>.
 
  <li><p>Return the <a>elements from point</a>
   given the coordinates <var>center point</var>.

--- a/index.html
+++ b/index.html
@@ -4690,18 +4690,18 @@ and <var>element</var> is:
   </select>
 </aside>
 
-<p>An <var><a>element</a></var>&apos;s
+<p>An <a>element</a>&apos;s
  <dfn>pointer-interactable paint tree</dfn>
  is produced this way:
 
 <ol>
- <li><p>If <a><var>element</var></a> is <a>not in the same tree</a>
+ <li><p>If |element| is <a>not in the same tree</a>
   as <var>session</var>&apos;s <a>current browsing context</a>&apos;s
   <a>active document</a>, return an empty sequence.
 
  <li><p>Let <var>rectangles</var> be
   the {{DOMRect}} sequence
-  returned by calling {{Element/getClientRects()}} on <a><var>element</var></a>.
+  returned by calling {{Element/getClientRects()}} on |element|.
 
  <!--
   An element which style property `display` is "none"
@@ -4711,7 +4711,7 @@ and <var>element</var> is:
   return an empty sequence.
 
  <li><p>Let <var>center point</var> be the <a>in-view center point</a>
-  of <a><var>element</var></a>.
+  of |element|.
 
  <li><p>Return the <a>elements from point</a>
   given the coordinates <var>center point</var>.

--- a/index.html
+++ b/index.html
@@ -4690,7 +4690,7 @@ and <var>element</var> is:
   </select>
 </aside>
 
-<p>An <a>element</a>&apos;s
+<p>An <a>element</a> |element|&apos;s
  <dfn>pointer-interactable paint tree</dfn>
  is produced this way:
 


### PR DESCRIPTION
The step of [in-view center point](https://w3c.github.io/webdriver/#dfn-center-point) already computes the first object of `getClientRects` on element. This PR makes the description more accurate.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yezhizhen/webdriver/pull/1927.html" title="Last updated on May 7, 2026, 9:02 AM UTC (974fd42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1927/785bc01...yezhizhen:974fd42.html" title="Last updated on May 7, 2026, 9:02 AM UTC (974fd42)">Diff</a>