### PR TITLE
Add safePrintableInset parameter for printing.

### DIFF
--- a/index.html
+++ b/index.html
@@ -11313,6 +11313,14 @@ variables</var> and <var>parameters</var> are:
  <li><p>If <var>shrinkToFit</var> is not a <a>Boolean</a>
  return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
+ <li><p>Let <var>safePrintableInset</var> be the result of <a>getting a
+  property with default</a> named "<code>safePrintableInset</code>" and with
+  default <code>0</code> from <var>parameters</var>.
+
+ <li><p>If <var>safePrintableInset</var> is not a <a>Number</a>, or is a
+  negative number, return <a>error</a> with <a>error code</a> <a>invalid
+  argument</a>.
+
  <li><p>Let <var>pageRanges</var> be the result of <a>getting a
   property with default</a> named "<code>pageRanges</code>" from
   <var>parameters</var> with default of an

--- a/index.html
+++ b/index.html
@@ -11375,8 +11375,9 @@ variables</var> and <var>parameters</var> are:
    each page edge needed to steer clear of the area that the printer is potentially
    incapable of marking reliably. Most printers have a small region along each
    edge of the page sheet which is unprintable, typically due to the printer's
-   paper handling mechanism. The document that is being printed may have CSS rules
-   to adjust page margins based on this. TODO: Link to spec, when it has landed?
+   paper handling mechanism. The document that is being printed may have
+   <a href="https://drafts.csswg.org/css-page-3/#page-margin-safety">CSS rules</a>
+   to adjust page margins based on this.
 
   <li><p>If <var>pageRanges</var> is not an empty <a>Array</a>,
  Let <var>pages</var> be the result of <a>trying</a> to <a>parse a

--- a/index.html
+++ b/index.html
@@ -11317,9 +11317,8 @@ variables</var> and <var>parameters</var> are:
   property with default</a> named "<code>safePrintableInset</code>" and with
   default <code>0</code> from <var>parameters</var>.
 
- <li><p>If <var>safePrintableInset</var> is not a <a>Number</a>, or is a
-  negative number, return <a>error</a> with <a>error code</a> <a>invalid
-  argument</a>.
+ <li><p>If <var>safePrintableInset</var> is not a <a>Number</a>, or is less than 0,
+ return <a>error</a> with <a>error code</a> <a>invalid argument</a>.
 
  <li><p>Let <var>pageRanges</var> be the result of <a>getting a
   property with default</a> named "<code>pageRanges</code>" from
@@ -11371,6 +11370,13 @@ variables</var> and <var>parameters</var> are:
        <dd>Resize the content to match the page width, overriding any
        page width specified in the content
      </dl>
+
+   <p>The value of <var>safePrintableInset</var> defines the minimum inset along
+   each page edge needed to steer clear of the area that the printer is potentially
+   incapable of marking reliably. Most printers have a small region along each
+   edge of the page sheet which is unprintable, typically due to the printer's
+   paper handling mechanism. The document that is being printed may have CSS rules
+   to adjust page margins based on this. TODO: Link to spec, when it has landed?
 
   <li><p>If <var>pageRanges</var> is not an empty <a>Array</a>,
  Let <var>pages</var> be the result of <a>trying</a> to <a>parse a


### PR DESCRIPTION
This is for testing the `page-margin-safety` descriptor in `@page` and
page margin box contexts.

Spec: https://drafts.csswg.org/css-page-3/#page-margin-safety
Spec discussion: https://github.com/w3c/csswg-drafts/issues/11395
RFC: https://github.com/web-platform-tests/rfcs/pull/233

wptrunner and webdriver code changes:
https://github.com/web-platform-tests/wpt/pull/58030


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mstensho/webdriver/pull/1950.html" title="Last updated on Aug 14, 2026, 11:55 AM UTC (5f98639)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1950/cc4c0d2...mstensho:5f98639.html" title="Last updated on Aug 14, 2026, 11:55 AM UTC (5f98639)">Diff</a>