### PR TITLE
Element Clear: Explicitly states `keyboard-interactable`

### DIFF
--- a/index.html
+++ b/index.html
@@ -6347,7 +6347,7 @@ variables</var> and <var>parameters</var> are:
  or <var>timer</var>&apos;s [=timer/timeout fired flag=] to be set,
  whichever occurs first.
 
- <li><p>If <var>element</var> is not <a>interactable</a>,
+ <li><p>If <var>element</var> is not <a>keyboard-interactable</a>,
   return <a>error</a> with <a>error code</a> <a>element not interactable</a>.
 
  <li><p>Run the substeps of the first matching statement:


### PR DESCRIPTION
This should really be [`keyboard-interactable`](https://w3c.github.io/webdriver/#dfn-keyboard-interactable) instead of [`interactable`](https://w3c.github.io/webdriver/#dfn-interactable)  to be logically correct, since
a pointer-interactable but not keyboard-interactable element is interactable by definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yezhizhen/webdriver/pull/1942.html" title="Last updated on Jan 24, 2026, 7:23 AM UTC (f524d08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1942/7528e5c...yezhizhen:f524d08.html" title="Last updated on Jan 24, 2026, 7:23 AM UTC (f524d08)">Diff</a>