### PR TITLE
Script execution: Throw error for invalid reference argument

### DIFF
--- a/index.html
+++ b/index.html
@@ -3391,6 +3391,9 @@ here needs to be rewritten. -->
     the <a>web frame identifier</a> property
     from <var>object</var>.
 
+  <li><p>If <var>reference</var> is not a <a>String</a>,
+    return an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
   <li><p>Let <var>browsing context</var> be the <a>browsing context</a> whose
     <a>window handle</a> is <var>reference</var>, or null if no such
     <a>browsing context</a> exists.
@@ -3413,6 +3416,9 @@ here needs to be rewritten. -->
     <a data-lt="getting a property">getting</a>
     the <a>web window identifier</a> property
     from <var>object</var>.
+
+  <li><p>If <var>reference</var> is not a <a>String</a>,
+    return an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
   <li>
     <p>Let <var>browsing context</var> be the <a>browsing context</a> whose
@@ -4475,6 +4481,9 @@ and <var>element</var> is:
   <a data-lt="getting a property">getting</a> the <a>web element
   identifier</a> property from <var>object</var>.
 
+ <li><p>If <var>reference</var> is not a <a>String</a>,
+  return an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
+
  <li><p>Let <var>element</var> be the result
   of <a>trying</a> to <a>get a known element</a>
   with <var>session</var> and <var>reference</var>.
@@ -4784,6 +4793,9 @@ and <var>element</var> is:
    <a data-lt="getting a property">getting</a>
    the <a>shadow root identifier</a> property
    from <var>object</var>.
+
+  <li><p>If <var>reference</var> is not a <a>String</a>,
+   return an <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
   <li><p>Let <var>shadow</var> be the result
    of <a>trying</a> to <a>get a known shadow root</a>


### PR DESCRIPTION
According to spec, the window/frame/element/shadow root reference must be String.

1. Let node id be a new globally unique string. (https://w3c.github.io/webdriver/#dfn-get-or-create-a-node-reference)
2. Each [browsing context](https://w3c.github.io/webdriver/#dfn-browsing-contexts) has an associated window handle which uniquely identifies it. This must be a [String](https://w3c.github.io/webdriver/#dfn-string) and must not be "current".

However, current spec does not report error for this, even though there are tests created 2 years ago
https://github.com/web-platform-tests/wpt/blob/427276cdcaf28068aa1a2dae9206f03df716d367/webdriver/tests/classic/execute_async_script/arguments.py#L165-L167 for this.

This PR add the step to throw error if reference is not string.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yezhizhen/webdriver/pull/1931.html" title="Last updated on Oct 18, 2025, 7:16 AM UTC (569337c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1931/a101f0a...yezhizhen:569337c.html" title="Last updated on Oct 18, 2025, 7:16 AM UTC (569337c)">Diff</a>