### PR TITLE
Add link to User Activation external specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -11401,6 +11401,7 @@ The list is not exhaustive and might not be up to date.
   <li><a href="https://www.w3.org/TR/reporting-1/#automation">Reporting API</a>
   <li><a href="https://www.w3.org/TR/secure-payment-confirmation/#sctn-automation">Secure Payment Confirmation</a>
   <li><a href="https://privacycg.github.io/storage-access/#automation">Storage Access API</a>
+  <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#user-activation-user-agent-automation">User Activation</a>
   <li><a href="https://www.w3.org/TR/webauthn-3/#sctn-automation">Web Authentication</a>
 </ol>
 


### PR DESCRIPTION
This PR extends the external specifications section with a link to the User Activation endpoint included in the HTML spec.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/webdriver/1973)
<!-- Reviewable:end -->
