### PR TITLE
Throw "invalid cookie domain" as its definition implies

### DIFF
--- a/index.html
+++ b/index.html
@@ -7603,6 +7603,12 @@ variables</var> and <var>parameters</var> are:
  <li><p><a>Try</a> to <a>handle any user prompts</a>
   with <var>session</var>.
 
+  <li><p>If <a>cookie name</a> or <a>cookie value</a> is <a><code>null</code></a>,
+  <a>cookie secure only</a> or <a>cookie HTTP only</a> are not boolean types,
+  or <a>cookie expiry time</a> is not an integer type, or it less than 0 or greater than
+  the <a>maximum safe integer</a>, return <a>error</a> with <a>error
+  code</a> <a>invalid argument</a>.
+
  <li><p>If <var>session</var>&apos;s <a>current browsing
   context</a>&apos;s <a>document element</a> is
   a <a>cookie-averse <code>Document</code> object</a> or
@@ -7610,12 +7616,6 @@ variables</var> and <var>parameters</var> are:
   browsing context</a>&apos;s <a>active document</a>&apos;s <a>domain</a>,
   return <a>error</a> with <a>error code</a> <a>invalid cookie
   domain</a>.
-
- <li><p>If <a>cookie name</a> or <a>cookie value</a> is <a><code>null</code></a>,
-  <a>cookie secure only</a> or <a>cookie HTTP only</a> are not boolean types,
-  or <a>cookie expiry time</a> is not an integer type, or it less than 0 or greater than
-  the <a>maximum safe integer</a>, return <a>error</a> with <a>error
-  code</a> <a>invalid argument</a>.
 
  <li><p><a>Create a cookie</a> in
   the <a>cookie store</a> associated with

--- a/index.html
+++ b/index.html
@@ -7605,13 +7605,13 @@ variables</var> and <var>parameters</var> are:
 
  <li><p>If <var>session</var>&apos;s <a>current browsing
   context</a>&apos;s <a>document element</a> is
-  a <a>cookie-averse <code>Document</code> object</a>,
+  a <a>cookie-averse <code>Document</code> object</a> or
+  <a>cookie domain</a> is not equal to <var>session</var>&apos;s <a>current
+  browsing context</a>&apos;s <a>active document</a>&apos;s <a>domain</a>,
   return <a>error</a> with <a>error code</a> <a>invalid cookie
   domain</a>.
 
  <li><p>If <a>cookie name</a> or <a>cookie value</a> is <a><code>null</code></a>,
-  <a>cookie domain</a> is not equal to <var>session</var>&apos;s <a>current
-  browsing context</a>&apos;s <a>active document</a>&apos;s <a>domain</a>,
   <a>cookie secure only</a> or <a>cookie HTTP only</a> are not boolean types,
   or <a>cookie expiry time</a> is not an integer type, or it less than 0 or greater than
   the <a>maximum safe integer</a>, return <a>error</a> with <a>error


### PR DESCRIPTION
See https://github.com/servo/servo/pull/43690#discussion_r2994771111

The definition of [InvalidCookieDomain](https://w3c.github.io/webdriver/#dfn-invalid-cookie-domain) is: An illegal attempt was made to set a cookie under a different domain than the current page. 

But somehow, the spec asks to throw "invalid argument" error for this case.
However, all browsers indeed throw "invalid cookie domain" for this case.

Following test aligns with current spec, yet fails for all browsers.
```python
def test_add_cookie_with_domain_not_matching_current_domain(session, url):
    session.url = url("/common/blank.html")

    new_cookie = {
        "name": "hello",
        "value": "world",
        "domain": "example.com",
        "path": "/",
        "httpOnly": False,
        "secure": False
    }

    response = add_cookie(session, new_cookie)
    assert_error(response, "invalid argument")
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1955)
<!-- Reviewable:end -->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yezhizhen/webdriver/pull/1955.html" title="Last updated on Apr 1, 2026, 3:57 AM UTC (555772e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1955/1d4b691...yezhizhen:555772e.html" title="Last updated on Apr 1, 2026, 3:57 AM UTC (555772e)">Diff</a>