### PR TITLE
Revert "fix: update get element tag name to return lowercase tag name"

### DIFF
--- a/index.html
+++ b/index.html
@@ -5823,7 +5823,7 @@ variables</var> and <var>parameters</var> are:
   with <var>URL variables</var>["<code>element id</code>"].
 
  <li><p>Let <var>qualified name</var> be the result of getting
-  <var>element</var>&apos;s {{Element/tagName}} IDL attribute in [=ASCII lowercase=].
+  <var>element</var>&apos;s {{Element/tagName}} IDL attribute.
 
  <li><p>Return <a>success</a> with data <var>qualified name</var>.
 </ol>


### PR DESCRIPTION
Reverts w3c/webdriver#1962

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1963)
<!-- Reviewable:end -->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/pull/1963.html" title="Last updated on May 27, 2026, 7:12 AM UTC (c3c0dca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webdriver/1963/905860d...c3c0dca.html" title="Last updated on May 27, 2026, 7:12 AM UTC (c3c0dca)">Diff</a>