### PR TITLE
Export 'WebDriver session' dfn for cross-spec xref

### DIFF
--- a/index.html
+++ b/index.html
@@ -2164,7 +2164,7 @@ with a "<code>moz:</code>" prefix:
 <section>
 <h2>Sessions</h2>
 
-<p>A WebDriver <dfn data-lt="sessions">session</dfn> represents the
+<p>A WebDriver <dfn data-lt="WebDriver session" data-local-lt="sessions" data-export>session</dfn> represents the
  logical connection between a <a>local end</a> and a
  specific <a>remote end</a>. The <a>session</a> object holds state
  specific to that connection.


### PR DESCRIPTION
## Summary
- Adds `data-export` and `data-lt="WebDriver session"` to the session `<dfn>` so other specs can reference it via `[=WebDriver session=]` with `data-cite="webdriver"`.
- Uses `data-local-lt="sessions"` to preserve existing internal links without exporting the generic plural.

## Motivation

Needed by [w3c-fedid/digital-credentials#381](https://github.com/w3c-fedid/digital-credentials/pull/381) which defines WebDriver BiDi extension commands that reference the session concept. Currently `[=WebDriver session=]` fails xref resolution because the dfn isn't exported.

## Verification

Ran `npx respec --haltonerror` locally — clean build, no regressions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1959)
<!-- Reviewable:end -->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/webdriver/pull/1959.html" title="Last updated on May 7, 2026, 9:17 AM UTC (bc6884e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1959/ef3f7fc...marcoscaceres:bc6884e.html" title="Last updated on May 7, 2026, 9:17 AM UTC (bc6884e)">Diff</a>