### PR TITLE
Upgrade Selenium atoms to revision 775cfb33b193eb8832cd5488f298006f45254685

### DIFF
--- a/index.html
+++ b/index.html
@@ -11878,10 +11878,10 @@ to automatically sort each list alphabetically.
  <dt>Selenium
  <dd>The following functions are defined within
   the <a href=https://selenium.dev>Selenium</a> project, at
-  revision <code>33c6b7841a59aaaad55744909c0600f066fd5593</code>.
+  revision <code>775cfb33b193eb8832cd5488f298006f45254685</code>.
   <ul>
-    <!-- bot.dom.getVisibleText --> <li><dfn><a href=https://github.com/SeleniumHQ/selenium/blob/a6b161a159c3d581b130f03a2e6e35f577f38dec/javascript/atoms/dom.js#L1007><code>bot.dom.getVisibleText</code></a></dfn>
-    <!-- bot.dom.isShown --> <li><dfn><a href=https://github.com/SeleniumHQ/selenium/blob/a6b161a159c3d581b130f03a2e6e35f577f38dec/javascript/atoms/dom.js#L573><code>bot.dom.isShown</code></a></dfn>
+    <!-- bot.dom.getVisibleText --> <li><dfn><a href=https://github.com/SeleniumHQ/selenium/blob/775cfb33b193eb8832cd5488f298006f45254685/javascript/atoms/dom.js#L1005><code>bot.dom.getVisibleText</code></a></dfn>
+    <!-- bot.dom.isShown --> <li><dfn><a href=https://github.com/SeleniumHQ/selenium/blob/775cfb33b193eb8832cd5488f298006f45254685/javascript/atoms/dom.js#L573><code>bot.dom.isShown</code></a></dfn>
   </ul>
 
  <dt>Styling


### PR DESCRIPTION
There was a bug in the Selenium atoms for `bot.dom.getVisibleText()`. It finally got fixed and we should update our atoms to as well fix it in WebDriver classic clients.

For the update in Firefox I'm working on https://bugzilla.mozilla.org/show_bug.cgi?id=1986392, and as well added a new test case for the wdspec tests.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/whimboo/webdriver/pull/1932.html" title="Last updated on Oct 22, 2025, 8:09 AM UTC (efbcd96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1932/00a6484...whimboo:efbcd96.html" title="Last updated on Oct 22, 2025, 8:09 AM UTC (efbcd96)">Diff</a>