### PR TITLE
Pass `subtype` to "create an input source"

### DIFF
--- a/index.html
+++ b/index.html
@@ -8197,7 +8197,7 @@ optional <var>subtype</var>:
 
   <li><p>If <var>source</var> is undefined, set <var>source</var> to
   the result of <a>trying</a> to <a>create an input source</a>
-  with <var>input state</var> and <var>type</var>.
+  with <var>input state</var>, <var>type</var> and <var>subtype</var>.
 
  <li><p>Return success with data <var>source</var>.</p></li>
 </ol>

--- a/index.html
+++ b/index.html
@@ -10297,7 +10297,7 @@ variables</var> and <var>parameters</var> are:
 
  <li><p>Let <var>actions by tick</var> be the result of <a>trying</a>
   to <a>extract an action sequence</a> with <var>input state</var>,
-  <var>parameters</var>, and <var>actions options</var>.
+  <var>parameters</var>, <var>actions options</var> and optional <var>subtype</var>.
 
  <li><p><a>Dispatch actions</a> with <var>input state</var>,
   <var>actions by tick</var>, <a>current browsing context</a>,

--- a/index.html
+++ b/index.html
@@ -8425,8 +8425,8 @@ options</var>:
   <ol>
    <li><p>Let <var>source actions</var> be the result of <a>trying</a>
     to <a>process an input source action sequence</a> given <var>input
-    state</var>, <var>action sequence</var>, and <var>actions
-    options</var>.
+    state</var>, <var>action sequence</var>, <var>actions
+    options</var> and optional <var>subtype</var>.
 
    <li><p>For each <var>action</var> in <var>source actions</var>:
 
@@ -8450,8 +8450,8 @@ options</var>:
 
 <p>When required to <dfn>process an input source action
  sequence</dfn>, given <var>input state</var>, <var>action
- sequence</var>, and <var>actions options</var>, a <a>remote end</a>
- must:
+ sequence</var>, and <var>actions options</var>, and optional <var>subtype</var>, 
+ a <a>remote end</a> must:
 
 <ol class="algorithm">
  <li><p>Let <var>type</var> be the result of <a>getting a property</a>


### PR DESCRIPTION
`subtype` is given in the context but never used.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yezhizhen/webdriver/pull/1929.html" title="Last updated on Sep 14, 2026, 8:34 AM UTC (e2643d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1929/14b5637...yezhizhen:e2643d6.html" title="Last updated on Sep 14, 2026, 8:34 AM UTC (e2643d6)">Diff</a>