### PR TITLE
Element Clear: Check both keyboard-interactable and pointer-interactable

### DIFF
--- a/index.html
+++ b/index.html
@@ -6347,7 +6347,8 @@ variables</var> and <var>parameters</var> are:
  or <var>timer</var>&apos;s [=timer/timeout fired flag=] to be set,
  whichever occurs first.
 
- <li><p>If <var>element</var> is not <a>interactable</a>,
+<li><p>If <var>element</var> is not
+ <a>keyboard-interactable</a> or not<a>pointer-interactable</a>,
   return <a>error</a> with <a>error code</a> <a>element not interactable</a>.
 
  <li><p>Run the substeps of the first matching statement:


### PR DESCRIPTION
This matches the [test expectation](https://github.com/web-platform-tests/wpt/blob/6bd5b2ad9fe6e4f7908fb2b45b0989a3ad5b3ffa/webdriver/tests/classic/element_clear/clear.py#L119) and [Gecko implementation](https://searchfox.org/firefox-main/source/remote/marionette/interaction.sys.mjs#358).

Previous error detection can be false-negative, as a pointer-interactable but not keyboard-interactable element is [`interactable`](https://w3c.github.io/webdriver/#dfn-interactable) by definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yezhizhen/webdriver/pull/1943.html" title="Last updated on Mar 31, 2026, 3:55 PM UTC (36e9bed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1943/7528e5c...yezhizhen:36e9bed.html" title="Last updated on Mar 31, 2026, 3:55 PM UTC (36e9bed)">Diff</a>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1943)
<!-- Reviewable:end -->
