### PR TITLE
Add links to 3 more external specifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -11392,12 +11392,15 @@ The list is not exhaustive and might not be up to date.
 <p>The following external specifications define additional WebDriver modules:
 
 <ol>
+  <li><a href="https://www.w3.org/TR/compute-pressure/#automation">Compute Pressure</a>
   <li><a href="https://html.spec.whatwg.org/multipage/system-state.html#user-agent-automation">Custom Scheme Handlers</a>
   <li><a href="https://www.w3.org/TR/device-posture/#automation">Device Posture API</a>
   <li><a href="https://www.w3.org/TR/fedcm/#automation">Federated Credential Management API</a>
+  <li><a href="https://www.w3.org/TR/generic-sensor/#automation">Generic Sensor API</a>
   <li><a href="https://www.w3.org/TR/gpc/#automation">Global Privacy Control</a>
   <li><a href="https://www.w3.org/TR/permissions/#automation-webdriver">Permissions</a>
   <li><a href="https://www.w3.org/TR/reporting-1/#automation">Reporting API</a>
+  <li><a href="https://www.w3.org/TR/secure-payment-confirmation/#sctn-automation">Secure Payment Confirmation</a>
   <li><a href="https://privacycg.github.io/storage-access/#automation">Storage Access API</a>
   <li><a href="https://www.w3.org/TR/webauthn-3/#sctn-automation">Web Authentication</a>
 </ol>


### PR DESCRIPTION
This PR extends the external specifications section introduced in #1940 with links to 3 more specifications:
* Compute Pressure
* Generic Sensor API
* Secure Payment Confirmation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1957)
<!-- Reviewable:end -->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eglitise/webdriver/pull/1957.html" title="Last updated on Apr 30, 2026, 12:44 PM UTC (89f3d0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1957/370aeff...eglitise:89f3d0d.html" title="Last updated on Apr 30, 2026, 12:44 PM UTC (89f3d0d)">Diff</a>