### PR TITLE
Add 'export' class to definition terms to be referenced in the Digital Credentials API

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@ It is acknowledged that this is complementary to the Evil Bit [[RFC3514]].
   a specific <a>intermediary node</a> and an <a>endpoint node</a> are
   said to be <dfn>upstream</dfn> of the <a>endpoint node</a>.
 
- <dt><dfn>Endpoint node</dfn>
+ <dt><dfn class="export">Endpoint node</dfn>
  <dd>An endpoint node is the final <a>remote end</a>
   in a chain of nodes that is not an <a>intermediary node</a>.
   The endpoint node is implemented by a user agent or a similar program.
@@ -1819,7 +1819,7 @@ with a "<code>moz:</code>" prefix:
  <li><p>Return <a>success</a> with data <a><code>null</code></a>.
 </ol>
 
-<p>When required to <dfn>validate capabilities</dfn> with
+<p>When required to <dfn class="export">validate capabilities</dfn> with
  argument <var>capabilities</var>:
 
 <ol>
@@ -1964,7 +1964,7 @@ with a "<code>moz:</code>" prefix:
 </aside>
 
 <p>
- When <dfn>matching capabilities</dfn> given
+ When <dfn class="export">matching capabilities</dfn> given
  JSON <a>Object</a> <var>capabilities</var>, and a <a>session
  configuration flags</a> <var>flags</var>, an <a>endpoint node</a>
  must take the following steps:


### PR DESCRIPTION
Edit: https://github.com/w3c-fedid/digital-credentials/pull/381

<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mohamedamir/webdriver/pull/1945.html" title="Last updated on Feb 6, 2026, 2:01 PM UTC (ba48df7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1945/8d7f8f8...mohamedamir:ba48df7.html" title="Last updated on Feb 6, 2026, 2:01 PM UTC (ba48df7)">Diff</a>