### PR TITLE
Remove inaccurate algorithm step

### DIFF
--- a/index.html
+++ b/index.html
@@ -7301,9 +7301,6 @@ variables</var> and <var>parameters</var> are:
     <li><p>Let <var>scriptPromise</var> be <a>PromiseResolve</a>(<a>Promise</a>,
       <var>scriptResult</var>.[[\Value]]).
 
-    <li><p>Upon fulfillment of <var>scriptPromise</var> with value <var>v</var>,
-      <a>resolve</a> <var>promise</var> with value <var>v</var>.
-
     <li><p>Upon rejection of <var>scriptPromise</var> with value <var>r</var>,
       <a>reject</a> <var>promise</var> with value <var>r</var>.
   </ol>


### PR DESCRIPTION
In modern implementations of this specification (the latest releases of Firefox, Chrome, and Safari), a returned thenable only impacts execution if it represents a Promise that is rejected prior to the invocation of the script's callback function. Fulfillment values are ignored in all cases.

---

I'm working on a fix for gh-1436. I'd like to correct this bug first (if it is indeed a bug) so that that fix can be more focused.

Relevant WPT tests: https://github.com/web-platform-tests/wpt/pull/57160


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bocoup/webdriver/pull/1939.html" title="Last updated on Jan 14, 2026, 6:11 PM UTC (ecc2b9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1939/7528e5c...bocoup:ecc2b9a.html" title="Last updated on Jan 14, 2026, 6:11 PM UTC (ecc2b9a)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1939)
<!-- Reviewable:end -->
